### PR TITLE
workaround: Temporarily relax protocol compliance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "beforeunload",
         "Bidi",
         "chromedriver",
+        "firstvalue",
         "geckodriver",
         "Hankaku",
         "htmlcollection",

--- a/src/WebDriverBiDi/JsonConverters/ProxyConfigurationJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/ProxyConfigurationJsonConverter.cs
@@ -33,7 +33,9 @@ public class ProxyConfigurationJsonConverter : JsonConverter<ProxyConfiguration>
 
         if (!rootElement.TryGetProperty("proxyType", out JsonElement typeElement))
         {
-            throw new JsonException("Proxy response must contain a 'proxyType' property");
+            // TODO: Uncomment the throw statement and remove the return statement
+            // once https://bugzilla.mozilla.org/show_bug.cgi?id=1916463 is fixed.
+            return ProxyConfiguration.UnsetProxy;
         }
 
         if (typeElement.ValueKind != JsonValueKind.String)

--- a/src/WebDriverBiDi/Session/CapabilitiesResult.cs
+++ b/src/WebDriverBiDi/Session/CapabilitiesResult.cs
@@ -72,7 +72,8 @@ public class CapabilitiesResult
     /// Gets a value indicating whether this session supports setting the size of the browser window.
     /// </summary>
     [JsonPropertyName("setWindowRect")]
-    [JsonRequired]
+    // TODO: Uncomment the JsonRequired attribute once https://bugzilla.mozilla.org/show_bug.cgi?id=1916522 is fixed.
+    // [JsonRequired]
     [JsonInclude]
     public bool SetWindowRect { get => this.setWindowRect; private set => this.setWindowRect = value; }
 

--- a/src/WebDriverBiDi/Session/ProxyConfiguration.cs
+++ b/src/WebDriverBiDi/Session/ProxyConfiguration.cs
@@ -14,6 +14,12 @@ using WebDriverBiDi.JsonConverters;
 [JsonConverter(typeof(ProxyConfigurationJsonConverter))]
 public class ProxyConfiguration
 {
+    /// <summary>
+    /// Represents a proxy value that is unset in the remote end.
+    /// TODO: Remove this static property once https://bugzilla.mozilla.org/show_bug.cgi?id=1916463 is fixed.
+    /// </summary>
+    public static readonly ProxyConfiguration UnsetProxy = new(ProxyType.Unset);
+
     private readonly Dictionary<string, object> additionalData = new();
     private ProxyType proxyType;
 

--- a/src/WebDriverBiDi/Session/ProxyType.cs
+++ b/src/WebDriverBiDi/Session/ProxyType.cs
@@ -15,6 +15,12 @@ using WebDriverBiDi.JsonConverters;
 public enum ProxyType
 {
     /// <summary>
+    /// No proxy value has been set.
+    /// TODO: Remove this enum value once https://bugzilla.mozilla.org/show_bug.cgi?id=1916463 is fixed.
+    /// </summary>
+    Unset,
+
+    /// <summary>
     /// Direct connection with no proxy.
     /// </summary>
     Direct,

--- a/test/WebDriverBiDi.Tests/Session/CapabilitiesResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/CapabilitiesResultTests.cs
@@ -214,7 +214,8 @@ public class CapabilitiesResultTests
         // spell-checker: ensable
     }
 
-    [Test]
+    // [Test]
+    // TODO: Restore this test when https://bugzilla.mozilla.org/show_bug.cgi?id=1916463 is fixed.
     public void TestCannotDeserializeWithEmptyProxy()
     {
         string json = @"{ ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { }, ""setWindowRect"": true, ""capName"": ""capValue"" }";
@@ -354,7 +355,8 @@ public class CapabilitiesResultTests
         Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json, deserializationOptions), Throws.InstanceOf<JsonException>());
     }
 
-    [Test]
+    // [Test]
+    // TODO: Restore this test when https://bugzilla.mozilla.org/show_bug.cgi?id=1916522 is fixed.
     public void TestDeserializingWithMissingSetWindowRectThrows()
     {
         string json = @"{ ""browserName"": ""greatBrowser"", ""browserVersion"": ""101.5b"", ""platformName"": ""otherOS"", ""userAgent"": ""WebDriverBidi.NET/1.0"", ""acceptInsecureCerts"": true, ""proxy"": { ""httpProxy"": ""http.proxy"" }, ""capName"": ""capValue"" }";


### PR DESCRIPTION
Creating BiDi-only sessions in Firefox has a number of bugs in it where the browser does not conform to the WebDriver BiDi protocol. This commit relaxes the strictness of the protocol temporarily to work around those bugs. The workarounds are marked with TODO comments, and should be reversed as soon as Firefox fixes the issues at hand. The current issues are:

* [New session response does not include required property setWindowRect](https://bugzilla.mozilla.org/show_bug.cgi?id=1916522)
* [New session with empty capabilities returns empty proxy property](https://bugzilla.mozilla.org/show_bug.cgi?id=1916463)