### PR TITLE
refactor: remove ability to directly notify event observers from public API

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,7 @@
             "command": "dotnet",
             "args": [
                 "test",
+                "--project",
                 "${workspaceFolder}/test/WebDriverBiDi.Tests"
             ],
             "problemMatcher": "$msCompile",
@@ -28,18 +29,8 @@
             "label": "dotnet: test"
         },
         {
-            "type": "process",
-            "command": "dotnet",
-            "args": [
-                "test",
-                "--project",
-                "${workspaceFolder}/test/WebDriverBiDi.Tests",
-                "--coverlet",
-                "--coverlet-output-format",
-                "lcov",
-                "--results-directory",
-                "${workspaceFolder}/test/coverage/lcov"
-            ],
+            "type": "shell",
+            "command": "rm -f ${workspaceFolder}/test/coverage/lcov.*.info && dotnet test --project ${workspaceFolder}/test/WebDriverBiDi.Tests --configuration Release --verbosity normal --coverlet --coverlet-output-format lcov --coverlet-exclude-by-file '**/_/src/**' --results-directory ${workspaceFolder}/test/coverage --coverlet-file-prefix lcov && ${workspaceFolder}/scripts/check-lcov-thresholds.sh --min-line 100 --min-branch 100 --min-method 100 ${workspaceFolder}/test/coverage/lcov.*.info",
             "problemMatcher": "$msCompile",
             "group": {
                 "kind": "test",

--- a/docs/code/advanced/CustomModulesSamples.cs
+++ b/docs/code/advanced/CustomModulesSamples.cs
@@ -486,17 +486,19 @@ public class CustomEventsModule : Module
     public const string CustomModuleName = "customModule";
     private const string CustomEventName = "custom.eventOccurred";
 
+    private readonly ObservableEventInvocable<CustomEventArgs> onCustomEvent =
+        new ObservableEventInvocable<CustomEventArgs>(CustomEventName);
+
     public CustomEventsModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
         // Register event with driver
-        this.RegisterObservableEvent<CustomEventArgs>(this.OnCustomEvent);
+        this.RegisterObservableEvent(this.onCustomEvent);
     }
 
     public override string ModuleName => CustomModuleName;
 
-    public ObservableEvent<CustomEventArgs> OnCustomEvent { get; } =
-        new ObservableEvent<CustomEventArgs>(CustomEventName);
+    public ObservableEvent<CustomEventArgs> OnCustomEvent => this.onCustomEvent;
 }
 
 public record CustomEventArgs : WebDriverBiDiEventArgs

--- a/docs/code/core-concepts/CoreConceptsCustomModuleSamples.cs
+++ b/docs/code/core-concepts/CoreConceptsCustomModuleSamples.cs
@@ -22,9 +22,14 @@ public class CustomModule : Module
     // "custom" is the protocol module name
     public const string CustomModuleName = "custom";
 
+    private readonly ObservableEventInvocable<CustomEventArgs> onCustomEvent =
+        new ObservableEventInvocable<CustomEventArgs>("custom.eventOccurred");
+
     public CustomModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
+        // Register custom events using the base class helper
+        this.RegisterObservableEvent(this.onCustomEvent);
     }
 
     public override string ModuleName => CustomModuleName;
@@ -37,9 +42,8 @@ public class CustomModule : Module
             parameters);
     }
 
-    // Define custom events
-    public ObservableEvent<CustomEventArgs> OnCustomEvent { get; } =
-        new ObservableEvent<CustomEventArgs>("custom.eventOccurred");
+    // Define custom events — expose as ObservableEvent<T> so callers cannot invoke it
+    public ObservableEvent<CustomEventArgs> OnCustomEvent => this.onCustomEvent;
 }
 
 // Command parameters (mutable - sent to browser)
@@ -127,9 +131,13 @@ public class MyCustomModule : Module
 {
     public const string ModuleNameConst = "myModule";
 
+    private readonly ObservableEventInvocable<MyEventArgs> onMyEvent =
+        new ObservableEventInvocable<MyEventArgs>("myModule.myEvent");
+
     public MyCustomModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
+        this.RegisterObservableEvent(this.onMyEvent);
     }
 
     public override string ModuleName => ModuleNameConst;
@@ -139,8 +147,7 @@ public class MyCustomModule : Module
         return await this.Driver.ExecuteCommandAsync<MyCommandResult>(parameters);
     }
 
-    public ObservableEvent<MyEventArgs> OnMyEvent { get; } =
-        new ObservableEvent<MyEventArgs>("myModule.myEvent");
+    public ObservableEvent<MyEventArgs> OnMyEvent => this.onMyEvent;
 }
 
 #pragma warning restore CS1591, CS0168, CS8600, CS8618

--- a/docs/code/core-concepts/CoreConceptsSamples.cs
+++ b/docs/code/core-concepts/CoreConceptsSamples.cs
@@ -803,16 +803,9 @@ public static class CoreConceptsSamples
         BiDiDriver driver = new BiDiDriver(TimeSpan.FromSeconds(30));
 
         // Register custom module BEFORE starting
+        // The module constructor calls RegisterObservableEvent for each event it exposes
         CustomModule customModule = new CustomModule(driver);
         driver.RegisterModule(customModule);
-
-        // Register custom event
-        driver.RegisterEvent<CustomEventArgs>(
-            customModule.OnCustomEvent.EventName,
-            async (eventInfo) =>
-            {
-                await customModule.OnCustomEvent.NotifyObserversAsync(eventInfo.ToEventArgs<CustomEventArgs>());
-            });
 
         // NOW start the driver
         await driver.StartAsync(webSocketUrl);

--- a/src/WebDriverBiDi.Client/Launchers/BrowserLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/BrowserLauncher.cs
@@ -44,7 +44,7 @@ public abstract class BrowserLauncher : IAsyncDisposable
     /// <summary>
     /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
     /// </summary>
-    public abstract ObservableEvent<LogMessageEventArgs> OnLogMessage { get; }
+    public ObservableEvent<LogMessageEventArgs> OnLogMessage => this.InvocableLogMessageObservableEvent;
 
     /// <summary>
     /// Gets or sets a value indicating the time to wait for an initial connection before timing out.
@@ -86,6 +86,11 @@ public abstract class BrowserLauncher : IAsyncDisposable
     /// Gets or sets the <see cref="BrowserLocator"/> to use for locating the browser executable.
     /// </summary>
     internal BrowserLocator BrowserLocator { get; set; }
+
+    /// <summary>
+    /// Gets an ObservableEventInvocable that subclasses can use to raise the OnLogMessage event.
+    /// </summary>
+    protected abstract ObservableEventInvocable<LogMessageEventArgs> InvocableLogMessageObservableEvent { get; }
 
     /// <summary>
     /// Creates a launcher for the specified browser using default settings.
@@ -299,7 +304,7 @@ public abstract class BrowserLauncher : IAsyncDisposable
     protected async Task LogAsync(string message, WebDriverBiDiLogLevel logLevel = WebDriverBiDiLogLevel.Info, string component = LoggerComponentName)
     {
         LogMessageEventArgs logMessageArgs = new(message, logLevel, component);
-        await this.OnLogMessage.NotifyObserversAsync(logMessageArgs);
+        await this.InvocableLogMessageObservableEvent.NotifyObserversAsync(logMessageArgs);
     }
 
     private async Task OnLocatorLogAsync(LogMessageEventArgs args)

--- a/src/WebDriverBiDi.Client/Launchers/BrowserLocator.cs
+++ b/src/WebDriverBiDi.Client/Launchers/BrowserLocator.cs
@@ -23,6 +23,7 @@ public class BrowserLocator
         ".cache",
         "webdriverbidi-net");
 
+    private readonly ObservableEventInvocable<LogMessageEventArgs> invocableLogMessageObservableEvent = new("browserLocator.logMessage");
     private readonly BrowserLocatorSettings settings;
     private readonly DriverLocator? driverLocator;
     private string cacheDirectory = DefaultCacheDir;
@@ -48,7 +49,7 @@ public class BrowserLocator
         if (this.driverLocator is not null)
         {
             this.driverLocator.CacheDirectory = this.cacheDirectory;
-            this.driverLocator.OnLogMessage.AddObserver(this.OnLogMessage.NotifyObserversAsync);
+            this.driverLocator.OnLogMessage.AddObserver(this.invocableLogMessageObservableEvent.NotifyObserversAsync);
         }
     }
 
@@ -78,7 +79,7 @@ public class BrowserLocator
     /// <summary>
     /// Gets an observable event that notifies when a log message is emitted by the browser locator.
     /// </summary>
-    public ObservableEvent<LogMessageEventArgs> OnLogMessage { get; } = new("browserLocator.logMessage");
+    public ObservableEvent<LogMessageEventArgs> OnLogMessage => this.invocableLogMessageObservableEvent;
 
     /// <summary>
     /// Gets a value indicating whether the locator requires access to the cache for downloaded browsers or drivers.
@@ -305,7 +306,7 @@ public class BrowserLocator
     /// <returns>The task object representing the asynchronous operation.</returns>
     protected async Task LogAsync(string message, WebDriverBiDiLogLevel level)
     {
-        await this.OnLogMessage.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
+        await this.invocableLogMessageObservableEvent.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
     }
 
     private async Task<string> LocateBrowserPathAsync(Cache? cacheInfo)

--- a/src/WebDriverBiDi.Client/Launchers/ChromeLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/ChromeLauncher.cs
@@ -81,11 +81,6 @@ public class ChromeLauncher : BrowserLauncher, IPipeServerProcessProvider
     }
 
     /// <summary>
-    /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
-    /// </summary>
-    public override ObservableEvent<LogMessageEventArgs> OnLogMessage { get; } = new("chromeLauncher.logMessage");
-
-    /// <summary>
     /// Gets a value indicating whether the service is running.
     /// </summary>
     public override bool IsRunning => this.browserProcess is not null && !this.browserProcess.HasExited;
