### PR TITLE
Unknown prompt behavior support

### DIFF
--- a/src/WebDriverBiDi/JsonConverters/EnumValueJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/EnumValueJsonConverter.cs
@@ -20,6 +20,17 @@ public class EnumValueJsonConverter<T> : JsonConverter<T>
     private readonly Dictionary<T, string> enumValuesToStrings = new();
     private readonly Dictionary<string, T> stringToEnumValues = new();
 
+    private readonly T? defaultEnumValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnumValueJsonConverter{T}"/> class.
+    /// </summary>
+    /// <param name="defaultValue">Default enum value if the parsing fails</param>
+    public EnumValueJsonConverter(T? defaultValue) : this()
+    {
+        this.defaultEnumValue = defaultValue;
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EnumValueJsonConverter{T}"/> class.
     /// </summary>
@@ -63,6 +74,11 @@ public class EnumValueJsonConverter<T> : JsonConverter<T>
         if (this.stringToEnumValues.TryGetValue(stringValue, out T enumValue))
         {
             return enumValue;
+        }
+
+        if (this.defaultEnumValue.HasValue)
+        {
+            return this.defaultEnumValue.Value;
         }
 
         throw new WebDriverBiDiException($"Deserialization error: value '{stringValue}' is not valid for enum type {typeof(T)}");

--- a/src/WebDriverBiDi/JsonConverters/EnumValueJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/EnumValueJsonConverter.cs
@@ -25,8 +25,9 @@ public class EnumValueJsonConverter<T> : JsonConverter<T>
     /// <summary>
     /// Initializes a new instance of the <see cref="EnumValueJsonConverter{T}"/> class.
     /// </summary>
-    /// <param name="defaultValue">Default enum value if the parsing fails</param>
-    public EnumValueJsonConverter(T? defaultValue) : this()
+    /// <param name="defaultValue">Default enum value if the parsing fails.</param>
+    public EnumValueJsonConverter(T? defaultValue)
+        : this()
     {
         this.defaultEnumValue = defaultValue;
     }

--- a/src/WebDriverBiDi/JsonConverters/JsonConverterWithArgsAttribute.cs
+++ b/src/WebDriverBiDi/JsonConverters/JsonConverterWithArgsAttribute.cs
@@ -1,0 +1,54 @@
+// * MIT License
+//  *
+//  * Copyright (c) Darío Kondratiuk
+//  *
+//  * Permission is hereby granted, free of charge, to any person obtaining a copy
+//  * of this software and associated documentation files (the "Software"), to deal
+//  * in the Software without restriction, including without limitation the rights
+//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  * copies of the Software, and to permit persons to whom the Software is
+//  * furnished to do so, subject to the following conditions:
+//  *
+//  * The above copyright notice and this permission notice shall be included in all
+//  * copies or substantial portions of the Software.
+//  *
+//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  * SOFTWARE.
+
+using System.Text.Json.Serialization;
+
+namespace WebDriverBiDi.JsonConverters;
+
+// Recipe taken from here https://github.com/dotnet/runtime/issues/54187#issuecomment-871293887
+/// <summary>
+/// This attribute plays like the JsonConverter. but it takes constructor arguments to be passed to the converter.
+/// </summary>
+internal class JsonConverterWithArgsAttribute : JsonConverterAttribute
+{
+    private Type converterType;
+
+    private object?[] converterArguments;
+
+    public JsonConverterWithArgsAttribute(Type converterType, params object?[] converterArguments)
+    {
+        this.converterType = converterType;
+        this.converterArguments = converterArguments;
+    }
+
+    // CreateConverter method is only called if base.ConverterType is null 
+    // so store the type parameter in a new property in the derived attribute
+    // https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs#L278
+    public new Type ConverterType => this.converterType;
+    
+    public object?[] ConverterArguments => this.converterArguments;
+
+    public override JsonConverter? CreateConverter(Type _)
+    {
+        return (JsonConverter)Activator.CreateInstance(ConverterType, ConverterArguments)!;
+    }
+}

--- a/src/WebDriverBiDi/JsonConverters/JsonConverterWithArgsAttribute.cs
+++ b/src/WebDriverBiDi/JsonConverters/JsonConverterWithArgsAttribute.cs
@@ -1,30 +1,13 @@
-// * MIT License
-//  *
-//  * Copyright (c) Darío Kondratiuk
-//  *
-//  * Permission is hereby granted, free of charge, to any person obtaining a copy
-//  * of this software and associated documentation files (the "Software"), to deal
-//  * in the Software without restriction, including without limitation the rights
-//  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  * copies of the Software, and to permit persons to whom the Software is
-//  * furnished to do so, subject to the following conditions:
-//  *
-//  * The above copyright notice and this permission notice shall be included in all
-//  * copies or substantial portions of the Software.
-//  *
-//  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  * SOFTWARE.
+// <copyright file="JsonConverterWithArgsAttribute.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+// Recipe taken from here https://github.com/dotnet/runtime/issues/54187#issuecomment-871293887
+namespace WebDriverBiDi.JsonConverters;
 
 using System.Text.Json.Serialization;
 
-namespace WebDriverBiDi.JsonConverters;
-
-// Recipe taken from here https://github.com/dotnet/runtime/issues/54187#issuecomment-871293887
 /// <summary>
 /// This attribute plays like the JsonConverter. but it takes constructor arguments to be passed to the converter.
 /// </summary>
@@ -34,21 +17,30 @@ internal class JsonConverterWithArgsAttribute : JsonConverterAttribute
 
     private object?[] converterArguments;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonConverterWithArgsAttribute"/> class.
+    /// </summary>
+    /// <param name="converterType">Converter type.</param>
+    /// <param name="converterArguments">Constructor arguments.</param>
     public JsonConverterWithArgsAttribute(Type converterType, params object?[] converterArguments)
     {
         this.converterType = converterType;
         this.converterArguments = converterArguments;
     }
 
-    // CreateConverter method is only called if base.ConverterType is null 
-    // so store the type parameter in a new property in the derived attribute
-    // https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs#L278
+    /// <summary>
+    /// Gets the converter type.
+    /// </summary>
     public new Type ConverterType => this.converterType;
-    
+
+    /// <summary>
+    /// Gets the converter's constructor arguments.
+    /// </summary>
     public object?[] ConverterArguments => this.converterArguments;
 
-    public override JsonConverter? CreateConverter(Type _)
+    /// <inheritdoc/>
+    public override JsonConverter? CreateConverter(Type type)
     {
-        return (JsonConverter)Activator.CreateInstance(ConverterType, ConverterArguments)!;
+        return (JsonConverter)Activator.CreateInstance(this.converterType, this.converterArguments)!;
     }
 }

