### PR TITLE
chore: remove unnecessary Dictionary/List Contains checks

### DIFF
--- a/src/WebDriverBiDi.Client/InputBuilder.cs
+++ b/src/WebDriverBiDi.Client/InputBuilder.cs
@@ -145,7 +145,7 @@ public class InputBuilder
         List<string> usedDevices = new();
         foreach (Action interaction in interactionsToAdd)
         {
-            if (!this.sources.ContainsKey(interaction.SourceId))
+            if (!this.sources.TryGetValue(interaction.SourceId, out SourceActions source))
             {
                 throw new ArgumentException($"Builder does not contain an input source for ID {interaction.SourceId}");
             }
@@ -156,12 +156,8 @@ public class InputBuilder
             }
 
             usedDevices.Add(interaction.SourceId);
-            if (unusedDevices.Contains(interaction.SourceId))
-            {
-                unusedDevices.Remove(interaction.SourceId);
-            }
+            unusedDevices.Remove(interaction.SourceId);
 
-            SourceActions source = this.sources[interaction.SourceId];
             if (source is KeySourceActions keySource)
             {
                 keySource.Actions.Add(interaction.AsActionType<IKeySourceAction>());

--- a/src/WebDriverBiDi.DemoWebSite/StoredContentRegistrar.cs
+++ b/src/WebDriverBiDi.DemoWebSite/StoredContentRegistrar.cs
@@ -61,9 +61,9 @@ public class StoredContentRegistrar
         byte[] fileContent = File.ReadAllBytes(fileToRegister);
         string relativeUrl = $"{relativeUrlPath}/{Path.GetFileName(fileToRegister)}";
         string mimeType = "text/plain";
-        if (knownMimeTypes.ContainsKey(fileExtension))
+        if (knownMimeTypes.TryGetValue(fileExtension, out string? knownMimeType))
         {
-            mimeType = knownMimeTypes[fileExtension];
+            mimeType = knownMimeType;
         }
 
         HttpRequestHandler handler = new WebResourceRequestHandler(fileContent)

--- a/src/WebDriverBiDi/BiDiDriver.cs
+++ b/src/WebDriverBiDi/BiDiDriver.cs
@@ -236,12 +236,11 @@ public class BiDiDriver
     public virtual T GetModule<T>(string moduleName)
         where T : Module
     {
-        if (!this.modules.ContainsKey(moduleName))
+        if (!this.modules.TryGetValue(moduleName, out Module module))
         {
             throw new WebDriverBiDiException($"Module '{moduleName}' is not registered with this driver");
         }
 
-        Module module = this.modules[moduleName];
         if (module is not T)
         {
             throw new WebDriverBiDiException($"Module '{moduleName}' is registered with this driver, but the module object is not of type {typeof(T)}");

--- a/src/WebDriverBiDi/BrowsingContext/AccessibilityLocator.cs
+++ b/src/WebDriverBiDi/BrowsingContext/AccessibilityLocator.cs
@@ -50,9 +50,9 @@ public class AccessibilityLocator : Locator
 
     private string? GetAccessiblePropertyValue(string propertyName)
     {
-        if (this.accessibilityAttributes.ContainsKey(propertyName))
+        if (this.accessibilityAttributes.TryGetValue(propertyName, out string value))
         {
-            return this.accessibilityAttributes[propertyName];
+            return value;
         }
 
         return null;
@@ -66,10 +66,7 @@ public class AccessibilityLocator : Locator
         }
         else
         {
-            if (this.accessibilityAttributes.ContainsKey(propertyName))
-            {
-                this.accessibilityAttributes.Remove(propertyName);
-            }
+            this.accessibilityAttributes.Remove(propertyName);
         }
     }
 }

--- a/src/WebDriverBiDi/Module.cs
+++ b/src/WebDriverBiDi/Module.cs
@@ -49,9 +49,8 @@ public abstract class Module
 
     private async Task OnDriverEventReceived(EventReceivedEventArgs e)
     {
-        if (this.asyncEventInvokers.ContainsKey(e.EventName))
+        if (this.asyncEventInvokers.TryGetValue(e.EventName, out EventInvoker eventInvoker))
         {
-            EventInvoker eventInvoker = this.asyncEventInvokers[e.EventName];
             await eventInvoker.InvokeEventAsync(e.EventData!, e.AdditionalData);
         }
     }

--- a/src/WebDriverBiDi/ObservableEvent{T}.cs
+++ b/src/WebDriverBiDi/ObservableEvent{T}.cs
@@ -99,10 +99,7 @@ public class ObservableEvent<T>
     /// <param name="observerId">The ID of the handler handling the event.</param>
     public void RemoveObserver(string observerId)
     {
-        if (this.observers.ContainsKey(observerId))
-        {
-            this.observers.Remove(observerId);
-        }
+        this.observers.Remove(observerId);
     }
 
     /// <summary>


### PR DESCRIPTION
- Use `TryGetValue` to avoid duplicate dictionary lookups.
- Use `Remove` directly to avoid duplicate lookups.