@@ -102,6 +97,11 @@ public class ChromeLauncher : BrowserLauncher, IPipeServerProcessProvider
     /// of the pipe handles used for communication.
     /// </summary>
     public Process? PipeServerProcess => this.browserProcess;
+
+    /// <summary>
+    /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
+    /// </summary>
+    protected override ObservableEventInvocable<LogMessageEventArgs> InvocableLogMessageObservableEvent { get; } = new("chromeLauncher.logMessage");
 
     private IList<string> CommandLineArguments
     {

--- a/src/WebDriverBiDi.Client/Launchers/ClassicDriverExecutableBrowserLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/ClassicDriverExecutableBrowserLauncher.cs
@@ -22,6 +22,10 @@ public abstract class ClassicDriverExecutableBrowserLauncher : WebDriverClassicB
     private const string LauncherProcessStartedEventName = "classicDriverBrowserLauncher.launcherProcessStarted";
 
     private static readonly SemaphoreSlim LockObject = new(1, 1);
+
+    private readonly ObservableEventInvocable<BrowserLauncherProcessStartingEventArgs> invocableBrowserLauncherProcessStartingObservableEvent = new(LauncherProcessStartingEventName);
+    private readonly ObservableEventInvocable<BrowserLauncherProcessStartedEventArgs> invocableBrowserLauncherProcessStartedObservableEvent = new(LauncherProcessStartedEventName);
+
     private readonly string launcherExecutableName;
     private bool isLoggingLauncherProcessOutput;
     private Process? launcherProcess;
@@ -53,12 +57,12 @@ public abstract class ClassicDriverExecutableBrowserLauncher : WebDriverClassicB
     /// <summary>
     /// Gets an observable event that notifies when the launcher process is starting.
     /// </summary>
-    public ObservableEvent<BrowserLauncherProcessStartingEventArgs> OnLauncherProcessStarting { get; } = new(LauncherProcessStartingEventName);
+    public ObservableEvent<BrowserLauncherProcessStartingEventArgs> OnLauncherProcessStarting => this.invocableBrowserLauncherProcessStartingObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when the launcher process has completely started.
     /// </summary>
-    public ObservableEvent<BrowserLauncherProcessStartedEventArgs> OnLauncherProcessStarted { get; } = new(LauncherProcessStartedEventName);
+    public ObservableEvent<BrowserLauncherProcessStartedEventArgs> OnLauncherProcessStarted => this.invocableBrowserLauncherProcessStartedObservableEvent;
 
     /// <summary>
     /// Gets or sets a value indicating whether the command prompt window of the browser launcher should be hidden.
@@ -257,12 +261,12 @@ public abstract class ClassicDriverExecutableBrowserLauncher : WebDriverClassicB
 
     private async Task OnLauncherProcessStartingAsync(BrowserLauncherProcessStartingEventArgs eventArgs)
     {
-        await this.OnLauncherProcessStarting.NotifyObserversAsync(eventArgs);
+        await this.invocableBrowserLauncherProcessStartingObservableEvent.NotifyObserversAsync(eventArgs);
     }
 
     private async Task OnLauncherProcessStartedAsync(BrowserLauncherProcessStartedEventArgs eventArgs)
     {
-        await this.OnLauncherProcessStarted.NotifyObserversAsync(eventArgs);
+        await this.invocableBrowserLauncherProcessStartedObservableEvent.NotifyObserversAsync(eventArgs);
     }
 
     private void StartLoggingProcessOutput()

--- a/src/WebDriverBiDi.Client/Launchers/DriverLocator.cs
+++ b/src/WebDriverBiDi.Client/Launchers/DriverLocator.cs
@@ -23,6 +23,7 @@ public class DriverLocator
         ".cache",
         "webdriverbidi-net");
 
+    private readonly ObservableEventInvocable<LogMessageEventArgs> invocableLogMessageObservableEvent = new("driverLocator.logMessage");
     private readonly BrowserLocatorSettings settings;
 
     /// <summary>
@@ -44,7 +45,7 @@ public class DriverLocator
     /// <summary>
     /// Gets an observable event that notifies when a log message is emitted by the driver locator.
     /// </summary>
-    public ObservableEvent<LogMessageEventArgs> OnLogMessage { get; } = new("driverLocator.logMessage");
+    public ObservableEvent<LogMessageEventArgs> OnLogMessage => this.invocableLogMessageObservableEvent;
 
     /// <summary>
     /// Finds the driver executable using default settings (Stable channel, Latest version, AutoLocateAndDownload).
@@ -199,7 +200,7 @@ public class DriverLocator
     /// <returns>The task object representing the asynchronous operation.</returns>
     internal async Task LogAsync(string message, WebDriverBiDiLogLevel level)
     {
-        await this.OnLogMessage.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
+        await this.invocableLogMessageObservableEvent.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
     }
 
     private async Task<Cache.InstalledDriverInfo> GetInstalledDriverInfoFromCacheAsync(Cache cacheInfo, DriverDownloadInfo driverDownloadInfo)

--- a/src/WebDriverBiDi.Client/Launchers/FileDownloader.cs
+++ b/src/WebDriverBiDi.Client/Launchers/FileDownloader.cs
@@ -15,10 +15,12 @@ internal class FileDownloader
     // 1 MB buffer for downloads
     private const int BufferSize = 1024 * 1024;
 
+    private readonly ObservableEventInvocable<FileDownloadProgressEventArgs> invocableFileDownloadProgressObservableEvent = new("fileDownloader.downloadProgress");
+
     /// <summary>
     /// Gets an observable event that notifies when download progress is updated.
     /// </summary>
-    public ObservableEvent<FileDownloadProgressEventArgs> OnDownloadProgress { get; } = new("fileDownloader.downloadProgress");
+    public ObservableEvent<FileDownloadProgressEventArgs> OnDownloadProgress => this.invocableFileDownloadProgressObservableEvent;
 
     /// <summary>
     /// Downloads a file from the specified URL to the specified destination path.
@@ -52,7 +54,7 @@ internal class FileDownloader
                 if (percent != lastPercent && percent % 10 == 0)
                 {
                     FileDownloadProgressEventArgs progressArgs = new(percent);
-                    await this.OnDownloadProgress.NotifyObserversAsync(progressArgs).ConfigureAwait(false);
+                    await this.invocableFileDownloadProgressObservableEvent.NotifyObserversAsync(progressArgs).ConfigureAwait(false);
                     lastPercent = percent;
                 }
             }

--- a/src/WebDriverBiDi.Client/Launchers/FirefoxLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/FirefoxLauncher.cs
@@ -39,14 +39,14 @@ public class FirefoxLauncher : BrowserLauncher
     }
 
     /// <summary>
-    /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
-    /// </summary>
-    public override ObservableEvent<LogMessageEventArgs> OnLogMessage { get; } = new("firefoxLauncher.logMessage");
-
-    /// <summary>
     /// Gets a value indicating whether the service is running.
     /// </summary>
     public override bool IsRunning => this.browserProcess is not null && !this.browserProcess.HasExited;
