### PR TITLE
Allow empty proxy

### DIFF
--- a/src/WebDriverBiDi/JsonConverters/ProxyConfigurationJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/ProxyConfigurationJsonConverter.cs
@@ -31,6 +31,12 @@ public class ProxyConfigurationJsonConverter : JsonConverter<ProxyConfiguration>
             throw new JsonException($"Proxy JSON must be an object, but was {rootElement.ValueKind}");
         }
 
+        // If the object is empty, return null.
+        if (!rootElement.EnumerateObject().Any())
+        {
+            return null;
+        }
+
         if (!rootElement.TryGetProperty("proxyType", out JsonElement typeElement))
         {
             throw new JsonException("Proxy response must contain a 'proxyType' property");

--- a/test/WebDriverBiDi.Tests/Session/CapabilitiesResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/CapabilitiesResultTests.cs
@@ -211,14 +211,7 @@ public class CapabilitiesResultTests
         // Disable spell checker for specifically disallowed value proxyautocomplete
         string json = @"{ ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { ""proxyType"": ""proxyautoconfig"", ""httpProxy"": ""http.proxy"" }, ""setWindowRect"": true, ""capName"": ""capValue"" }";
         Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json, deserializationOptions), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("value 'proxyautoconfig' is not valid for enum type"));
-        // spell-checker: ensable
-    }
-
-    [Test]
-    public void TestCannotDeserializeWithEmptyProxy()
-    {
-        string json = @"{ ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { }, ""setWindowRect"": true, ""capName"": ""capValue"" }";
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json, deserializationOptions), Throws.InstanceOf<JsonException>().With.Message.Contains("must contain a 'proxyType' property"));
+        // spell-checker: enable
     }
 
     [Test]
@@ -380,5 +373,14 @@ public class CapabilitiesResultTests
     {
         string json = @"{ ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { ""httpProxy"": ""http.proxy"" }, ""webSocketUrl"": 123, ""capName"": ""capValue"" }";
         Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json, deserializationOptions), Throws.InstanceOf<JsonException>());
+    }
+    
+    [Test]
+    public void TestProxyTypeIsOptional()
+    {
+        string json = @"{ ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": {}, ""setWindowRect"": true, ""capName"": ""capValue"" }";
+        CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json, deserializationOptions);
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Proxy, Is.Null);
     }
 }


### PR DESCRIPTION
Firefox is sending an empty Proxy for a "null" setting.

```
{"type":"success","id":1,"result":{"sessionId":"740ce520-6e9c-4a4a-a72f-002fbc5c41b2","capabilities":{"acceptInsecureCerts":false,"browserName":"firefox","browserVersion":"131.0a1","platformName":"mac","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:131.0) Gecko/20100101 Firefox/131.0","moz:buildID":"20240822140036","moz:headless":false,"moz:platformVersion":"23.6.0","moz:processID":59732,"moz:profile":"/var/folders/_d/6zl2pzmn1cd0y9h9rdx6zwcc0000gn/T/lmg1yjcb.f3k","moz:shutdownTimeout":60000,
"proxy":{}}}}
```