### PR TITLE
refactor: use byte[] in connection to avoid duplicate encoding

### DIFF
--- a/src/WebDriverBiDi.Client/ChromeLauncher.cs
+++ b/src/WebDriverBiDi.Client/ChromeLauncher.cs
@@ -411,7 +411,7 @@ public class ChromeLauncher : BrowserLauncher
         long commandId = 0;
         DevToolsProtocolCommand command = new(commandId, "Target.getTargets");
         await connection.StartAsync(this.WebSocketUrl).ConfigureAwait(false);
-        await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+        await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
         syncEvent.Wait(TimeSpan.FromSeconds(3));
         syncEvent.Reset();
         commandId++;
@@ -427,7 +427,7 @@ public class ChromeLauncher : BrowserLauncher
             command = new DevToolsProtocolCommand(commandId, "Target.attachToTarget");
             command.Parameters["targetId"] = targetId;
             command.Parameters["flatten"] = true;
-            await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+            await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
             syncEvent.Wait(TimeSpan.FromSeconds(3));
             syncEvent.Reset();
             commandId++;
@@ -440,7 +440,7 @@ public class ChromeLauncher : BrowserLauncher
             command = new DevToolsProtocolCommand(commandId, "Runtime.evaluate");
             command.Parameters["expression"] = "document.body.click()";
             command.Parameters["userGesture"] = true;
-            await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+            await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
             syncEvent.Wait(TimeSpan.FromSeconds(3));
             syncEvent.Reset();
             commandId++;
@@ -448,7 +448,7 @@ public class ChromeLauncher : BrowserLauncher
             // Enable the Runtime CDP domain.
             command = new DevToolsProtocolCommand(commandId, "Runtime.enable");
             command.SessionId = sessionId;
-            await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+            await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
             syncEvent.Wait(TimeSpan.FromSeconds(3));
             syncEvent.Reset();
             commandId++;
@@ -457,7 +457,7 @@ public class ChromeLauncher : BrowserLauncher
             command = new DevToolsProtocolCommand(commandId, "Target.exposeDevToolsProtocol");
             command.Parameters["bindingName"] = "cdp";
             command.Parameters["targetId"] = targetId;
-            await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+            await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
             syncEvent.Wait(TimeSpan.FromSeconds(3));
             syncEvent.Reset();
             commandId++;
@@ -480,7 +480,7 @@ public class ChromeLauncher : BrowserLauncher
                 command = new DevToolsProtocolCommand(commandId, "Runtime.evaluate");
                 command.Parameters["expression"] = mapperScript;
                 command.SessionId = sessionId;
-                await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+                await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
                 syncEvent.Wait(TimeSpan.FromSeconds(3));
                 syncEvent.Reset();
                 commandId++;
@@ -490,7 +490,7 @@ public class ChromeLauncher : BrowserLauncher
                 command.Parameters["expression"] = @$"window.runMapperInstance(""{targetId}"")";
                 command.Parameters["awaitPromise"] = true;
                 command.SessionId = sessionId;
-                await connection.SendDataAsync(JsonSerializer.Serialize(command)).ConfigureAwait(false);
+                await connection.SendDataAsync(JsonSerializer.SerializeToUtf8Bytes(command)).ConfigureAwait(false);
                 syncEvent.Wait(TimeSpan.FromSeconds(3));
                 syncEvent.Reset();
                 commandId++;

--- a/src/WebDriverBiDi/ObservableEvent{T}.cs
+++ b/src/WebDriverBiDi/ObservableEvent{T}.cs
@@ -40,6 +40,11 @@ public class ObservableEvent<T>
     public int MaxObserverCount => this.maxObserverCount;
 
     /// <summary>
+    /// Gets the current number of observers that are observing this event.
+    /// </summary>
+    public int CurrentObserverCount => this.observers.Count;
+
+    /// <summary>
     /// Adds a function to observe the event that takes an argument of type T and returns void.
     /// It will be wrapped in a Task so that it can be awaited.
     /// </summary>

--- a/src/WebDriverBiDi/Protocol/ConnectionDataReceivedEventArgs.cs
+++ b/src/WebDriverBiDi/Protocol/ConnectionDataReceivedEventArgs.cs
@@ -10,13 +10,13 @@ namespace WebDriverBiDi.Protocol;
 /// </summary>
 public class ConnectionDataReceivedEventArgs : WebDriverBiDiEventArgs
 {
-    private readonly string data;
+    private readonly byte[] data;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConnectionDataReceivedEventArgs" /> class.
     /// </summary>
     /// <param name="data">The data received from the connection.</param>
-    public ConnectionDataReceivedEventArgs(string data)
+    public ConnectionDataReceivedEventArgs(byte[] data)
     {
         this.data = data;
     }
@@ -24,5 +24,5 @@ public class ConnectionDataReceivedEventArgs : WebDriverBiDiEventArgs
     /// <summary>
     /// Gets the data received from the connection.
     /// </summary>
-    public string Data => this.data;
+    public byte[] Data => this.data;
 }

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestConnection.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestConnection.cs
@@ -21,7 +21,7 @@ public class TestConnection : Connection
 
     public async Task RaiseDataReceivedEventAsync(string data)
     {
-        await this.OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(data));
+        await this.OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(Encoding.UTF8.GetBytes(data)));
     }
 
     public async Task RaiseLogMessageEventAsync(string message, WebDriverBiDiLogLevel level)
@@ -54,14 +54,14 @@ public class TestConnection : Connection
         }
     }
 
-    public override Task SendDataAsync(string data)
+    public override Task SendDataAsync(byte[] data)
     {
         if (this.BypassStart)
         {
             // Bypass the check to see if the connection has been started,
             // so that we can test the plumbing without needing an actual
             // WebSocket server active.
-            return this.SendWebSocketDataAsync(Encoding.UTF8.GetBytes(data));
+            return this.SendWebSocketDataAsync(data);
         }
 
         return base.SendDataAsync(data);


### PR DESCRIPTION
`System.Text.Json` can serialize / deserialize bytes directly. This PR reduces the `byte[] -> string -> byte[] -> json` conversions to just `byte[] -> json` (when logging isn't enabled).
An additional buffer (`MemoryStream`) is only allocated when there are multiple WebSocket payloads for one message. Most of the time there is just one payload.
I added a `CurrentObserverCount` to check if there are any logging observer to only allocate a string in this case.