### PR TITLE
Make CloseAsync parameter nullable.

### DIFF
--- a/src/WebDriverBiDi/Browser/BrowserModule.cs
+++ b/src/WebDriverBiDi/Browser/BrowserModule.cs
@@ -34,9 +34,9 @@ public sealed class BrowserModule : Module
     /// </summary>
     /// <param name="commandProperties">The parameters for the command.</param>
     /// <returns>An empty command result.</returns>
-    public async Task<EmptyResult> CloseAsync(CloseCommandParameters commandProperties)
+    public async Task<EmptyResult> CloseAsync(CloseCommandParameters? commandProperties = null)
     {
-        return await this.Driver.ExecuteCommandAsync<EmptyResult>(commandProperties).ConfigureAwait(false);
+        return await this.Driver.ExecuteCommandAsync<EmptyResult>(commandProperties ?? new()).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
@@ -25,6 +25,27 @@ public class BrowserModuleTests
 
         Assert.That(result, Is.Not.Null);
     }
+    
+    [Test]
+    public async Task TestExecuteCloseCommandWithNoCloseArgument()
+    {
+        TestConnection connection = new();
+        connection.DataSendComplete += async (sender, e) =>
+        {
+            string responseJson = @"{ ""type"": ""success"", ""id"": " + e.SentCommandId + @", ""result"": { } }";
+            await connection.RaiseDataReceivedEventAsync(responseJson);
+        };
+
+        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
+        BrowserModule module = new(driver);
+
+        var task = module.CloseAsync();
+        task.Wait(TimeSpan.FromSeconds(1));
+        var result = task.Result;
+
+        Assert.That(result, Is.Not.Null);
+    }
 
     [Test]
     public async Task TestExecuteCreateUserContextCommand()


### PR DESCRIPTION
CloseCommandParameters have no useful properties. We don't even need to pass it.