### PR TITLE
fix: reinstate strictness of protocol for cookie retreival

### DIFF
--- a/src/WebDriverBiDi/Network/Cookie.cs
+++ b/src/WebDriverBiDi/Network/Cookie.cs
@@ -43,10 +43,7 @@ public record Cookie
     /// Gets the domain of the cookie.
     /// </summary>
     [JsonPropertyName("domain")]
-#pragma warning disable SA1515
-    // TODO (Issue #53): Uncomment the below when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [JsonRequired]
-#pragma warning restore SA1515
+    [JsonRequired]
     [JsonInclude]
     public string Domain { get; internal set; } = string.Empty;
 
@@ -54,10 +51,7 @@ public record Cookie
     /// Gets the path of the cookie.
     /// </summary>
     [JsonPropertyName("path")]
-#pragma warning disable SA1515
-    // TODO (Issue #53): Uncomment the below when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [JsonRequired]
-#pragma warning restore SA1515
+    [JsonRequired]
     [JsonInclude]
     public string Path { get; internal set; } = string.Empty;
 
@@ -90,10 +84,7 @@ public record Cookie
     /// Gets the byte length of the cookie when serialized in an HTTP cookie header.
     /// </summary>
     [JsonPropertyName("size")]
-#pragma warning disable SA1515
-    // TODO (Issue #53): Uncomment the below when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [JsonRequired]
-#pragma warning restore SA1515
+    [JsonRequired]
     [JsonInclude]
     public long Size { get; internal set; } = 0;
 
@@ -102,10 +93,7 @@ public record Cookie
     /// encrypted connection like HTTPS.
     /// </summary>
     [JsonPropertyName("secure")]
-#pragma warning disable SA1515
-    // TODO (Issue #53): Uncomment the below when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [JsonRequired]
-#pragma warning restore SA1515
+    [JsonRequired]
     [JsonInclude]
     public bool Secure { get; internal set; }
 
@@ -115,10 +103,7 @@ public record Cookie
     /// via JavaScript (<see langword="false" />).
     /// </summary>
     [JsonPropertyName("httpOnly")]
-#pragma warning disable SA1515
-    // TODO (Issue #53): Uncomment the below when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [JsonRequired]
-#pragma warning restore SA1515
+    [JsonRequired]
     [JsonInclude]
     public bool HttpOnly { get; internal set; }
 
@@ -126,10 +111,7 @@ public record Cookie
     /// Gets a value indicating whether the cookie is a same-site cookie.
     /// </summary>
     [JsonPropertyName("sameSite")]
-#pragma warning disable SA1515
-    // TODO (Issue #53): Uncomment the below when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [JsonRequired]
-#pragma warning restore SA1515
+    [JsonRequired]
     [JsonInclude]
     public CookieSameSiteValue SameSite { get; internal set; } = CookieSameSiteValue.None;
 

--- a/test/WebDriverBiDi.Tests/Network/CookieTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/CookieTests.cs
@@ -344,8 +344,7 @@ public class CookieTests
         Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'value'"));
     }
 
-    // TODO (Issue #53): Re-enable the below test when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [Test]
+    [Test]
     public void TestDeserializeWithMissingDomainThrows()
     {
         string json = """
@@ -365,8 +364,7 @@ public class CookieTests
         Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'domain'"));
     }
 
-    // TODO (Issue #53): Re-enable the below test when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [Test]
+    [Test]
     public void TestDeserializeWithMissingPathThrows()
     {
         string json = """
@@ -386,8 +384,7 @@ public class CookieTests
         Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'path'"));
     }
 
-    // TODO (Issue #53): Re-enable the below test when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [Test]
+    [Test]
     public void TestDeserializeWithMissingSecureThrows()
     {
         string json = """
@@ -407,8 +404,7 @@ public class CookieTests
         Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'secure'"));
     }
 
-    // TODO (Issue #53): Re-enable the below test when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [Test]
+    [Test]
     public void TestDeserializeWithMissingHttpOnlyThrows()
     {
         string json = """
@@ -428,8 +424,7 @@ public class CookieTests
         Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'httpOnly'"));
     }
 
-    // TODO (Issue #53): Re-enable the below test when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [Test]
+    [Test]
     public void TestDeserializeWithMissingSameSiteThrows()
     {
         string json = """
@@ -449,8 +444,7 @@ public class CookieTests
         Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'sameSite'"));
     }
 
-    // TODO (Issue #53): Re-enable the below test when https://bugzilla.mozilla.org/show_bug.cgi?id=1887118 is fixed.
-    // [Test]
+    [Test]
     public void TestDeserializeWithMissingSizeThrows()
     {
         string json = """


### PR DESCRIPTION
Firefox has fixed their [issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1887118) with incomplete cookies being returned by the protocol. Closes #53.