### PR TITLE
Expose timings setter

### DIFF
--- a/src/WebDriverBiDi/Network/RequestData.cs
+++ b/src/WebDriverBiDi/Network/RequestData.cs
@@ -98,7 +98,7 @@ public class RequestData
     [JsonPropertyName("timings")]
     [JsonRequired]
     [JsonInclude]
-    public FetchTimingInfo Timings { get => this.timingInfo; private set => this.timingInfo = value; }
+    public FetchTimingInfo Timings { get => this.timingInfo; set => this.timingInfo = value; }
 
     /// <summary>
     /// Gets or sets the headers of the request for serialization purposes.


### PR DESCRIPTION
Puppeteer keeps a reference of the request info on its request class and updates the timing value on `network.responseCompleted`. [See](https://github.com/puppeteer/puppeteer/blob/b60067735da000200b1b151a0cfb5ace5bf75738/packages/puppeteer-core/src/bidi/core/Request.ts#L111).