+
+    /// <summary>
+    /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
+    /// </summary>
+    protected override ObservableEventInvocable<LogMessageEventArgs> InvocableLogMessageObservableEvent { get; } = new("firefoxLauncher.logMessage");
 
     private IList<string> CommandLineArguments
     {

--- a/src/WebDriverBiDi.Client/Launchers/WebDriverClassicBrowserLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/WebDriverClassicBrowserLauncher.cs
@@ -44,11 +44,6 @@ public class WebDriverClassicBrowserLauncher : BrowserLauncher
     public override bool IsBiDiSessionInitialized => true;
 
     /// <summary>
-    /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
-    /// </summary>
-    public override ObservableEvent<LogMessageEventArgs> OnLogMessage { get; } = new("classicBrowserLauncher.logMessage");
-
-    /// <summary>
     /// Gets a value indicating whether the browser is currently running.
     /// For remote browsers, this is true if a session has been established.
     /// </summary>
@@ -68,6 +63,11 @@ public class WebDriverClassicBrowserLauncher : BrowserLauncher
     /// Gets a value indicating whether the browser can be closed using WebDriver BiDi's browser.close command.
     /// </summary>
     public override bool IsBrowserCloseAllowed => this.BrowserLocator.BrowserName != "firefox";
+
+    /// <summary>
+    /// Gets an observable event that notifies when a log message is emitted by the browser launcher.
+    /// </summary>
+    protected override ObservableEventInvocable<LogMessageEventArgs> InvocableLogMessageObservableEvent { get; } = new("classicBrowserLauncher.logMessage");
 
     /// <summary>
     /// Gets or sets the location of the browser executable.

--- a/src/WebDriverBiDi/BiDiDriver.cs
+++ b/src/WebDriverBiDi/BiDiDriver.cs
@@ -72,6 +72,12 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
     private readonly EventObserver<LogMessageEventArgs> transportLogMessageObserver;
     private readonly EventObserver<EventHandlerErrorOccurredEventArgs> transportEventHandlerErrorOccurredObserver;
 
+    private readonly ObservableEventInvocable<EventReceivedEventArgs> invocableEventReceivedObserableEvent;
+    private readonly ObservableEventInvocable<ErrorReceivedEventArgs> invocableErrorReceivedObservableEvent;
+    private readonly ObservableEventInvocable<UnknownMessageReceivedEventArgs> invocableUnknownMessageReceivedObservableEvent;
+    private readonly ObservableEventInvocable<EventHandlerErrorOccurredEventArgs> invocableEventHandlerErrorOccurredObservableEvent;
+    private readonly ObservableEventInvocable<LogMessageEventArgs> invocableLogMessageObservableEvent;
+
     private readonly Transport transport;
     private readonly ConcurrentDictionary<string, Module> modules = [];
     private readonly ConcurrentDictionary<string, EventInvoker> eventInvokers = [];
@@ -144,11 +150,11 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
         this.transportLogMessageObserver = this.transport.OnLogMessage.AddObserver(this.OnTransportLogMessageAsync);
         this.transportEventHandlerErrorOccurredObserver = this.transport.OnEventHandlerErrorOccurred.AddObserver(this.OnTransportEventHandlerErrorOccurredAsync);
 
-        this.OnEventReceived = this.CreateObservableEvent<EventReceivedEventArgs>(EventReceivedEventName);
-        this.OnUnexpectedErrorReceived = this.CreateObservableEvent<ErrorReceivedEventArgs>(UnexpectedErrorReceivedEventName);
-        this.OnUnknownMessageReceived = this.CreateObservableEvent<UnknownMessageReceivedEventArgs>(UnknownMessageReceivedEventName);
-        this.OnEventHandlerErrorOccurred = this.CreateObservableEvent<EventHandlerErrorOccurredEventArgs>(EventHandlerErrorOccurredEventName);
-        this.OnLogMessage = this.CreateObservableEvent<LogMessageEventArgs>(LogMessageEventName);
+        this.invocableEventReceivedObserableEvent = this.CreateObservableEvent<EventReceivedEventArgs>(EventReceivedEventName);
+        this.invocableErrorReceivedObservableEvent = this.CreateObservableEvent<ErrorReceivedEventArgs>(UnexpectedErrorReceivedEventName);
+        this.invocableUnknownMessageReceivedObservableEvent = this.CreateObservableEvent<UnknownMessageReceivedEventArgs>(UnknownMessageReceivedEventName);
+        this.invocableEventHandlerErrorOccurredObservableEvent = this.CreateObservableEvent<EventHandlerErrorOccurredEventArgs>(EventHandlerErrorOccurredEventName);
+        this.invocableLogMessageObservableEvent = this.CreateObservableEvent<LogMessageEventArgs>(LogMessageEventName);
 
         this.Bluetooth = new BluetoothModule(this);
         this.RegisterModule(this.Bluetooth);
@@ -198,17 +204,17 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
     /// <summary>
     /// Gets an observable event that notifies when a protocol event is received from protocol transport.
     /// </summary>
-    public ObservableEvent<EventReceivedEventArgs> OnEventReceived { get; }
+    public ObservableEvent<EventReceivedEventArgs> OnEventReceived => this.invocableEventReceivedObserableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a protocol error is received from protocol transport.
     /// </summary>
-    public ObservableEvent<ErrorReceivedEventArgs> OnUnexpectedErrorReceived { get; }
+    public ObservableEvent<ErrorReceivedEventArgs> OnUnexpectedErrorReceived => this.invocableErrorReceivedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when an unknown message is received from protocol transport.
     /// </summary>
-    public ObservableEvent<UnknownMessageReceivedEventArgs> OnUnknownMessageReceived { get; }
+    public ObservableEvent<UnknownMessageReceivedEventArgs> OnUnknownMessageReceived => this.invocableUnknownMessageReceivedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when an error occurs in an observer of an observable event.
@@ -217,12 +223,12 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
     /// This event is for diagnostic and observability purposes, and does not prevent
     /// the propagation of the error back to the Transport class.
     /// </remarks>
-    public ObservableEvent<EventHandlerErrorOccurredEventArgs> OnEventHandlerErrorOccurred { get; }
+    public ObservableEvent<EventHandlerErrorOccurredEventArgs> OnEventHandlerErrorOccurred => this.invocableEventHandlerErrorOccurredObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a log message is emitted by this driver.
     /// </summary>
-    public ObservableEvent<LogMessageEventArgs> OnLogMessage { get; }
+    public ObservableEvent<LogMessageEventArgs> OnLogMessage => this.invocableLogMessageObservableEvent;
 
     /// <summary>
     /// Gets the bluetooth module as described in the W3C Web Bluetooth Specification.
@@ -737,7 +743,7 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
     /// <returns>The task object representing the asynchronous operation.</returns>
     protected async Task LogAsync(string message, WebDriverBiDiLogLevel logLevel)
     {
-        await this.OnLogMessage.NotifyObserversAsync(new LogMessageEventArgs(message, logLevel, LoggerComponentName)).ConfigureAwait(false);
+        await this.invocableLogMessageObservableEvent.NotifyObserversAsync(new LogMessageEventArgs(message, logLevel, LoggerComponentName)).ConfigureAwait(false);
     }
 
     private void ThrowIfDisposed()
@@ -753,10 +759,10 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
         return this.transport.ReportEventObserverErrorAsync(errorInfo);
     }
 
-    private ObservableEvent<T> CreateObservableEvent<T>(string eventName)
+    private ObservableEventInvocable<T> CreateObservableEvent<T>(string eventName)
         where T : WebDriverBiDiEventArgs
     {
-        ObservableEvent<T> observableEvent = new(eventName);
+        ObservableEventInvocable<T> observableEvent = new(eventName);
         observableEvent.SetObserverErrorReporter(this.ReportObservableEventObserverError);
         return observableEvent;
     }
@@ -768,26 +774,26 @@ public class BiDiDriver : IBiDiCommandExecutor, IBiDiDriverConfiguration, IBiDiD
             await invoker.InvokeEventAsync(e.EventData, e.AdditionalData).ConfigureAwait(false);
         }
 
-        await this.OnEventReceived.NotifyObserversAsync(e).ConfigureAwait(false);
+        await this.invocableEventReceivedObserableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
     }
 
     private async Task OnTransportErrorEventReceivedAsync(ErrorReceivedEventArgs e)
     {
-        await this.OnUnexpectedErrorReceived.NotifyObserversAsync(e).ConfigureAwait(false);
+        await this.invocableErrorReceivedObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
     }
 
     private async Task OnTransportUnknownMessageReceivedAsync(UnknownMessageReceivedEventArgs e)
     {
-        await this.OnUnknownMessageReceived.NotifyObserversAsync(e).ConfigureAwait(false);
+        await this.invocableUnknownMessageReceivedObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
     }
 
     private async Task OnTransportEventHandlerErrorOccurredAsync(EventHandlerErrorOccurredEventArgs e)
     {
-        await this.OnEventHandlerErrorOccurred.NotifyObserversAsync(e).ConfigureAwait(false);
+        await this.invocableEventHandlerErrorOccurredObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
     }
 
     private async Task OnTransportLogMessageAsync(LogMessageEventArgs e)
     {
-        await this.OnLogMessage.NotifyObserversAsync(e).ConfigureAwait(false);
+        await this.invocableLogMessageObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
     }
 }

--- a/src/WebDriverBiDi/Bluetooth/BluetoothModule.cs
+++ b/src/WebDriverBiDi/Bluetooth/BluetoothModule.cs
@@ -20,6 +20,11 @@ public sealed class BluetoothModule : Module
     private const string CharacteristicEventGeneratedEventName = $"{BluetoothModuleName}.characteristicEventGenerated";
     private const string DescriptorEventGeneratedEventName = $"{BluetoothModuleName}.descriptorEventGenerated";
 
+    private readonly ObservableEventInvocable<CharacteristicEventGeneratedEventArgs> invocableCharacteristicGeneratedObservableEvent = new(CharacteristicEventGeneratedEventName);
+    private readonly ObservableEventInvocable<DescriptorEventGeneratedEventArgs> invocableDescriptorEventGeneratedObservableEvent = new(DescriptorEventGeneratedEventName);
+    private readonly ObservableEventInvocable<GattConnectionAttemptedEventArgs> invocableGattConnectionAttemptedObservableEvent = new(GattConnectionAttemptedEventName);
+    private readonly ObservableEventInvocable<RequestDevicePromptUpdatedEventArgs> invocableRequestDevicePromptUpdatedObservableEvent = new(RequestDevicePromptUpdatedEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BluetoothModule"/> class.
     /// </summary>
@@ -27,35 +32,35 @@ public sealed class BluetoothModule : Module
     public BluetoothModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent(this.OnRequestDevicePromptUpdated);
-        this.RegisterObservableEvent(this.OnGattConnectionAttempted);
-        this.RegisterObservableEvent(this.OnCharacteristicGeneratedEvent);
-        this.RegisterObservableEvent(this.OnDescriptorGeneratedEvent);
+        this.RegisterObservableEvent(this.invocableRequestDevicePromptUpdatedObservableEvent);
+        this.RegisterObservableEvent(this.invocableGattConnectionAttemptedObservableEvent);
+        this.RegisterObservableEvent(this.invocableCharacteristicGeneratedObservableEvent);
+        this.RegisterObservableEvent(this.invocableDescriptorEventGeneratedObservableEvent);
     }
 
     /// <summary>
     /// Gets an observable event that notifies when a Bluetooth device generates a characteristic event.
     /// </summary>
     [ObservableEventName(CharacteristicEventGeneratedEventName)]
-    public ObservableEvent<CharacteristicEventGeneratedEventArgs> OnCharacteristicGeneratedEvent { get; } = new(CharacteristicEventGeneratedEventName);
+    public ObservableEvent<CharacteristicEventGeneratedEventArgs> OnCharacteristicGeneratedEvent => this.invocableCharacteristicGeneratedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a Bluetooth device generates a descriptor event.
     /// </summary>
     [ObservableEventName(DescriptorEventGeneratedEventName)]
-    public ObservableEvent<DescriptorEventGeneratedEventArgs> OnDescriptorGeneratedEvent { get; } = new(DescriptorEventGeneratedEventName);
+    public ObservableEvent<DescriptorEventGeneratedEventArgs> OnDescriptorGeneratedEvent => this.invocableDescriptorEventGeneratedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a Bluetooth device attempts a GATT connection.
     /// </summary>
     [ObservableEventName(GattConnectionAttemptedEventName)]
-    public ObservableEvent<GattConnectionAttemptedEventArgs> OnGattConnectionAttempted { get; } = new(GattConnectionAttemptedEventName);
+    public ObservableEvent<GattConnectionAttemptedEventArgs> OnGattConnectionAttempted => this.invocableGattConnectionAttemptedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a Bluetooth device prompt is updated.
     /// </summary>
     [ObservableEventName(RequestDevicePromptUpdatedEventName)]