--- a/src/WebDriverBiDi/Session/UserPromptHandlerType.cs
+++ b/src/WebDriverBiDi/Session/UserPromptHandlerType.cs
@@ -11,9 +11,14 @@ using WebDriverBiDi.JsonConverters;
 /// <summary>
 /// The types of user prompts.
 /// </summary>
-[JsonConverter(typeof(EnumValueJsonConverter<UserPromptHandlerType>))]
+[JsonConverterWithArgs(typeof(EnumValueJsonConverter<UserPromptHandlerType>), Unknown)]
 public enum UserPromptHandlerType
 {
+    /// <summary>
+    /// The handler type is unknown.
+    /// </summary>
+    Unknown,
+
     /// <summary>
     /// Handler accepts the user prompt.
     /// </summary>

--- a/test/WebDriverBiDi.Tests/BrowsingContext/UserPromptOpenEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/UserPromptOpenEventArgsTests.cs
@@ -167,14 +167,7 @@ public class UserPromptOpenedEventArgsTests
         string json = @"{ ""context"": ""myContextId"", ""type"": ""alert"", ""message"": ""some prompt message"" }";
         Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
     }
-
-    [Test]
-    public void TestDeserializeWithInvalidHandlerTypeValueThrows()
-    {
-        string json = @"{ ""context"": ""myContextId"", ""type"": ""alert"", ""handler"": ""invalid"", ""message"": ""some prompt message"" }";
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<WebDriverBiDiException>());
-    }
-
+    
     [Test]
     public void TestDeserializeWithMissingMessageValueThrows()
     {

--- a/test/WebDriverBiDi.Tests/Session/NewCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/NewCommandResultTests.cs
@@ -14,7 +14,7 @@ public class NewCommandResultTests
     [Test]
     public void TestCanDeserialize()
     {
-        string json = @"{ ""sessionId"": ""mySession"", ""capabilities"": { ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { ""proxyType"": ""manual"", ""httpProxy"": ""http.proxy"" }, ""setWindowRect"": true, ""capName"": ""capValue"" } }";
+        string json = @"{ ""sessionId"": ""mySession"", ""capabilities"": { ""unhandledPromptBehavior"": { ""alert"" : ""dismiss""}, ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { ""proxyType"": ""manual"", ""httpProxy"": ""http.proxy"" }, ""setWindowRect"": true, ""capName"": ""capValue"" } }";
         NewCommandResult? result = JsonSerializer.Deserialize<NewCommandResult>(json, deserializationOptions);
         Assert.That(result, Is.Not.Null);
         Assert.Multiple(() =>
@@ -23,6 +23,7 @@ public class NewCommandResultTests
             Assert.That(result.Capabilities.BrowserName, Is.EqualTo("greatBrowser"));
             Assert.That(result.Capabilities.BrowserVersion, Is.EqualTo("101.5b"));
             Assert.That(result.Capabilities.PlatformName, Is.EqualTo("otherOS"));
+            Assert.That(result.Capabilities.UnhandledPromptBehavior!.Alert, Is.EqualTo(UserPromptHandlerType.Dismiss));
             Assert.That(result.Capabilities.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
             Assert.That(result.Capabilities.AcceptInsecureCertificates, Is.EqualTo(true));
             Assert.That(result.Capabilities.Proxy, Is.Not.Null);
@@ -34,6 +35,18 @@ public class NewCommandResultTests
             Assert.That(result.Capabilities.AdditionalCapabilities, Contains.Key("capName"));
             Assert.That(result.Capabilities.AdditionalCapabilities["capName"], Is.Not.Null);
             Assert.That(result.Capabilities.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
+        });
+    }
+    
+    [Test]
+    public void TestSupportsUnknownUnhandledPromptBehavior()
+    {
+        string json = @"{ ""sessionId"": ""mySession"", ""capabilities"": { ""unhandledPromptBehavior"": { ""alert"" : ""something invalid""}, ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { ""proxyType"": ""manual"", ""httpProxy"": ""http.proxy"" }, ""setWindowRect"": true, ""capName"": ""capValue"" } }";
+        NewCommandResult? result = JsonSerializer.Deserialize<NewCommandResult>(json, deserializationOptions);
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Capabilities.UnhandledPromptBehavior!.Alert, Is.EqualTo(UserPromptHandlerType.Unknown));
         });
     }
 


### PR DESCRIPTION
# Description

Bringing this idea to the table based on [this issue in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1909455).

I think our library shouldn't break on unexpected data, unless we do need that data.
Yes, our library is right, Firefox is wrong, but we shouldn't break users if that happens.

This PR introduces a fallback on `UserPromptHandlerType` and, potentially to any problematic enum.

Feel free to say No :)