-    public ObservableEvent<RequestDevicePromptUpdatedEventArgs> OnRequestDevicePromptUpdated { get; } = new(RequestDevicePromptUpdatedEventName);
+    public ObservableEvent<RequestDevicePromptUpdatedEventArgs> OnRequestDevicePromptUpdated => this.invocableRequestDevicePromptUpdatedObservableEvent;
 
     /// <summary>
     /// Gets the module name.

--- a/src/WebDriverBiDi/BrowsingContext/BrowsingContextModule.cs
+++ b/src/WebDriverBiDi/BrowsingContext/BrowsingContextModule.cs
@@ -30,6 +30,21 @@ public sealed class BrowsingContextModule : Module
     private const string UserPromptClosedEventName = $"{BrowsingContextModuleName}.userPromptClosed";
     private const string UserPromptOpenedEventName = $"{BrowsingContextModuleName}.userPromptOpened";
 
+    private readonly ObservableEventInvocable<BrowsingContextEventArgs> invocableContextCreatedObservableEvent = new(ContextCreatedEventName);
+    private readonly ObservableEventInvocable<BrowsingContextEventArgs> invocableContextDestroyedObservableEvent = new(ContextDestroyedEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableNavigationStartedObservableEvent = new(NavigationStartedEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableFragmentNavigatedObservableEvent = new(FragmentNavigatedEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableDomContentLoadedObservableEvent = new(DomContentLoadedEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableLoadObservableEvent = new(LoadEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableNavigationAbortedObservableEvent = new(NavigationAbortedEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableNavigationCommittedObservableEvent = new(NavigationCommittedEventName);
+    private readonly ObservableEventInvocable<NavigationEventArgs> invocableNavigationFailedObservableEvent = new(NavigationFailedEventName);
+    private readonly ObservableEventInvocable<DownloadWillBeginEventArgs> invocableDownloadWillBeginObservableEvent = new(DownloadWillBeginEventName);
+    private readonly ObservableEventInvocable<DownloadEndEventArgs> invocableDownloadEndObservableEvent = new(DownloadEndEventName);
+    private readonly ObservableEventInvocable<HistoryUpdatedEventArgs> invocableHistoryUpdatedObservableEvent = new(HistoryUpdatedEventName);
+    private readonly ObservableEventInvocable<UserPromptClosedEventArgs> invocableUserPromptClosedObservableEvent = new(UserPromptClosedEventName);
+    private readonly ObservableEventInvocable<UserPromptOpenedEventArgs> invocableUserPromptOpenedObservableEvent = new(UserPromptOpenedEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BrowsingContextModule"/> class.
     /// </summary>
@@ -37,105 +52,105 @@ public sealed class BrowsingContextModule : Module
     public BrowsingContextModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent<BrowsingContextInfo, BrowsingContextEventArgs>(this.OnContextCreated, info => new BrowsingContextEventArgs(info));
-        this.RegisterObservableEvent<BrowsingContextInfo, BrowsingContextEventArgs>(this.OnContextDestroyed, info => new BrowsingContextEventArgs(info));
-        this.RegisterObservableEvent(this.OnNavigationStarted);
-        this.RegisterObservableEvent(this.OnFragmentNavigated);
-        this.RegisterObservableEvent(this.OnDomContentLoaded);
-        this.RegisterObservableEvent(this.OnLoad);
-        this.RegisterObservableEvent(this.OnDownloadWillBegin);
-        this.RegisterObservableEvent(this.OnDownloadEnd);
-        this.RegisterObservableEvent(this.OnNavigationAborted);
-        this.RegisterObservableEvent(this.OnNavigationCommitted);
-        this.RegisterObservableEvent(this.OnNavigationFailed);
-        this.RegisterObservableEvent(this.OnHistoryUpdated);
-        this.RegisterObservableEvent(this.OnUserPromptClosed);
-        this.RegisterObservableEvent(this.OnUserPromptOpened);
+        this.RegisterObservableEvent<BrowsingContextInfo, BrowsingContextEventArgs>(this.invocableContextCreatedObservableEvent, info => new BrowsingContextEventArgs(info));
+        this.RegisterObservableEvent<BrowsingContextInfo, BrowsingContextEventArgs>(this.invocableContextDestroyedObservableEvent, info => new BrowsingContextEventArgs(info));
+        this.RegisterObservableEvent(this.invocableNavigationStartedObservableEvent);
+        this.RegisterObservableEvent(this.invocableFragmentNavigatedObservableEvent);
+        this.RegisterObservableEvent(this.invocableDomContentLoadedObservableEvent);
+        this.RegisterObservableEvent(this.invocableLoadObservableEvent);
+        this.RegisterObservableEvent(this.invocableDownloadWillBeginObservableEvent);
+        this.RegisterObservableEvent(this.invocableDownloadEndObservableEvent);
+        this.RegisterObservableEvent(this.invocableNavigationAbortedObservableEvent);
+        this.RegisterObservableEvent(this.invocableNavigationCommittedObservableEvent);
+        this.RegisterObservableEvent(this.invocableNavigationFailedObservableEvent);
+        this.RegisterObservableEvent(this.invocableHistoryUpdatedObservableEvent);
+        this.RegisterObservableEvent(this.invocableUserPromptClosedObservableEvent);
+        this.RegisterObservableEvent(this.invocableUserPromptOpenedObservableEvent);
     }
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context is created.
     /// </summary>
     [ObservableEventName(ContextCreatedEventName)]
-    public ObservableEvent<BrowsingContextEventArgs> OnContextCreated { get; } = new(ContextCreatedEventName);
+    public ObservableEvent<BrowsingContextEventArgs> OnContextCreated => this.invocableContextCreatedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context is destroyed.
     /// </summary>
     [ObservableEventName(ContextDestroyedEventName)]
-    public ObservableEvent<BrowsingContextEventArgs> OnContextDestroyed { get; } = new(ContextDestroyedEventName);
+    public ObservableEvent<BrowsingContextEventArgs> OnContextDestroyed => this.invocableContextDestroyedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context navigation is started.
     /// </summary>
     [ObservableEventName(NavigationStartedEventName)]
-    public ObservableEvent<NavigationEventArgs> OnNavigationStarted { get; } = new(NavigationStartedEventName);
+    public ObservableEvent<NavigationEventArgs> OnNavigationStarted => this.invocableNavigationStartedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context fragment is navigated.
     /// </summary>
     [ObservableEventName(FragmentNavigatedEventName)]
-    public ObservableEvent<NavigationEventArgs> OnFragmentNavigated { get; } = new(FragmentNavigatedEventName);
+    public ObservableEvent<NavigationEventArgs> OnFragmentNavigated => this.invocableFragmentNavigatedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when the DOM content in a browsing context is loaded.
     /// </summary>
     [ObservableEventName(DomContentLoadedEventName)]
-    public ObservableEvent<NavigationEventArgs> OnDomContentLoaded { get; } = new(DomContentLoadedEventName);
+    public ObservableEvent<NavigationEventArgs> OnDomContentLoaded => this.invocableDomContentLoadedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a download in a browsing context is about to begin.
     /// </summary>
     [ObservableEventName(DownloadWillBeginEventName)]
-    public ObservableEvent<DownloadWillBeginEventArgs> OnDownloadWillBegin { get; } = new(DownloadWillBeginEventName);
+    public ObservableEvent<DownloadWillBeginEventArgs> OnDownloadWillBegin => this.invocableDownloadWillBeginObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a download has ended.
     /// </summary>
     [ObservableEventName(DownloadEndEventName)]
-    public ObservableEvent<DownloadEndEventArgs> OnDownloadEnd { get; } = new(DownloadEndEventName);
+    public ObservableEvent<DownloadEndEventArgs> OnDownloadEnd => this.invocableDownloadEndObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when the content in a browsing context is loaded.
     /// </summary>
     [ObservableEventName(LoadEventName)]
-    public ObservableEvent<NavigationEventArgs> OnLoad { get; } = new(LoadEventName);
+    public ObservableEvent<NavigationEventArgs> OnLoad => this.invocableLoadObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context navigation is aborted.
     /// </summary>
     [ObservableEventName(NavigationAbortedEventName)]
-    public ObservableEvent<NavigationEventArgs> OnNavigationAborted { get; } = new(NavigationAbortedEventName);
+    public ObservableEvent<NavigationEventArgs> OnNavigationAborted => this.invocableNavigationAbortedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context navigation is committed.
     /// </summary>
     [ObservableEventName(NavigationCommittedEventName)]
-    public ObservableEvent<NavigationEventArgs> OnNavigationCommitted { get; } = new(NavigationCommittedEventName);
+    public ObservableEvent<NavigationEventArgs> OnNavigationCommitted => this.invocableNavigationCommittedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a browsing context navigation fails.
     /// </summary>
     [ObservableEventName(NavigationFailedEventName)]
-    public ObservableEvent<NavigationEventArgs> OnNavigationFailed { get; } = new(NavigationFailedEventName);
+    public ObservableEvent<NavigationEventArgs> OnNavigationFailed => this.invocableNavigationFailedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when the browser history is updated.
     /// </summary>
     [ObservableEventName(HistoryUpdatedEventName)]
-    public ObservableEvent<HistoryUpdatedEventArgs> OnHistoryUpdated { get; } = new(HistoryUpdatedEventName);
+    public ObservableEvent<HistoryUpdatedEventArgs> OnHistoryUpdated => this.invocableHistoryUpdatedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a user prompt is opened.
     /// </summary>
     [ObservableEventName(UserPromptOpenedEventName)]
-    public ObservableEvent<UserPromptOpenedEventArgs> OnUserPromptOpened { get; } = new(UserPromptOpenedEventName);
+    public ObservableEvent<UserPromptOpenedEventArgs> OnUserPromptOpened => this.invocableUserPromptOpenedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a user prompt is closed.
     /// </summary>
     [ObservableEventName(UserPromptClosedEventName)]
-    public ObservableEvent<UserPromptClosedEventArgs> OnUserPromptClosed { get; } = new(UserPromptClosedEventName);
+    public ObservableEvent<UserPromptClosedEventArgs> OnUserPromptClosed => this.invocableUserPromptClosedObservableEvent;
 
     /// <summary>
     /// Gets the module name.

--- a/src/WebDriverBiDi/Input/InputModule.cs
+++ b/src/WebDriverBiDi/Input/InputModule.cs
@@ -17,6 +17,8 @@ public sealed class InputModule : Module
 
     private const string FileDialogOpenedEventName = $"{InputModuleName}.fileDialogOpened";
 
+    private readonly ObservableEventInvocable<FileDialogOpenedEventArgs> invocableFileDialogOpenedObservableEvent = new(FileDialogOpenedEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="InputModule"/> class.
     /// </summary>
@@ -24,7 +26,7 @@ public sealed class InputModule : Module
     public InputModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent(this.OnFileDialogOpened);
+        this.RegisterObservableEvent(this.invocableFileDialogOpenedObservableEvent);
     }
 
     /// <summary>
@@ -36,7 +38,7 @@ public sealed class InputModule : Module
     /// Gets an observable event that notifies when a file dialog is opened.
     /// </summary>
     [ObservableEventName(FileDialogOpenedEventName)]
-    public ObservableEvent<FileDialogOpenedEventArgs> OnFileDialogOpened { get; } = new(FileDialogOpenedEventName);
+    public ObservableEvent<FileDialogOpenedEventArgs> OnFileDialogOpened => this.invocableFileDialogOpenedObservableEvent;
 
     /// <summary>
     /// Performs a set of actions.

--- a/src/WebDriverBiDi/Log/LogModule.cs
+++ b/src/WebDriverBiDi/Log/LogModule.cs
@@ -17,6 +17,8 @@ public sealed class LogModule : Module
 
     private const string EntryAddedEventName = $"{LogModuleName}.entryAdded";
 
+    private readonly ObservableEventInvocable<EntryAddedEventArgs> invocableEntryAddedObservableEvent = new(EntryAddedEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="LogModule"/> class.
     /// </summary>
@@ -24,14 +26,14 @@ public sealed class LogModule : Module
     public LogModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent<LogEntry, EntryAddedEventArgs>(this.OnEntryAdded, entry => new EntryAddedEventArgs(entry));
+        this.RegisterObservableEvent<LogEntry, EntryAddedEventArgs>(this.invocableEntryAddedObservableEvent, entry => new EntryAddedEventArgs(entry));
     }
 
     /// <summary>
     /// Gets an observable event that notifies when an entry is added to the log.
     /// </summary>
     [ObservableEventName(EntryAddedEventName)]
-    public ObservableEvent<EntryAddedEventArgs> OnEntryAdded { get; } = new(EntryAddedEventName);
+    public ObservableEvent<EntryAddedEventArgs> OnEntryAdded => this.invocableEntryAddedObservableEvent;
 
     /// <summary>
     /// Gets the module name.

--- a/src/WebDriverBiDi/Module.cs
+++ b/src/WebDriverBiDi/Module.cs
@@ -36,7 +36,7 @@ public abstract class Module
     /// </summary>
     /// <typeparam name="T">The type of event args, which must also be the deserialized event data type.</typeparam>
     /// <param name="observableEvent">The <see cref="ObservableEvent{T}"/> to notify when the event is received.</param>
-    protected void RegisterObservableEvent<T>(ObservableEvent<T> observableEvent)
+    protected void RegisterObservableEvent<T>(ObservableEventInvocable<T> observableEvent)
         where T : WebDriverBiDiEventArgs
     {
         this.ConfigureObserverErrorReporting(observableEvent);
@@ -60,7 +60,7 @@ public abstract class Module
     /// <typeparam name="TEventArgs">The event args type to produce and forward.</typeparam>
     /// <param name="observableEvent">The <see cref="ObservableEvent{T}"/> to notify when the event is received.</param>
     /// <param name="eventArgsConverter">A function that creates a <typeparamref name="TEventArgs"/> from the deserialized data.</param>
-    protected void RegisterObservableEvent<T, TEventArgs>(ObservableEvent<TEventArgs> observableEvent, Func<T, TEventArgs> eventArgsConverter)
+    protected void RegisterObservableEvent<T, TEventArgs>(ObservableEventInvocable<TEventArgs> observableEvent, Func<T, TEventArgs> eventArgsConverter)
         where TEventArgs : WebDriverBiDiEventArgs
     {
         this.ConfigureObserverErrorReporting(observableEvent);

--- a/src/WebDriverBiDi/Network/NetworkModule.cs
+++ b/src/WebDriverBiDi/Network/NetworkModule.cs
@@ -21,6 +21,12 @@ public sealed class NetworkModule : Module
     private const string ResponseStartedEventName = $"{NetworkModuleName}.responseStarted";
     private const string ResponseCompletedEventName = $"{NetworkModuleName}.responseCompleted";
 
+    private readonly ObservableEventInvocable<AuthRequiredEventArgs> invocableAuthRequiredObservableEvent = new(AuthRequiredEventName);
+    private readonly ObservableEventInvocable<BeforeRequestSentEventArgs> invocableBeforeRequestSentObservableEvent = new(BeforeRequestSentEventName);
+    private readonly ObservableEventInvocable<FetchErrorEventArgs> invocableFetchErrorObservableEvent = new(FetchErrorEventName);
+    private readonly ObservableEventInvocable<ResponseStartedEventArgs> invocableResponseStartedObservableEvent = new(ResponseStartedEventName);
+    private readonly ObservableEventInvocable<ResponseCompletedEventArgs> invocableResponseCompletedObservableEvent = new(ResponseCompletedEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="NetworkModule"/> class.
     /// </summary>
@@ -28,42 +34,42 @@ public sealed class NetworkModule : Module
     public NetworkModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent(this.OnAuthRequired);
-        this.RegisterObservableEvent(this.OnBeforeRequestSent);
-        this.RegisterObservableEvent(this.OnFetchError);
-        this.RegisterObservableEvent(this.OnResponseStarted);
-        this.RegisterObservableEvent(this.OnResponseCompleted);
+        this.RegisterObservableEvent(this.invocableAuthRequiredObservableEvent);
+        this.RegisterObservableEvent(this.invocableBeforeRequestSentObservableEvent);
+        this.RegisterObservableEvent(this.invocableFetchErrorObservableEvent);
+        this.RegisterObservableEvent(this.invocableResponseCompletedObservableEvent);
+        this.RegisterObservableEvent(this.invocableResponseStartedObservableEvent);
     }
 
     /// <summary>
     /// Gets an observable event that notifies when an authorization required response is received.
     /// </summary>
     [ObservableEventName(AuthRequiredEventName)]
-    public ObservableEvent<AuthRequiredEventArgs> OnAuthRequired { get; } = new(AuthRequiredEventName);
+    public ObservableEvent<AuthRequiredEventArgs> OnAuthRequired => this.invocableAuthRequiredObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies before a network request is sent.
     /// </summary>
     [ObservableEventName(BeforeRequestSentEventName)]
-    public ObservableEvent<BeforeRequestSentEventArgs> OnBeforeRequestSent { get; } = new(BeforeRequestSentEventName);
+    public ObservableEvent<BeforeRequestSentEventArgs> OnBeforeRequestSent => this.invocableBeforeRequestSentObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when an error is encountered fetching data.
     /// </summary>
     [ObservableEventName(FetchErrorEventName)]
-    public ObservableEvent<FetchErrorEventArgs> OnFetchError { get; } = new(FetchErrorEventName);
+    public ObservableEvent<FetchErrorEventArgs> OnFetchError => this.invocableFetchErrorObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when network response has started.
     /// </summary>
     [ObservableEventName(ResponseStartedEventName)]
-    public ObservableEvent<ResponseStartedEventArgs> OnResponseStarted { get; } = new(ResponseStartedEventName);
+    public ObservableEvent<ResponseStartedEventArgs> OnResponseStarted => this.invocableResponseStartedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when network response has completed.
     /// </summary>
     [ObservableEventName(ResponseCompletedEventName)]
-    public ObservableEvent<ResponseCompletedEventArgs> OnResponseCompleted { get; } = new(ResponseCompletedEventName);
+    public ObservableEvent<ResponseCompletedEventArgs> OnResponseCompleted => this.invocableResponseCompletedObservableEvent;
 
     /// <summary>
     /// Gets the module name.

--- a/src/WebDriverBiDi/ObservableEventInvocable{T}.cs
+++ b/src/WebDriverBiDi/ObservableEventInvocable{T}.cs
@@ -1,0 +1,46 @@
+// <copyright file="ObservableEventInvocable{T}.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi;
+
+/// <summary>
+/// Producer-side implementation of a subject in the Observer pattern for events, allowing a producer
+/// to notify observers.
+/// </summary>
+/// <typeparam name="T">The type of event arguments containing information about the observable event.</typeparam>
+public class ObservableEventInvocable<T> : ObservableEvent<T>
+    where T : WebDriverBiDiEventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableEventInvocable{T}"/> class.
+    /// </summary>
+    /// <param name="eventName">The name of the event.</param>
+    public ObservableEventInvocable(string eventName)
+        : this(eventName, 0)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableEventInvocable{T}"/> class.
+    /// </summary>
+    /// <param name="eventName">The name of the event.</param>
+    /// <param name="maxObserverCount">The maximum number of handlers that may observe this event.</param>
+    public ObservableEventInvocable(string eventName, uint maxObserverCount)
+        : base(eventName, maxObserverCount)
+    {
+    }
+
+    /// <summary>
+    /// Asynchronously notifies observers when this observable event occurs. Each observer is
+    /// notified independently; an exception thrown by one observer does not prevent subsequent
+    /// observers from being notified. If exactly one observer throws, the original exception is
+    /// rethrown. If multiple observers throw, an <see cref="AggregateException"/> containing all
+    /// caught exceptions is thrown after all observers have been notified.
+    /// </summary>
+    /// <param name="notifyData">The data of the event.</param>
+    /// <returns>The task object representing the asynchronous operation.</returns>
+    /// <exception cref="AggregateException">Thrown when multiple observer handlers throw an exception.</exception>
+    public new Task NotifyObserversAsync(T notifyData) => base.NotifyObserversAsync(notifyData);
+}

--- a/src/WebDriverBiDi/ObservableEvent{T}.cs
+++ b/src/WebDriverBiDi/ObservableEvent{T}.cs
@@ -32,17 +32,8 @@ public class ObservableEvent<T>
     /// Initializes a new instance of the <see cref="ObservableEvent{T}"/> class.
     /// </summary>
     /// <param name="eventName">The name of the event.</param>
-    public ObservableEvent(string eventName)
-        : this(eventName, 0)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ObservableEvent{T}"/> class.
-    /// </summary>
-    /// <param name="eventName">The name of the event.</param>
     /// <param name="maxObserverCount">The maximum number of handlers that may observe this event.</param>
-    public ObservableEvent(string eventName, uint maxObserverCount)
+    protected ObservableEvent(string eventName, uint maxObserverCount)
     {
         this.EventName = eventName;
         this.MaxObserverCount = maxObserverCount;
@@ -161,6 +152,33 @@ public class ObservableEvent<T>
     }
 
     /// <summary>
+    /// Returns a string that represents the current object.
+    /// </summary>
+    /// <returns>A string that represents the current object.</returns>
+    public override string ToString()
+    {
+        // Make a copy of the observers under the lock to avoid holding the
+        // lock while building the string.
+        List<EventObserver<T>> observerList;
+        lock (this.observerLock)
+        {
+            observerList = [.. this.observers.Values];
+        }
+
+        return $"ObservableEvent<{typeof(T).Name}> with observers:\n    {string.Join("\n    ", observerList)}";
+    }
+
+    /// <summary>
+    /// Sets the internal reporter used to surface observer failures that occur
+    /// after the handler has already returned to the caller.
+    /// </summary>
+    /// <param name="reporter">The reporter callback.</param>
+    internal void SetObserverErrorReporter(Func<EventObserverErrorInfo, Task> reporter)
+    {
+        this.observerErrorReporter = reporter;
+    }
+
+    /// <summary>
     /// Asynchronously notifies observers when this observable event occurs. Each observer is
     /// notified independently; an exception thrown by one observer does not prevent subsequent
     /// observers from being notified. If exactly one observer throws, the original exception is
@@ -170,7 +188,7 @@ public class ObservableEvent<T>
     /// <param name="notifyData">The data of the event.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     /// <exception cref="AggregateException">Thrown when multiple observer handlers throw an exception.</exception>
-    public async Task NotifyObserversAsync(T notifyData)
+    protected async Task NotifyObserversAsync(T notifyData)
     {
         // Snapshot the observers under the lock so that iteration is safe
         // even if observers are added or removed concurrently. The lock is
@@ -206,32 +224,5 @@ public class ObservableEvent<T>
 
             throw new AggregateException("One or more observer handlers threw an exception.", exceptions);
         }
-    }
-
-    /// <summary>
-    /// Returns a string that represents the current object.
-    /// </summary>
-    /// <returns>A string that represents the current object.</returns>
-    public override string ToString()
-    {
-        // Make a copy of the observers under the lock to avoid holding the
-        // lock while building the string.
-        List<EventObserver<T>> observerList;
-        lock (this.observerLock)
-        {
-            observerList = [.. this.observers.Values];
-        }
-
-        return $"ObservableEvent<{typeof(T).Name}> with observers:\n    {string.Join("\n    ", observerList)}";
-    }
-
-    /// <summary>
-    /// Sets the internal reporter used to surface observer failures that occur
-    /// after the handler has already returned to the caller.
-    /// </summary>
-    /// <param name="reporter">The reporter callback.</param>
-    internal void SetObserverErrorReporter(Func<EventObserverErrorInfo, Task> reporter)
-    {
-        this.observerErrorReporter = reporter;
     }
 }

--- a/src/WebDriverBiDi/Protocol/Connection.cs
+++ b/src/WebDriverBiDi/Protocol/Connection.cs
@@ -89,27 +89,47 @@ public abstract class Connection : IAsyncDisposable
     /// <summary>
     /// Gets an observable event that notifies when data is received from this connection.
     /// </summary>
-    public ObservableEvent<ConnectionDataReceivedEventArgs> OnDataReceived { get; } = new(DataReceivedEventName);
+    public ObservableEvent<ConnectionDataReceivedEventArgs> OnDataReceived => this.InvocableConnectionDataReceivedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a communication error occurs on this connection.
     /// </summary>
-    public ObservableEvent<ConnectionErrorEventArgs> OnConnectionError { get; } = new(ConnectionErrorEventName);
+    public ObservableEvent<ConnectionErrorEventArgs> OnConnectionError => this.InvocableConnectionErrorObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when the remote end gracefully closes this connection.
     /// </summary>
-    public ObservableEvent<ConnectionDisconnectedEventArgs> OnRemoteDisconnected { get; } = new(RemoteDisconnectedEventName);
+    public ObservableEvent<ConnectionDisconnectedEventArgs> OnRemoteDisconnected => this.InvocableRemoteDisconnectedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a log message is written.
     /// </summary>
-    public ObservableEvent<LogMessageEventArgs> OnLogMessage { get; } = new(LogMessageEventName);
+    public ObservableEvent<LogMessageEventArgs> OnLogMessage => this.InvocableLogMessageObservableEvent;
 
     /// <summary>
     /// Gets a value indicating whether this connection has been disposed.
     /// </summary>
     protected bool IsDisposed => Interlocked.CompareExchange(ref this.isDisposedFlag, 0, 0) == 1;
+
+    /// <summary>
+    /// Gets an ObservableEventInvocable that subclasses can use to raise the OnDataReceived event.
+    /// </summary>
+    protected ObservableEventInvocable<ConnectionDataReceivedEventArgs> InvocableConnectionDataReceivedObservableEvent { get; } = new(DataReceivedEventName);
+
+    /// <summary>
+    /// Gets an ObservableEventInvocable that subclasses can use to raise the OnConnectionError event.
+    /// </summary>
+    protected ObservableEventInvocable<ConnectionErrorEventArgs> InvocableConnectionErrorObservableEvent { get; } = new(ConnectionErrorEventName);
+
+    /// <summary>
+    /// Gets an ObservableEventInvocable that subclasses can use to raise the OnRemoteDisconnected event.
+    /// </summary>
+    protected ObservableEventInvocable<ConnectionDisconnectedEventArgs> InvocableRemoteDisconnectedObservableEvent { get; } = new(RemoteDisconnectedEventName);
+
+    /// <summary>
+    /// Gets an ObservableEventInvocable that subclasses can use to raise the OnLogMessage event.
+    /// </summary>
+    protected ObservableEventInvocable<LogMessageEventArgs> InvocableLogMessageObservableEvent { get; } = new(LogMessageEventName);
 
     /// <summary>
     /// Asynchronously starts communication with the remote end of this connection.
@@ -185,6 +205,6 @@ public abstract class Connection : IAsyncDisposable
     /// <returns>The task object representing the asynchronous operation.</returns>
     protected async Task LogAsync(string message, WebDriverBiDiLogLevel level)
     {
-        await this.OnLogMessage.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
+        await this.InvocableLogMessageObservableEvent.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
     }
 }

--- a/src/WebDriverBiDi/Protocol/PipeConnection.cs
+++ b/src/WebDriverBiDi/Protocol/PipeConnection.cs
@@ -354,7 +354,7 @@ public class PipeConnection : Connection
                                 await this.LogAsync($"RECV <<< {Encoding.UTF8.GetString(messageData)}", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
                             }
 
-                            await this.OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(messageData)).ConfigureAwait(false);
+                            await this.InvocableConnectionDataReceivedObservableEvent.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(messageData)).ConfigureAwait(false);
                         }
 
                         startIndex = i + 1;
@@ -373,7 +373,7 @@ public class PipeConnection : Connection
             // If the loop exited without cancellation, the remote end closed the connection gracefully.
             if (!cancellationToken.IsCancellationRequested)
             {
-                await this.OnRemoteDisconnected.NotifyObserversAsync(new ConnectionDisconnectedEventArgs()).ConfigureAwait(false);
+                await this.InvocableRemoteDisconnectedObservableEvent.NotifyObserversAsync(new ConnectionDisconnectedEventArgs()).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -383,12 +383,12 @@ public class PipeConnection : Connection
         catch (IOException e)
         {
             await this.LogAsync($"Unexpected error during receive of data: {e.Message}").ConfigureAwait(false);
-            await this.OnConnectionError.NotifyObserversAsync(new ConnectionErrorEventArgs(e)).ConfigureAwait(false);
+            await this.InvocableConnectionErrorObservableEvent.NotifyObserversAsync(new ConnectionErrorEventArgs(e)).ConfigureAwait(false);
         }
         catch (ObjectDisposedException e)
         {
             await this.LogAsync($"Unexpected error during receive of data: {e.Message}").ConfigureAwait(false);
-            await this.OnConnectionError.NotifyObserversAsync(new ConnectionErrorEventArgs(e)).ConfigureAwait(false);
+            await this.InvocableConnectionErrorObservableEvent.NotifyObserversAsync(new ConnectionErrorEventArgs(e)).ConfigureAwait(false);
         }
         finally
         {

--- a/src/WebDriverBiDi/Protocol/Transport.cs
+++ b/src/WebDriverBiDi/Protocol/Transport.cs
@@ -75,6 +75,12 @@ public class Transport : IAsyncDisposable
     private const string TransportErrorObserverDescription = "transport error observer";
     private const string TransportUnknownMessageObserverDescription = "transport unknown message observer";
 
+    private readonly ObservableEventInvocable<EventReceivedEventArgs> invocableEventReceivedObservableEvent;
+    private readonly ObservableEventInvocable<ErrorReceivedEventArgs> invocableErrorReceivedObservableEvent;
+    private readonly ObservableEventInvocable<UnknownMessageReceivedEventArgs> invocableUnknownMessageReceivedObservableEvent;
+    private readonly ObservableEventInvocable<EventHandlerErrorOccurredEventArgs> invocableErrorHandlerErrorOccurredObservableEvent;
+    private readonly ObservableEventInvocable<LogMessageEventArgs> invocableLogMessageObservableEvent;
+
     private readonly JsonTypeInfo<Command> commandJsonTypeInfo;
     private readonly JsonTypeInfo<ErrorResponseMessage> errorResponseJsonTypeInfo;
     private readonly JsonSerializerOptions options = new()
@@ -152,11 +158,11 @@ public class Transport : IAsyncDisposable
         this.commandJsonTypeInfo = (JsonTypeInfo<Command>)this.options.GetTypeInfo(typeof(Command));
         this.errorResponseJsonTypeInfo = (JsonTypeInfo<ErrorResponseMessage>)this.options.GetTypeInfo(typeof(ErrorResponseMessage));
 
-        this.OnEventReceived = this.CreateObservableEvent<EventReceivedEventArgs>(EventReceivedEventName);
-        this.OnErrorEventReceived = this.CreateObservableEvent<ErrorReceivedEventArgs>(ErrorReceivedEventName);
-        this.OnUnknownMessageReceived = this.CreateObservableEvent<UnknownMessageReceivedEventArgs>(UnknownMessageReceivedEventName);
-        this.OnEventHandlerErrorOccurred = this.CreateObservableEvent<EventHandlerErrorOccurredEventArgs>(EventHandlerErrorOccurredEventName);
-        this.OnLogMessage = this.CreateObservableEvent<LogMessageEventArgs>(LogMessageEventName);
+        this.invocableEventReceivedObservableEvent = this.CreateObservableEvent<EventReceivedEventArgs>(EventReceivedEventName);
+        this.invocableErrorReceivedObservableEvent = this.CreateObservableEvent<ErrorReceivedEventArgs>(ErrorReceivedEventName);
+        this.invocableUnknownMessageReceivedObservableEvent = this.CreateObservableEvent<UnknownMessageReceivedEventArgs>(UnknownMessageReceivedEventName);
+        this.invocableErrorHandlerErrorOccurredObservableEvent = this.CreateObservableEvent<EventHandlerErrorOccurredEventArgs>(EventHandlerErrorOccurredEventName);
+        this.invocableLogMessageObservableEvent = this.CreateObservableEvent<LogMessageEventArgs>(LogMessageEventName);
 
         this.connectionDataReceivedObserver = connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
         this.connectionErrorObserver = connection.OnConnectionError.AddObserver(this.OnConnectionErrorAsync);
@@ -167,28 +173,28 @@ public class Transport : IAsyncDisposable
     /// <summary>
     /// Gets an observable event that notifies when an event is received from the protocol.
     /// </summary>
-    public ObservableEvent<EventReceivedEventArgs> OnEventReceived { get; }
+    public ObservableEvent<EventReceivedEventArgs> OnEventReceived => this.invocableEventReceivedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when an error is received from the protocol
     /// that is not the result of a command execution.
     /// </summary>
-    public ObservableEvent<ErrorReceivedEventArgs> OnErrorEventReceived { get; }
+    public ObservableEvent<ErrorReceivedEventArgs> OnErrorEventReceived => this.invocableErrorReceivedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when an unknown message is received from the protocol.
     /// </summary>
-    public ObservableEvent<UnknownMessageReceivedEventArgs> OnUnknownMessageReceived { get; }
+    public ObservableEvent<UnknownMessageReceivedEventArgs> OnUnknownMessageReceived => this.invocableUnknownMessageReceivedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when an error occurs in an observer of an observable event.
     /// </summary>
-    public ObservableEvent<EventHandlerErrorOccurredEventArgs> OnEventHandlerErrorOccurred { get; }
+    public ObservableEvent<EventHandlerErrorOccurredEventArgs> OnEventHandlerErrorOccurred => this.invocableErrorHandlerErrorOccurredObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a log message is written.
     /// </summary>
-    public ObservableEvent<LogMessageEventArgs> OnLogMessage { get; }
+    public ObservableEvent<LogMessageEventArgs> OnLogMessage => this.invocableLogMessageObservableEvent;
 
     /// <summary>
     /// Gets or sets a value indicating how this <see cref="Transport"/> should behave when an
@@ -564,7 +570,7 @@ public class Transport : IAsyncDisposable
     internal async Task ReportEventObserverErrorAsync(EventObserverErrorInfo errorInfo)
     {
         WebDriverBiDiEventSource.RaiseEvent.EventHandlerError(errorInfo.ObservableEventName, errorInfo.Exception.Message);
-        await this.OnEventHandlerErrorOccurred.NotifyObserversAsync(new EventHandlerErrorOccurredEventArgs(errorInfo)).ConfigureAwait(false);
+        await this.invocableErrorHandlerErrorOccurredObservableEvent.NotifyObserversAsync(new EventHandlerErrorOccurredEventArgs(errorInfo)).ConfigureAwait(false);
         this.CaptureUnhandledError(UnhandledErrorType.EventHandlerException, errorInfo.Exception, this.GetEventHandlerTerminalReason(errorInfo.ObservableEventName));
     }
 
@@ -815,7 +821,7 @@ public class Transport : IAsyncDisposable
     {
         try
         {
-            await this.OnEventReceived.NotifyObserversAsync(e).ConfigureAwait(false);
+            await this.invocableEventReceivedObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -827,7 +833,7 @@ public class Transport : IAsyncDisposable
     {
         try
         {
-            await this.OnErrorEventReceived.NotifyObserversAsync(e).ConfigureAwait(false);
+            await this.invocableErrorReceivedObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -839,7 +845,7 @@ public class Transport : IAsyncDisposable
     {
         try
         {
-            await this.OnUnknownMessageReceived.NotifyObserversAsync(e).ConfigureAwait(false);
+            await this.invocableUnknownMessageReceivedObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -849,7 +855,7 @@ public class Transport : IAsyncDisposable
 
     private async Task OnConnectionLogMessageAsync(LogMessageEventArgs e)
     {
-        await this.OnLogMessage.NotifyObserversAsync(e).ConfigureAwait(false);
+        await this.invocableLogMessageObservableEvent.NotifyObserversAsync(e).ConfigureAwait(false);
     }
 
     private async Task OnConnectionDataReceivedAsync(ConnectionDataReceivedEventArgs e)
@@ -1140,7 +1146,7 @@ public class Transport : IAsyncDisposable
 
     private async Task LogAsync(string message, WebDriverBiDiLogLevel level)
     {
-        await this.OnLogMessage.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
+        await this.invocableLogMessageObservableEvent.NotifyObserversAsync(new LogMessageEventArgs(message, level, LoggerComponentName)).ConfigureAwait(false);
     }
 
     private Exception CreateTerminationException(IList<Exception> exceptions, TransportErrorBehavior errorBehavior = TransportErrorBehavior.Terminate)
@@ -1169,10 +1175,10 @@ public class Transport : IAsyncDisposable
         return $"Unhandled exception in user event handler for event name {observableEventName}";
     }
 
-    private ObservableEvent<T> CreateObservableEvent<T>(string eventName)
+    private ObservableEventInvocable<T> CreateObservableEvent<T>(string eventName)
         where T : WebDriverBiDiEventArgs
     {
-        ObservableEvent<T> observableEvent = new(eventName);
+        ObservableEventInvocable<T> observableEvent = new(eventName);
         observableEvent.SetObserverErrorReporter(this.ReportEventObserverErrorAsync);
         return observableEvent;
     }

--- a/src/WebDriverBiDi/Protocol/WebSocketConnection.cs
+++ b/src/WebDriverBiDi/Protocol/WebSocketConnection.cs
@@ -288,7 +288,7 @@ public class WebSocketConnection : Connection
                                     await this.LogAsync($"RECV <<< {Encoding.UTF8.GetString(bytes)}", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
                                 }
 
-                                await this.OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(bytes)).ConfigureAwait(false);
+                                await this.InvocableConnectionDataReceivedObservableEvent.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(bytes)).ConfigureAwait(false);
                             }
                         }
                     }
@@ -309,7 +309,7 @@ public class WebSocketConnection : Connection
             // If the loop exited without cancellation, the remote end closed the connection gracefully.
             if (!cancellationToken.IsCancellationRequested)
             {
-                await this.OnRemoteDisconnected.NotifyObserversAsync(new ConnectionDisconnectedEventArgs()).ConfigureAwait(false);
+                await this.InvocableRemoteDisconnectedObservableEvent.NotifyObserversAsync(new ConnectionDisconnectedEventArgs()).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -319,7 +319,7 @@ public class WebSocketConnection : Connection
         catch (WebSocketException e)
         {
             await this.LogAsync($"Unexpected error during receive of data: {e.Message}").ConfigureAwait(false);
-            await this.OnConnectionError.NotifyObserversAsync(new ConnectionErrorEventArgs(e)).ConfigureAwait(false);
+            await this.InvocableConnectionErrorObservableEvent.NotifyObserversAsync(new ConnectionErrorEventArgs(e)).ConfigureAwait(false);
         }
         finally
         {

--- a/src/WebDriverBiDi/Script/ScriptModule.cs
+++ b/src/WebDriverBiDi/Script/ScriptModule.cs
@@ -19,6 +19,10 @@ public sealed class ScriptModule : Module
     private const string RealmDestroyedEventName = $"{ScriptModuleName}.realmDestroyed";
     private const string MessageEventName = $"{ScriptModuleName}.message";
 
+    private readonly ObservableEventInvocable<RealmCreatedEventArgs> invocableRealmCreatedObservableEvent = new(RealmCreatedEventName);
+    private readonly ObservableEventInvocable<RealmDestroyedEventArgs> invocableRealmDestroyedObservableEvent = new(RealmDestroyedEventName);
+    private readonly ObservableEventInvocable<MessageEventArgs> invocableMessageObservableEvent = new(MessageEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ScriptModule"/> class.
     /// </summary>
@@ -26,28 +30,28 @@ public sealed class ScriptModule : Module
     public ScriptModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent<RealmInfo, RealmCreatedEventArgs>(this.OnRealmCreated, info => new RealmCreatedEventArgs(info));
-        this.RegisterObservableEvent(this.OnRealmDestroyed);
-        this.RegisterObservableEvent(this.OnMessage);
+        this.RegisterObservableEvent<RealmInfo, RealmCreatedEventArgs>(this.invocableRealmCreatedObservableEvent, info => new RealmCreatedEventArgs(info));
+        this.RegisterObservableEvent(this.invocableRealmDestroyedObservableEvent);
+        this.RegisterObservableEvent(this.invocableMessageObservableEvent);
     }
 
     /// <summary>
     /// Gets an observable event that notifies when a new script realm is created.
     /// </summary>
     [ObservableEventName(RealmCreatedEventName)]
-    public ObservableEvent<RealmCreatedEventArgs> OnRealmCreated { get; } = new(RealmCreatedEventName);
+    public ObservableEvent<RealmCreatedEventArgs> OnRealmCreated => this.invocableRealmCreatedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a script realm is destroyed.
     /// </summary>
     [ObservableEventName(RealmDestroyedEventName)]
-    public ObservableEvent<RealmDestroyedEventArgs> OnRealmDestroyed { get; } = new(RealmDestroyedEventName);
+    public ObservableEvent<RealmDestroyedEventArgs> OnRealmDestroyed => this.invocableRealmDestroyedObservableEvent;
 
     /// <summary>
     /// Gets an observable event that notifies when a preload script sends data to the client.
     /// </summary>
     [ObservableEventName(MessageEventName)]
-    public ObservableEvent<MessageEventArgs> OnMessage { get; } = new(MessageEventName);
+    public ObservableEvent<MessageEventArgs> OnMessage => this.invocableMessageObservableEvent;
 
     /// <summary>
     /// Gets the module name.

--- a/src/WebDriverBiDi/Speculation/SpeculationModule.cs
+++ b/src/WebDriverBiDi/Speculation/SpeculationModule.cs
@@ -18,6 +18,8 @@ public sealed class SpeculationModule : Module
 
     private const string PrefetchStatusUpdatedEventName = $"{SpeculationModuleName}.prefetchStatusUpdated";
 
+    private readonly ObservableEventInvocable<PrefetchStatusUpdatedEventArgs> invocablePrefetchStatusUpdatedObservableEvent = new(PrefetchStatusUpdatedEventName);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SpeculationModule"/> class.
     /// </summary>
@@ -25,14 +27,14 @@ public sealed class SpeculationModule : Module
     public SpeculationModule(IBiDiCommandExecutor driver)
         : base(driver)
     {
-        this.RegisterObservableEvent(this.OnPrefetchStatusUpdated);
+        this.RegisterObservableEvent(this.invocablePrefetchStatusUpdatedObservableEvent);
     }
 
     /// <summary>
     /// Gets an observable event that notifies when the prefetch status of a resource is updated.
     /// </summary>
     [ObservableEventName(PrefetchStatusUpdatedEventName)]
-    public ObservableEvent<PrefetchStatusUpdatedEventArgs> OnPrefetchStatusUpdated { get; } = new(PrefetchStatusUpdatedEventName);
+    public ObservableEvent<PrefetchStatusUpdatedEventArgs> OnPrefetchStatusUpdated => this.invocablePrefetchStatusUpdatedObservableEvent;
 
     /// <summary>
     /// Gets the module name.

--- a/test/WebDriverBiDi.Benchmarks/BenchmarkEchoConnection.cs
+++ b/test/WebDriverBiDi.Benchmarks/BenchmarkEchoConnection.cs
@@ -54,7 +54,7 @@ public sealed class BenchmarkEchoConnection : Connection
         // decouples this from the sender's await on WaitForCompletionAsync.
         long commandId = ExtractCommandId(data);
         byte[] response = BuildSuccessResponse(commandId);
-        await this.OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(response)).ConfigureAwait(false);
+        await this.InvocableConnectionDataReceivedObservableEvent.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(response)).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/test/WebDriverBiDi.Benchmarks/EventDispatchBenchmarks.cs
+++ b/test/WebDriverBiDi.Benchmarks/EventDispatchBenchmarks.cs
@@ -18,7 +18,7 @@ namespace WebDriverBiDi.Benchmarks;
 [MemoryDiagnoser]
 public class EventDispatchBenchmarks
 {
-    private ObservableEvent<BenchmarkEventArgs> observableEvent = null!;
+    private ObservableEventInvocable<BenchmarkEventArgs> observableEvent = null!;
     private BenchmarkEventArgs eventArgs = null!;
     private List<EventObserver<BenchmarkEventArgs>> observers = null!;
 
@@ -39,7 +39,7 @@ public class EventDispatchBenchmarks
     public void Setup()
     {
         this.eventArgs = new BenchmarkEventArgs();
-        this.observableEvent = new ObservableEvent<BenchmarkEventArgs>("benchmark.event");
+        this.observableEvent = new ObservableEventInvocable<BenchmarkEventArgs>("benchmark.event");
         this.observers = new List<EventObserver<BenchmarkEventArgs>>(this.ObserverCount);
         for (int i = 0; i < this.ObserverCount; i++)
         {

--- a/test/WebDriverBiDi.Tests/ObservableEventTests.cs
+++ b/test/WebDriverBiDi.Tests/ObservableEventTests.cs
@@ -1288,7 +1288,7 @@ public class ObservableEventTests
             this.TestObservableEvent = new CustomTimeObservableEvent<TestObservableEventArgs>("testModule.testEvent", maxObserverCount, timeProvider);
         }
 
-        public ObservableEvent<TestObservableEventArgs> TestObservableEvent { get; }
+        public ObservableEventInvocable<TestObservableEventArgs> TestObservableEvent { get; }
 
         public async Task RaiseTestEventAsync(string eventValue)
         {
@@ -1296,7 +1296,7 @@ public class ObservableEventTests
         }
     }
 
-    private class CustomTimeObservableEvent<T> : ObservableEvent<T>
+    private class CustomTimeObservableEvent<T> : ObservableEventInvocable<T>
         where T : WebDriverBiDiEventArgs
     {
         public CustomTimeObservableEvent(string eventName, uint maxObserverCount, TimeProvider timeProvider)

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestPipeConnection.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestPipeConnection.cs
@@ -33,7 +33,7 @@ public class TestPipeConnection : PipeConnection
 
     public async Task RaiseRemoteDisconnectedEventAsync()
     {
-        await this.OnRemoteDisconnected.NotifyObserversAsync(new ConnectionDisconnectedEventArgs());
+        await this.InvocableRemoteDisconnectedObservableEvent.NotifyObserversAsync(new ConnectionDisconnectedEventArgs());
     }
 
     public bool PipesDisposed

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestProtocolModule.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestProtocolModule.cs
@@ -4,6 +4,8 @@ public sealed class TestProtocolModule : Module
 {
     private const string EventName = "protocol.event";
 
+    private readonly ObservableEventInvocable<TestEventArgs> invocableTestObservableEvent;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TestProtocolModule"/> class.
     /// </summary>
@@ -11,14 +13,14 @@ public sealed class TestProtocolModule : Module
     public TestProtocolModule(IBiDiCommandExecutor driver, uint maxObserverCount = 0, bool registerEvents = true)
         : base(driver)
     {
-        this.OnEventInvoked = new ObservableEvent<TestEventArgs>(EventName, maxObserverCount);
+        this.invocableTestObservableEvent = new ObservableEventInvocable<TestEventArgs>(EventName, maxObserverCount);
         if (registerEvents)
         {
-            this.RegisterObservableEvent(this.OnEventInvoked);
+            this.RegisterObservableEvent(this.invocableTestObservableEvent);
         }
     }
 
-    public ObservableEvent<TestEventArgs> OnEventInvoked { get; }
+    public ObservableEvent<TestEventArgs> OnEventInvoked => this.invocableTestObservableEvent;
 
     public override string ModuleName => "protocol";
 

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestWebSocketConnection.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestWebSocketConnection.cs
@@ -61,22 +61,22 @@ public class TestWebSocketConnection : WebSocketConnection
 
     public async Task RaiseDataReceivedEventAsync(string data)
     {
-        await this.OnDataReceived.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(Encoding.UTF8.GetBytes(data)));
+        await this.InvocableConnectionDataReceivedObservableEvent.NotifyObserversAsync(new ConnectionDataReceivedEventArgs(Encoding.UTF8.GetBytes(data)));
     }
 
     public async Task RaiseLogMessageEventAsync(string message, WebDriverBiDiLogLevel level)
     {
-        await this.OnLogMessage.NotifyObserversAsync(new LogMessageEventArgs(message, level, "TestWebSocketConnection"));
+        await this.InvocableLogMessageObservableEvent.NotifyObserversAsync(new LogMessageEventArgs(message, level, "TestWebSocketConnection"));
     }
 
     public async Task RaiseConnectionErrorEventAsync(Exception exception)
     {
-        await this.OnConnectionError.NotifyObserversAsync(new ConnectionErrorEventArgs(exception));
+        await this.InvocableConnectionErrorObservableEvent.NotifyObserversAsync(new ConnectionErrorEventArgs(exception));
     }
 
     public async Task RaiseRemoteDisconnectedEventAsync()
     {
-        await this.OnRemoteDisconnected.NotifyObserversAsync(new ConnectionDisconnectedEventArgs());
+        await this.InvocableRemoteDisconnectedObservableEvent.NotifyObserversAsync(new ConnectionDisconnectedEventArgs());
     }
 
     public override async Task StartAsync(string url, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Technically, this is a breaking change, as `ObservableEvent<T>` no longer has a publicly accessible `NotifyObserverAsync()` method. Consumers who've created custom events should move to having a `private` `ObservableEventInvocable<T>` field, and expose the `ObservableEvent<T>` in the public API.