### PR TITLE
refactor: migrate tests to use xUnit.NET

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,7 +30,7 @@
         },
         {
             "type": "shell",
-            "command": "dotnet build --configuration Release ${workspaceFolder}/test/WebDriverBiDi.Tests/WebDriverBiDi.Tests.csproj && ${workspaceFolder}/test/WebDriverBiDi.Tests/bin/Release/net10.0/WebDriverBiDi.Tests --coverlet --coverlet-output-format teamcity --coverlet-output-format lcov --coverlet-exclude-by-file '**/_/src/**' --coverlet-exclude '[WebDriverBiDi.NamedPipeTestApplication]*' --results-directory '${workspaceFolder}/test/coverage' --coverlet-file-prefix lcov",
+            "command": "dotnet build --configuration Release ${workspaceFolder}/test/WebDriverBiDi.Tests/WebDriverBiDi.Tests.csproj && ${workspaceFolder}/test/WebDriverBiDi.Tests/bin/Release/net10.0/WebDriverBiDi.Tests --coverlet --coverlet-output-format lcov --coverlet-exclude-by-file '**/_/src/**' --coverlet-exclude '[WebDriverBiDi.NamedPipeTestApplication]*' --results-directory '${workspaceFolder}/test/coverage' --coverlet-file-prefix lcov",
             "problemMatcher": "$msCompile",
             "group": {
                 "kind": "test",

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The project uses System.Text.Json for JSON serialization/deserialization in the 
 uses [Json.NET](https://www.newtonsoft.com/json) for some unit tests. It is believed that there is some
 value in testing serialization by deserializing with a different JSON serialization engine.
 
-The project uses [NUnit](https://nunit.org/) for its unit tests.
+The project uses [xUnit.net](https://xunit.net/) for its unit tests.
 
 For testing of browsing web pages and WebSocket traffic, this project uses the
 [PinchHitter](https://github.com/jimevans/PinchHitter) test server library.

--- a/src/WebDriverBiDi.Analyzers.CodeFixProviders/BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider.cs
+++ b/src/WebDriverBiDi.Analyzers.CodeFixProviders/BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider.cs
@@ -126,7 +126,7 @@ public class BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider : CodeFix
         }
 
         // Create a copy of the register statement to insert
-        StatementSyntax? registerStatementCopy = trackedRegisterStatement.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+        StatementSyntax? registerStatementCopy = trackedRegisterStatement.WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
         // Insert RegisterModule before StartAsync
         MethodDeclarationSyntax? newMethod = methodWithoutRegister.InsertNodesBefore(updatedStartAsyncStatement, new[] { registerStatementCopy });

--- a/src/WebDriverBiDi.Analyzers.CodeFixProviders/BiDiDriver002_EventRegistrationAfterStartCodeFixProvider.cs
+++ b/src/WebDriverBiDi.Analyzers.CodeFixProviders/BiDiDriver002_EventRegistrationAfterStartCodeFixProvider.cs
@@ -113,7 +113,7 @@ public class BiDiDriver002_EventRegistrationAfterStartCodeFixProvider : CodeFixP
         }
 
         // Insert the register statement before StartAsync
-        StatementSyntax registerStatementCopy = trackedRegisterStatement.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+        StatementSyntax registerStatementCopy = trackedRegisterStatement.WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
         SyntaxNode newMethod = methodWithoutRegister.InsertNodesBefore(updatedStartAsyncStatement, new[] { registerStatementCopy });
 
         SyntaxNode newRoot = root.ReplaceNode(method, newMethod);

--- a/src/WebDriverBiDi.Analyzers.CodeFixProviders/BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider.cs
+++ b/src/WebDriverBiDi.Analyzers.CodeFixProviders/BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider.cs
@@ -109,7 +109,7 @@ public class BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider
         }
 
         // Insert the register statement before StartAsync
-        StatementSyntax registerStatementCopy = trackedRegisterStatement.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+        StatementSyntax registerStatementCopy = trackedRegisterStatement.WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
         SyntaxNode newMethod = methodWithoutRegister.InsertNodesBefore(updatedStartAsyncStatement, new[] { registerStatementCopy });
 
         SyntaxNode newRoot = root.ReplaceNode(method, newMethod);

--- a/src/WebDriverBiDi.Client/Launchers/BrowserLocator.cs
+++ b/src/WebDriverBiDi.Client/Launchers/BrowserLocator.cs
@@ -5,6 +5,8 @@
 
 namespace WebDriverBiDi.Client.Launchers;
 
+using System.Diagnostics.CodeAnalysis;
+
 /// <summary>
 /// Provides methods for locating and downloading browsers for testing.
 /// </summary>
@@ -200,9 +202,6 @@ public class BrowserLocator
             driverPath = await this.driverLocator.LocateDriverAsync(cacheInfo).ConfigureAwait(false);
         }
 
-        // Save cache if it was loaded (it's only loaded when using AutoLocateAndDownload)
-        cacheInfo?.Save();
-
         return new BrowserExecutableInfo(browserPath, driverPath);
     }
 
@@ -347,30 +346,66 @@ public class BrowserLocator
             throw new InvalidOperationException("Cache should have been loaded for AutoLocateAndDownload behavior.");
         }
 
-        BrowserDownloadInfo browserDownloadInfo = await this.settings.GetBrowserDownloadInfo().ConfigureAwait(false);
-        Cache.InstalledBrowserInfo browserInfo = await this.GetInstalledBrowserInfoFromCacheAsync(cacheInfo, browserDownloadInfo).ConfigureAwait(false);
-        string cachedInstallDirectory = Path.Combine(this.CacheDirectory, this.settings.BrowserName, this.settings.Channel, browserInfo.Version);
-        string executablePath = Path.Combine(cachedInstallDirectory, this.settings.ExpectedExecutablePath);
-
-        string cacheLogMessage = $"Using {this.settings.BrowserLocationBehaviorDescription} browser.";
-        if (!File.Exists(executablePath) || browserInfo.ForceNewDownload)
+        FileLock fileLock = new(Path.Combine(this.CacheDirectory, $".lock-{this.settings.BrowserName}-{this.settings.Channel}"));
+        using IDisposable lockHandle = await fileLock.AcquireAsync().ConfigureAwait(false);
         {
-            if (browserInfo.ForceNewDownload && Directory.Exists(cachedInstallDirectory))
+            // Reload the cache in case the requested browser was downloaded while acquiring the lock.
+            // If cache has a valid, non-expired entry and the executable already exists,
+            // skip the network call entirely.
+            cacheInfo = Cache.Load(this.CacheDirectory);
+            if (this.IsBrowserCached(cacheInfo, out string? cachedExecutablePath))
             {
-                Directory.Delete(cachedInstallDirectory, true);
+                if (!this.settings.IncludeDriver)
+                {
+                    await this.LogAsync($"Using {this.settings.BrowserLocationBehaviorDescription} browser.", WebDriverBiDiLogLevel.Info).ConfigureAwait(false);
+                }
+
+                return cachedExecutablePath;
             }
 
-            await this.DownloadAndExtractBrowserAsync(browserInfo, cachedInstallDirectory, executablePath).ConfigureAwait(false);
-            cacheLogMessage = $"Downloaded {this.settings.BrowserDisplayName} ready at: {executablePath}";
-        }
+            BrowserDownloadInfo browserDownloadInfo = await this.settings.GetBrowserDownloadInfo().ConfigureAwait(false);
+            Cache.InstalledBrowserInfo browserInfo = await this.GetInstalledBrowserInfoFromCacheAsync(cacheInfo, browserDownloadInfo).ConfigureAwait(false);
+            string cachedInstallDirectory = Path.Combine(this.CacheDirectory, this.settings.BrowserName, this.settings.Channel, browserInfo.Version);
+            string executablePath = Path.Combine(cachedInstallDirectory, this.settings.ExpectedExecutablePath);
 
-        if (!this.settings.IncludeDriver)
+            string cacheLogMessage = $"Using {this.settings.BrowserLocationBehaviorDescription} browser.";
+            if (!File.Exists(executablePath) || browserInfo.ForceNewDownload)
+            {
+                if (browserInfo.ForceNewDownload && Directory.Exists(cachedInstallDirectory))
+                {
+                    Directory.Delete(cachedInstallDirectory, true);
+                }
+
+                await this.DownloadAndExtractBrowserAsync(browserInfo, cachedInstallDirectory, executablePath).ConfigureAwait(false);
+                cacheLogMessage = $"Downloaded {this.settings.BrowserDisplayName} ready at: {executablePath}";
+            }
+
+            if (!this.settings.IncludeDriver)
+            {
+                // If we are using a browser driver, this has already been logged.
+                await this.LogAsync(cacheLogMessage, WebDriverBiDiLogLevel.Info).ConfigureAwait(false);
+            }
+
+            cacheInfo.Save();
+            return executablePath;
+        }
+    }
+
+    private bool IsBrowserCached(Cache cacheInfo, [NotNullWhen(true)] out string? cachedExecutablePath)
+    {
+        cachedExecutablePath = null;
+        if (cacheInfo.TryGetCachedBrowser(this.settings, out Cache.InstalledBrowserInfo? browserInfo) && !browserInfo.IsCachedVersionInfoExpired() && !browserInfo.ForceNewDownload)
         {
-            // If we are using a browser driver, this has already been logged.
-            await this.LogAsync(cacheLogMessage, WebDriverBiDiLogLevel.Info).ConfigureAwait(false);
+            string installDirectory = Path.Combine(this.CacheDirectory, this.settings.BrowserName, this.settings.Channel, browserInfo.Version);
+            string executablePath = Path.Combine(installDirectory, this.settings.ExpectedExecutablePath);
+            if (File.Exists(executablePath))
+            {
+                cachedExecutablePath = executablePath;
+                return true;
+            }
         }
 
-        return executablePath;
+        return false;
     }
 
     private async Task<Cache.InstalledBrowserInfo> GetInstalledBrowserInfoFromCacheAsync(Cache cacheInfo, BrowserDownloadInfo browserDownloadInfo)

--- a/src/WebDriverBiDi.Client/Launchers/DriverLocator.cs
+++ b/src/WebDriverBiDi.Client/Launchers/DriverLocator.cs
@@ -128,8 +128,6 @@ public class DriverLocator
             : null;
 
         string? driverPath = await locator.LocateDriverAsync(cacheInfo).ConfigureAwait(false);
-        cacheInfo?.Save();
-
         return driverPath;
     }
 
@@ -176,20 +174,27 @@ public class DriverLocator
             throw new InvalidOperationException("Cache should have been loaded for AutoLocateAndDownload behavior.");
         }
 
-        DriverDownloadInfo driverDownloadInfo = await this.settings.GetMatchingDriverDownloadInfo().ConfigureAwait(false);
-        Cache.InstalledDriverInfo driverInfo = await this.GetInstalledDriverInfoFromCacheAsync(cacheInfo, driverDownloadInfo).ConfigureAwait(false);
-        string driverCacheDirectory = Path.Combine(this.CacheDirectory, "drivers", driverDownloadInfo.DriverName, driverDownloadInfo.Version);
-        string executablePath = Path.Combine(driverCacheDirectory, this.settings.DriverExecutableName);
-
-        string cacheLogMessage = $"Using cached {driverDownloadInfo.DriverName}.";
-        if (!File.Exists(executablePath))
+        FileLock fileLock = new(Path.Combine(this.CacheDirectory, $".lock-{this.settings.BrowserName}-Driver-{this.settings.Channel}"));
+        using IDisposable lockHandle = await fileLock.AcquireAsync().ConfigureAwait(false);
         {
-            await this.DownloadAndExtractDriverAsync(driverInfo, driverCacheDirectory, executablePath).ConfigureAwait(false);
-            cacheLogMessage = $"{driverDownloadInfo.DriverName} ready at: {executablePath}";
-        }
+            // Reload the cache in case the requested browser version was loaded while acquiring the lock
+            cacheInfo = Cache.Load(this.CacheDirectory);
+            DriverDownloadInfo driverDownloadInfo = await this.settings.GetMatchingDriverDownloadInfo().ConfigureAwait(false);
+            Cache.InstalledDriverInfo driverInfo = await this.GetInstalledDriverInfoFromCacheAsync(cacheInfo, driverDownloadInfo).ConfigureAwait(false);
+            string driverCacheDirectory = Path.Combine(this.CacheDirectory, "drivers", driverDownloadInfo.DriverName, driverDownloadInfo.Version);
+            string executablePath = Path.Combine(driverCacheDirectory, this.settings.DriverExecutableName);
 
-        await this.LogAsync(cacheLogMessage, WebDriverBiDiLogLevel.Info).ConfigureAwait(false);
-        return executablePath;
+            string cacheLogMessage = $"Using cached {driverDownloadInfo.DriverName}.";
+            if (!File.Exists(executablePath))
+            {
+                await this.DownloadAndExtractDriverAsync(driverInfo, driverCacheDirectory, executablePath).ConfigureAwait(false);
+                cacheLogMessage = $"{driverDownloadInfo.DriverName} ready at: {executablePath}";
+            }
+
+            await this.LogAsync(cacheLogMessage, WebDriverBiDiLogLevel.Info).ConfigureAwait(false);
+            cacheInfo.Save();
+            return executablePath;
+        }
     }
 
     /// <summary>

--- a/src/WebDriverBiDi.Client/Launchers/FileLock.cs
+++ b/src/WebDriverBiDi.Client/Launchers/FileLock.cs
@@ -1,0 +1,71 @@
+// <copyright file="FileLock.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Client.Launchers;
+
+/// <summary>
+/// A cross-process file-based lock. Call <see cref="AcquireAsync"/> to wait until the lock
+/// is available, then dispose the returned handle to release it.
+/// </summary>
+internal sealed class FileLock
+{
+    private readonly string lockFilePath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileLock"/> class.
+    /// </summary>
+    /// <param name="lockFilePath">The path to the lock file.</param>
+    internal FileLock(string lockFilePath)
+    {
+        this.lockFilePath = lockFilePath;
+    }
+
+    /// <summary>
+    /// Waits until the lock is available, acquires it, and returns a handle that releases
+    /// the lock when disposed.
+    /// </summary>
+    /// <returns>An <see cref="IDisposable"/> that releases the lock when disposed.</returns>
+    internal async Task<IDisposable> AcquireAsync()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(this.lockFilePath)!);
+        while (true)
+        {
+            try
+            {
+                FileStream stream = new(this.lockFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                return new LockHandle(stream, this.lockFilePath);
+            }
+            catch (IOException)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class LockHandle : IDisposable
+    {
+        private readonly FileStream stream;
+        private readonly string lockFilePath;
+        private bool disposed;
+
+        internal LockHandle(FileStream stream, string lockFilePath)
+        {
+            this.stream = stream;
+            this.lockFilePath = lockFilePath;
+        }
+
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.stream.Close();
+            File.Delete(this.lockFilePath);
+        }
+    }
+}

--- a/src/WebDriverBiDi/EventObserver{T}.cs
+++ b/src/WebDriverBiDi/EventObserver{T}.cs
@@ -315,8 +315,11 @@ public class EventObserver<T> : IDisposable, IAsyncDisposable, IComparable<Event
                 // subsequent handler invocations are not queued into it.
                 if (collected.Count == count)
                 {
+                    int readerCount = 0;
                     lock (this.captureLock)
                     {
+                        readerCount = this.waitingReaderCount;
+
                         // Only close if it is still the same channel we started with
                         // (StopCapturingTasks might have already closed it).
                         // Note: We are using ReferenceEquals here, though the equality
@@ -335,7 +338,7 @@ public class EventObserver<T> : IDisposable, IAsyncDisposable, IComparable<Event
                     // through the normal error pipeline instead of being silently swallowed.
                     // Only do this when we are the sole active reader: if another WaitForCapturedTasksAsync
                     // caller is queued behind the semaphore, those tasks are legitimately theirs to consume.
-                    if (this.waitingReaderCount == 1)
+                    if (readerCount == 1)
                     {
                         string eventName = this.observableEvent.EventName;
                         while (channel.Reader.TryRead(out Task? racedTask))

--- a/src/WebDriverBiDi/EventObserver{T}.cs
+++ b/src/WebDriverBiDi/EventObserver{T}.cs
@@ -311,8 +311,10 @@ public class EventObserver<T> : IDisposable, IAsyncDisposable, IComparable<Event
                     }
                 }
 
-                // If we collected the requested number of tasks, auto-close the channel so that
-                // subsequent handler invocations are not queued into it.
+                // If we collected the requested number of tasks and are the sole active reader,
+                // auto-close the channel so that subsequent handler invocations are not queued
+                // into it. When another waiter is active (readerCount > 1), leave the channel
+                // open so that waiter can continue receiving tasks.
                 if (collected.Count == count)
                 {
                     int readerCount = 0;
@@ -320,12 +322,9 @@ public class EventObserver<T> : IDisposable, IAsyncDisposable, IComparable<Event
                     {
                         readerCount = this.waitingReaderCount;
 
-                        // Only close if it is still the same channel we started with
-                        // (StopCapturingTasks might have already closed it).
-                        // Note: We are using ReferenceEquals here, though the equality
-                        // operator (`==`) would be semantically equivalent. ReferenceEquals
-                        // explicitly tells us we are checking for the same instance.
-                        if (ReferenceEquals(this.capturedTaskQueue, channel))
+                        // Only close if we are the sole active reader and the channel is still
+                        // the one we started with (StopCapturingTasks might have already closed it).
+                        if (readerCount == 1 && ReferenceEquals(this.capturedTaskQueue, channel))
                         {
                             this.CloseCaptureChannel();
                         }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver001AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver001AnalyzerTests.cs
@@ -13,14 +13,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver001 analyzer that detects module registration after StartAsync().
 /// </summary>
-[TestFixture]
 public class BiDiDriver001AnalyzerTests
 {
     /// <summary>
     /// Tests that RegisterModule() called after StartAsync() reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModule_AfterStartAsync_ReportsDiagnostic()
     {
         string test = """
@@ -88,14 +87,14 @@ public class BiDiDriver001AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterModule() called before StartAsync() does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModule_BeforeStartAsync_NoDiagnostic()
     {
         string test = """
@@ -151,14 +150,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-BiDiDriver types are not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverType_NoDiagnostic()
     {
         string test = """
@@ -192,14 +191,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods without body are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string test = """
@@ -241,14 +240,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple drivers in the same method are tracked independently.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_IndependentTracking()
     {
         string test = """
@@ -313,14 +312,14 @@ public class BiDiDriver001AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that variable declarations without initializers are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task VariableWithoutInitializer_NoDiagnostic()
     {
         string test = """
@@ -367,14 +366,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterModule on non-tracked drivers doesn't report diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModuleOnNonTrackedDriver_NoDiagnostic()
     {
         string test = """
@@ -428,14 +427,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterModule with no arguments still reports diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModule_AfterStartAsync_WithNoArguments_ReportsDiagnostic()
     {
         string test = """
@@ -489,14 +488,14 @@ public class BiDiDriver001AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that direct invocation (without await) of StartAsync is tracked when called directly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModule_AfterDirectStartAsyncCall_ReportsDiagnostic()
     {
         string test = """
@@ -562,14 +561,14 @@ public class BiDiDriver001AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that chained member access expressions are handled correctly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModule_AfterStartAsync_ChainedMemberAccess_ReportsDiagnostic()
     {
         string test = """
@@ -642,14 +641,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-invocation expressions in expression statements are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonInvocationExpressionStatement_NoDiagnostic()
     {
         string test = """
@@ -697,14 +696,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations without member access syntax are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InvocationWithoutMemberAccess_NoDiagnostic()
     {
         string test = """
@@ -751,26 +750,26 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that GetFixAllProvider returns the correct provider.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider provider = new BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider();
         FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.EqualTo(WellKnownFixAllProviders.BatchFixer));
+        Assert.Equal(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests the analyzer detects multiple RegisterModule calls after StartAsync.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleRegisterModule_AfterStartAsync_ReportsBothDiagnostics()
     {
         string test = """
@@ -835,14 +834,14 @@ public class BiDiDriver001AnalyzerTests
         };
         testState.ExpectedDiagnostics.AddRange(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that StartAsync invocation without member access doesn't cause issues in code fix.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_StartAsyncWithoutMemberAccess_HandledGracefully()
     {
         string testCode = """
@@ -899,38 +898,38 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI001()
     {
         BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider provider = new BiDiDriver001_ModuleRegistrationAfterStartCodeFixProvider();
 
-        Assert.That(provider.FixableDiagnosticIds, Does.Contain(BiDiDriver001_ModuleRegistrationAfterStartAnalyzer.DiagnosticId));
-        Assert.That(provider.FixableDiagnosticIds.Length, Is.EqualTo(1));
+        Assert.Contains(BiDiDriver001_ModuleRegistrationAfterStartAnalyzer.DiagnosticId, provider.FixableDiagnosticIds);
+        Assert.Single(provider.FixableDiagnosticIds);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property of the analyzer.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI001()
     {
         BiDiDriver001_ModuleRegistrationAfterStartAnalyzer analyzer = new BiDiDriver001_ModuleRegistrationAfterStartAnalyzer();
 
-        Assert.That(analyzer.SupportedDiagnostics.Length, Is.EqualTo(1));
-        Assert.That(analyzer.SupportedDiagnostics[0].Id, Is.EqualTo(BiDiDriver001_ModuleRegistrationAfterStartAnalyzer.DiagnosticId));
+        Assert.Single(analyzer.SupportedDiagnostics);
+        Assert.Equal(BiDiDriver001_ModuleRegistrationAfterStartAnalyzer.DiagnosticId, analyzer.SupportedDiagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests that unresolved method calls are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task UnresolvedMethodCall_NoDiagnostic()
     {
         string test = """
@@ -983,14 +982,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that complex expressions are handled gracefully in GetDriverVariableName.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ComplexExpression_NoDiagnostic()
     {
         string test = """
@@ -1045,14 +1044,14 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that StartAsync called through a variable reference (not member access) is handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StartAsyncThroughDelegate_NoDiagnostic()
     {
         string test = """
@@ -1107,7 +1106,6 @@ public class BiDiDriver001AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver001CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver001CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver001 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver001CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix moves RegisterModule() before StartAsync().
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterModule_AfterStartAsync_CodeFixMovesItBefore()
     {
         string testCode = """
@@ -123,6 +121,6 @@ public class BiDiDriver001CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver002AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver002AnalyzerTests.cs
@@ -13,14 +13,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver002 analyzer that detects event registration after StartAsync.
 /// </summary>
-[TestFixture]
 public class BiDiDriver002AnalyzerTests
 {
     /// <summary>
     /// Tests that RegisterEvent called after StartAsync reports an error diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterEvent_AfterStartAsync_ReportsError()
     {
         string test = """
@@ -72,14 +71,14 @@ public class BiDiDriver002AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterEvent called before StartAsync does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterEvent_BeforeStartAsync_NoDiagnostic()
     {
         string test = """
@@ -122,14 +121,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver called after StartAsync reports an error diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_AfterStartAsync_ReportsError()
     {
         string test = """
@@ -189,14 +188,14 @@ public class BiDiDriver002AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver called before StartAsync does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_BeforeStartAsync_NoDiagnostic()
     {
         string test = """
@@ -251,14 +250,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple AddObserver calls after StartAsync report errors.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleAddObserver_AfterStartAsync_ReportsMultipleErrors()
     {
         string test = """
@@ -336,14 +335,14 @@ public class BiDiDriver002AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods without body are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string test = """
@@ -381,14 +380,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-BiDiDriver types are not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverType_NoDiagnostic()
     {
         string test = """
@@ -422,14 +421,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on non-ObservableEvent types does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNonObservableEvent_NoDiagnostic()
     {
         string test = """
@@ -475,14 +474,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that assignment expressions with invocations are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AssignmentExpression_AfterStartAsync_ReportsError()
     {
         string test = """
@@ -543,14 +542,14 @@ public class BiDiDriver002AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on a non-module and non-driver ObservableEvent does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNonDriverNonModuleEvent_NoDiagnostic()
     {
         string test = """
@@ -600,14 +599,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations without member access are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task Invocation_WithoutMemberAccess_NoDiagnostic()
     {
         string test = """
@@ -648,14 +647,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that unresolved method symbols are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task UnresolvedMethodSymbol_NoDiagnostic()
     {
         string test = """
@@ -695,14 +694,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with null type symbol is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithNullTypeSymbol_NoDiagnostic()
     {
         string test = """
@@ -743,50 +742,50 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider returns the correct provider.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver002_EventRegistrationAfterStartCodeFixProvider provider = new BiDiDriver002_EventRegistrationAfterStartCodeFixProvider();
         FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.EqualTo(WellKnownFixAllProviders.BatchFixer));
+        Assert.Equal(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI002()
     {
         BiDiDriver002_EventRegistrationAfterStartCodeFixProvider provider = new BiDiDriver002_EventRegistrationAfterStartCodeFixProvider();
 
-        Assert.That(provider.FixableDiagnosticIds, Does.Contain(BiDiDriver002_EventRegistrationAfterStartAnalyzer.DiagnosticId));
-        Assert.That(provider.FixableDiagnosticIds.Length, Is.EqualTo(1));
+        Assert.Contains(BiDiDriver002_EventRegistrationAfterStartAnalyzer.DiagnosticId, provider.FixableDiagnosticIds);
+        Assert.Single(provider.FixableDiagnosticIds);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property of the analyzer.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI002()
     {
         BiDiDriver002_EventRegistrationAfterStartAnalyzer analyzer = new BiDiDriver002_EventRegistrationAfterStartAnalyzer();
 
-        Assert.That(analyzer.SupportedDiagnostics.Length, Is.EqualTo(1));
-        Assert.That(analyzer.SupportedDiagnostics[0].Id, Is.EqualTo(BiDiDriver002_EventRegistrationAfterStartAnalyzer.DiagnosticId));
+        Assert.Single(analyzer.SupportedDiagnostics);
+        Assert.Equal(BiDiDriver002_EventRegistrationAfterStartAnalyzer.DiagnosticId, analyzer.SupportedDiagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests that multiple drivers are tracked independently.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_IndependentTracking()
     {
         string test = """
@@ -841,14 +840,14 @@ public class BiDiDriver002AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that variable without initializer is handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task VariableWithoutInitializer_NoDiagnostic()
     {
         string test = """
@@ -891,14 +890,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterEvent on non-tracked driver doesn't report diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterEventOnNonTrackedDriver_NoDiagnostic()
     {
         string test = """
@@ -942,14 +941,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that complex expression statements are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ComplexExpressionStatement_NoDiagnostic()
     {
         string test = """
@@ -990,14 +989,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on unresolved expression type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnUnresolvedExpressionType_NoDiagnostic()
     {
         string test = """
@@ -1037,14 +1036,14 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on a property that doesn't exist is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNonExistentProperty_NoDiagnostic()
     {
         string test = """
@@ -1084,7 +1083,6 @@ public class BiDiDriver002AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver002CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver002CodeFixProviderTests.cs
@@ -13,14 +13,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver002 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver002CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix moves RegisterEvent before StartAsync.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterEvent_CodeFixMovesBeforeStartAsync()
     {
         string testCode = """
@@ -103,14 +102,14 @@ public class BiDiDriver002CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix moves AddObserver before StartAsync.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_CodeFixMovesBeforeStartAsync()
     {
         string testCode = """
@@ -217,6 +216,6 @@ public class BiDiDriver002CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver003AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver003AnalyzerTests.cs
@@ -13,14 +13,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver003 analyzer that detects RegisterTypeInfoResolver after StartAsync.
 /// </summary>
-[TestFixture]
 public class BiDiDriver003AnalyzerTests
 {
     /// <summary>
     /// Tests that RegisterTypeInfoResolver called after StartAsync reports an error diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterTypeInfoResolver_AfterStartAsync_ReportsError()
     {
         string test = """
@@ -75,14 +74,14 @@ public class BiDiDriver003AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterTypeInfoResolver called before StartAsync does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterTypeInfoResolver_BeforeStartAsync_NoDiagnostic()
     {
         string test = """
@@ -125,14 +124,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods without body are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string test = """
@@ -170,14 +169,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-BiDiDriver types are not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverType_NoDiagnostic()
     {
         string test = """
@@ -212,14 +211,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple RegisterTypeInfoResolver calls after StartAsync report errors.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleRegisterTypeInfoResolver_AfterStartAsync_ReportsMultipleErrors()
     {
         string test = """
@@ -271,14 +270,14 @@ public class BiDiDriver003AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that assignment expressions with invocations are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AssignmentExpression_AfterStartAsync_ReportsError()
     {
         string test = """
@@ -334,14 +333,14 @@ public class BiDiDriver003AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations without member access are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task Invocation_WithoutMemberAccess_NoDiagnostic()
     {
         string test = """
@@ -385,14 +384,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that unresolved method symbols are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task UnresolvedMethodSymbol_NoDiagnostic()
     {
         string test = """
@@ -435,14 +434,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that variables without initializers are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task VariableWithoutInitializer_NoDiagnostic()
     {
         string test = """
@@ -485,14 +484,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that RegisterTypeInfoResolver on non-tracked drivers doesn't report diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterTypeInfoResolverOnNonTrackedDriver_NoDiagnostic()
     {
         string test = """
@@ -536,14 +535,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple drivers are tracked independently.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_IndependentTracking()
     {
         string test = """
@@ -597,14 +596,14 @@ public class BiDiDriver003AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that complex expression statements are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ComplexExpressionStatement_NoDiagnostic()
     {
         string test = """
@@ -648,14 +647,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that complex member access expressions are handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ComplexMemberAccessExpression_NoDiagnostic()
     {
         string test = """
@@ -698,14 +697,14 @@ public class BiDiDriver003AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that chained member access expressions are tracked correctly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ChainedMemberAccess_AfterStartAsync_ReportsError()
     {
         string test = """
@@ -762,46 +761,46 @@ public class BiDiDriver003AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider returns the correct provider.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider provider = new BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider();
         FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.EqualTo(WellKnownFixAllProviders.BatchFixer));
+        Assert.Equal(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI003()
     {
         BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider provider = new BiDiDriver003_TypeInfoResolverRegistrationAfterStartCodeFixProvider();
 
-        Assert.That(provider.FixableDiagnosticIds, Does.Contain(BiDiDriver003_TypeInfoResolverRegistrationAfterStartAnalyzer.DiagnosticId));
-        Assert.That(provider.FixableDiagnosticIds.Length, Is.EqualTo(1));
+        Assert.Contains(BiDiDriver003_TypeInfoResolverRegistrationAfterStartAnalyzer.DiagnosticId, provider.FixableDiagnosticIds);
+        Assert.Single(provider.FixableDiagnosticIds);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property of the analyzer.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI003()
     {
         BiDiDriver003_TypeInfoResolverRegistrationAfterStartAnalyzer analyzer = new BiDiDriver003_TypeInfoResolverRegistrationAfterStartAnalyzer();
 
-        Assert.That(analyzer.SupportedDiagnostics.Length, Is.EqualTo(1));
-        Assert.That(analyzer.SupportedDiagnostics[0].Id, Is.EqualTo(BiDiDriver003_TypeInfoResolverRegistrationAfterStartAnalyzer.DiagnosticId));
+        Assert.Single(analyzer.SupportedDiagnostics);
+        Assert.Equal(BiDiDriver003_TypeInfoResolverRegistrationAfterStartAnalyzer.DiagnosticId, analyzer.SupportedDiagnostics[0].Id);
     }
 
-    [Test]
+    [Fact]
     public async Task RegisterTypeInfoResolver_OnCustomTypeImplementingInterface_AfterStartAsync_ReportsError()
     {
         // The driver variable is of type MyCustomDriver, whose name is NOT "BiDiDriver" or
@@ -861,6 +860,6 @@ public class BiDiDriver003AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver003CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver003CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver003 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver003CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix moves RegisterTypeInfoResolver before StartAsync.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RegisterTypeInfoResolver_CodeFixMovesBeforeStartAsync()
     {
         string testCode = """
@@ -102,6 +100,6 @@ public class BiDiDriver003CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver004AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver004AnalyzerTests.cs
@@ -13,14 +13,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver004 analyzer that suggests using CancellationToken.
 /// </summary>
-[TestFixture]
 public class BiDiDriver004AnalyzerTests
 {
     /// <summary>
     /// Tests that methods without CancellationToken report an info diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NavigateAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -79,14 +78,14 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods with CancellationToken do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NavigateAsync_WithCancellationToken_NoDiagnostic()
     {
         string test = """
@@ -140,14 +139,14 @@ public class BiDiDriver004AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-BiDiDriver/Module methods are not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverMethod_NoDiagnostic()
     {
         string test = """
@@ -179,14 +178,14 @@ public class BiDiDriver004AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods not in the suggestion list do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonSuggestedMethod_WithoutCancellationToken_NoDiagnostic()
     {
         string test = """
@@ -231,14 +230,14 @@ public class BiDiDriver004AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that StartAsync without CancellationToken reports info.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StartAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -280,14 +279,14 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that EvaluateAsync without CancellationToken reports info.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EvaluateAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -337,14 +336,14 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods without overload that takes CancellationToken do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodWithoutTokenOverload_NoDiagnostic()
     {
         string test = """
@@ -396,14 +395,14 @@ public class BiDiDriver004AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that unresolved method symbols are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task UnresolvedMethodSymbol_NoDiagnostic()
     {
         string test = """
@@ -445,14 +444,14 @@ public class BiDiDriver004AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that null containing type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NullContainingType_NoDiagnostic()
     {
         string test = """
@@ -478,50 +477,50 @@ public class BiDiDriver004AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider returns the correct provider.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver004_CancellationTokenSuggestionCodeFixProvider provider = new BiDiDriver004_CancellationTokenSuggestionCodeFixProvider();
         FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.EqualTo(WellKnownFixAllProviders.BatchFixer));
+        Assert.Equal(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI004()
     {
         BiDiDriver004_CancellationTokenSuggestionCodeFixProvider provider = new BiDiDriver004_CancellationTokenSuggestionCodeFixProvider();
 
-        Assert.That(provider.FixableDiagnosticIds, Does.Contain(BiDiDriver004_CancellationTokenSuggestionAnalyzer.DiagnosticId));
-        Assert.That(provider.FixableDiagnosticIds.Length, Is.EqualTo(1));
+        Assert.Contains(BiDiDriver004_CancellationTokenSuggestionAnalyzer.DiagnosticId, provider.FixableDiagnosticIds);
+        Assert.Single(provider.FixableDiagnosticIds);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property of the analyzer.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI004()
     {
         BiDiDriver004_CancellationTokenSuggestionAnalyzer analyzer = new BiDiDriver004_CancellationTokenSuggestionAnalyzer();
 
-        Assert.That(analyzer.SupportedDiagnostics.Length, Is.EqualTo(1));
-        Assert.That(analyzer.SupportedDiagnostics[0].Id, Is.EqualTo(BiDiDriver004_CancellationTokenSuggestionAnalyzer.DiagnosticId));
+        Assert.Single(analyzer.SupportedDiagnostics);
+        Assert.Equal(BiDiDriver004_CancellationTokenSuggestionAnalyzer.DiagnosticId, analyzer.SupportedDiagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests that CallFunctionAsync without CancellationToken reports info.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CallFunctionAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -571,14 +570,14 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that ExecuteCommandAsync without CancellationToken reports info.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ExecuteCommandAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -620,14 +619,14 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that GetTreeAsync without CancellationToken reports info.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task GetTreeAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -677,14 +676,14 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that LocateNodesAsync without CancellationToken reports info.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LocateNodesAsync_WithoutCancellationToken_ReportsInfo()
     {
         string test = """
@@ -734,6 +733,6 @@ public class BiDiDriver004AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver004CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver004CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver004 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver004CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix adds CancellationToken.None.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NavigateAsync_CodeFixAddsCancellationTokenNone()
     {
         string testCode = """
@@ -125,14 +123,14 @@ public class BiDiDriver004CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix adds cancellationToken parameter.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NavigateAsync_CodeFixAddsCancellationTokenParameter()
     {
         string testCode = """
@@ -238,6 +236,6 @@ public class BiDiDriver004CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver005AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver005AnalyzerTests.cs
@@ -16,14 +16,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver005 analyzer that detects missing Session.SubscribeAsync calls.
 /// </summary>
-[TestFixture]
 public class BiDiDriver005AnalyzerTests
 {
     /// <summary>
     /// Tests that AddObserver without SubscribeAsync reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithoutSubscribeAsync_ReportsWarning()
     {
         string test = """
@@ -95,14 +94,14 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with SubscribeAsync does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithSubscribeAsync_NoDiagnostic()
     {
         string test = """
@@ -183,14 +182,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on driver internal events does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnDriverInternalEvent_NoDiagnostic()
     {
         string test = """
@@ -247,14 +246,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple AddObserver calls without SubscribeAsync report warnings.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleAddObserver_WithoutSubscribeAsync_ReportsMultipleWarnings()
     {
         string test = """
@@ -340,14 +339,14 @@ public class BiDiDriver005AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods without body are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string test = """
@@ -410,14 +409,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on non-module property does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNonModuleProperty_NoDiagnostic()
     {
         string test = """
@@ -471,14 +470,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on non-ObservableEvent does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNonObservableEvent_NoDiagnostic()
     {
         string test = """
@@ -527,14 +526,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on non-BiDiDriver variable does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNonDriverVariable_NoDiagnostic()
     {
         string test = """
@@ -593,14 +592,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with wrong event name in SubscribeAsync reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithWrongEventNameInSubscribe_ReportsWarning()
     {
         string test = """
@@ -687,14 +686,14 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple events with partial subscription reports warnings for unsubscribed events.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleAddObserver_WithPartialSubscribe_ReportsWarningForUnsubscribed()
     {
         string test = """
@@ -794,14 +793,14 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with array creation syntax in SubscribeAsync works correctly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithArrayCreationSyntax_NoDiagnostic()
     {
         string test = """
@@ -883,14 +882,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with C# 12 collection expression syntax in SubscribeAsync does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithCollectionExpressionSyntax_NoDiagnostic()
     {
         string test = """
@@ -972,14 +971,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with C# 12 collection expression syntax and a wrong event name reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithCollectionExpressionSyntax_WrongEvent_ReportsWarning()
     {
         string test = """
@@ -1066,7 +1065,7 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -1074,7 +1073,7 @@ public class BiDiDriver005AnalyzerTests
     /// (i.e., referenced as a compiled assembly rather than defined in source).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithoutSubscribeAsync_MetadataBacked_ReportsWarning()
     {
         string test = """
@@ -1105,14 +1104,14 @@ public class BiDiDriver005AnalyzerTests
         testState.TestState.AdditionalReferences.Add(await CreateFakeLibMetadataReference());
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that BIDI005 does not fire when SubscribeAsync uses .EventName property access instead of a string literal.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithSubscribeAsync_EventNamePropertyAccess_NoDiagnostic()
     {
         string test = """
@@ -1193,14 +1192,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that BIDI005 does not fire when SubscribeAsync uses .EventName property access, with metadata-backed types.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithSubscribeAsync_EventNamePropertyAccess_MetadataBacked_NoDiagnostic()
     {
         string test = """
@@ -1227,14 +1226,14 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.TestState.AdditionalReferences.Add(await CreateFakeLibMetadataReference());
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that BIDI005 does not fire when SubscribeAsync is present, with metadata-backed types.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithSubscribeAsync_MetadataBacked_NoDiagnostic()
     {
         string test = """
@@ -1261,27 +1260,27 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.TestState.AdditionalReferences.Add(await CreateFakeLibMetadataReference());
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI005()
     {
         BiDiDriver005_MissingEventSubscriptionAnalyzer analyzer = new();
         System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor> diagnostics = analyzer.SupportedDiagnostics;
 
-        Assert.That(diagnostics, Has.Length.EqualTo(1));
-        Assert.That(diagnostics[0].Id, Is.EqualTo(BiDiDriver005_MissingEventSubscriptionAnalyzer.DiagnosticId));
+        Assert.Single(diagnostics);
+        Assert.Equal(BiDiDriver005_MissingEventSubscriptionAnalyzer.DiagnosticId, diagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests that AddObserver called via non-member-access invocation is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_ViaDelegate_NoDiagnostic()
     {
         string test = """
@@ -1328,14 +1327,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that unresolved AddObserver method is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_UnresolvedMethod_NoDiagnostic()
     {
         string test = """
@@ -1396,14 +1395,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on expression with null type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnNullTypeExpression_NoDiagnostic()
     {
         string test = """
@@ -1452,14 +1451,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on ObservableEvent without ObservableEventNameAttribute is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithoutObservableEventNameAttribute_NoDiagnostic()
     {
         string test = """
@@ -1518,14 +1517,14 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SubscribeAsync called via non-member-access invocation is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_ViaDelegate_NoDiagnostic()
     {
         string test = """
@@ -1613,14 +1612,14 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that unresolved SubscribeAsync method is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_UnresolvedMethod_StillReportsWarning()
     {
         string test = """
@@ -1698,14 +1697,14 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver on a field (not property) is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_OnField_NoDiagnostic()
     {
         string test = """
@@ -1772,7 +1771,7 @@ public class BiDiDriver005AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -1780,7 +1779,7 @@ public class BiDiDriver005AnalyzerTests
     /// The analyzer reports a warning because it cannot resolve the event name from a local variable's EventName property.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_WithLocalVariableEventName_ReportsWarning()
     {
         string test = """
@@ -1868,7 +1867,7 @@ public class BiDiDriver005AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver005CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver005CodeFixProviderTests.cs
@@ -13,14 +13,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver005 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver005CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix adds the missing event name to SubscribeAsync.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_AddsEventNameToSubscribeAsync()
     {
         string testCode = """
@@ -179,14 +178,14 @@ public class BiDiDriver005CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix adds the first event name to an empty SubscribeAsync array.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_AddsEventNameToEmptySubscribeAsync()
     {
         string testCode = """
@@ -345,10 +344,10 @@ public class BiDiDriver005CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task NoSubscribeAsync_DiagnosticFires()
     {
         // There is an AddObserver call but no Session.SubscribeAsync in the method.
@@ -435,7 +434,7 @@ public class BiDiDriver005CodeFixProviderTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver005_MissingEventSubscriptionAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task CollectionExpression_CodeFixAddsEventName()
     {
         // Exercises the CollectionExpressionSyntax branch in the fix provider.
@@ -597,10 +596,10 @@ public class BiDiDriver005CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_WithNoArguments_CodeFixMakesNoChange()
     {
         // SubscribeAsync() called with no arguments — AddEventNameToSubscribeCall returns
@@ -682,7 +681,7 @@ public class BiDiDriver005CodeFixProviderTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver005_MissingEventSubscriptionAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_WithNonArrayArgument_DiagnosticFires()
     {
         // SubscribeAsync called with a variable reference rather than an array literal.

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver006AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver006AnalyzerTests.cs
@@ -12,14 +12,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver006 analyzer that detects undisposed EventObservers.
 /// </summary>
-[TestFixture]
 public class BiDiDriver006AnalyzerTests
 {
     /// <summary>
     /// Tests that EventObserver without disposal reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithoutDisposal_ReportsWarning()
     {
         string test = """
@@ -80,14 +79,14 @@ public class BiDiDriver006AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that EventObserver with using statement does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithUsingStatement_NoDiagnostic()
     {
         string test = """
@@ -143,14 +142,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that EventObserver with explicit Unobserve call does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithUnobserveCall_NoDiagnostic()
     {
         string test = """
@@ -207,14 +206,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that EventObserver with Dispose call does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithDisposeCall_NoDiagnostic()
     {
         string test = """
@@ -271,14 +270,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that EventObserver with DisposeAsync call does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithDisposeAsyncCall_NoDiagnostic()
     {
         string test = """
@@ -336,14 +335,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that EventObserver with traditional using statement does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithTraditionalUsingStatement_NoDiagnostic()
     {
         string test = """
@@ -401,14 +400,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods without body or expression body are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodWithoutBodyOrExpressionBody_NoDiagnostic()
     {
         string test = """
@@ -459,14 +458,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-AddObserver invocations are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonAddObserverInvocation_NoDiagnostic()
     {
         string test = """
@@ -521,27 +520,27 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI006()
     {
         BiDiDriver006_ObserverDisposalAnalyzer analyzer = new();
         System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> diagnostics = analyzer.SupportedDiagnostics;
 
-        Assert.That(diagnostics, Has.Length.EqualTo(1));
-        Assert.That(diagnostics[0].Id, Is.EqualTo(BiDiDriver006_ObserverDisposalAnalyzer.DiagnosticId));
+        Assert.Single(diagnostics);
+        Assert.Equal(BiDiDriver006_ObserverDisposalAnalyzer.DiagnosticId, diagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests that AddObserver call without member access expression is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_ViaDelegate_NoDiagnostic()
     {
         string test = """
@@ -596,14 +595,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with unresolved method symbol is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_UnresolvedMethod_NoDiagnostic()
     {
         string test = """
@@ -657,14 +656,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver returning non-generic type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_ReturningNonGenericType_NoDiagnostic()
     {
         string test = """
@@ -718,14 +717,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that disposal call on complex member access is recognized.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_DisposedViaComplexMemberAccess_NoDiagnostic()
     {
         string test = """
@@ -788,14 +787,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple undisposed observers report multiple warnings.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleUndisposedObservers_ReportsMultipleWarnings()
     {
         string test = """
@@ -867,40 +866,40 @@ public class BiDiDriver006AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider property.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver006_ObserverDisposalCodeFixProvider provider = new();
         Microsoft.CodeAnalysis.CodeFixes.FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.Not.Null);
-        Assert.That(fixAllProvider, Is.EqualTo(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer));
+        Assert.NotNull(fixAllProvider);
+        Assert.Equal(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI006()
     {
         BiDiDriver006_ObserverDisposalCodeFixProvider provider = new();
         System.Collections.Immutable.ImmutableArray<string> ids = provider.FixableDiagnosticIds;
 
-        Assert.That(ids, Has.Length.EqualTo(1));
-        Assert.That(ids[0], Is.EqualTo(BiDiDriver006_ObserverDisposalAnalyzer.DiagnosticId));
+        Assert.Single(ids);
+        Assert.Equal(BiDiDriver006_ObserverDisposalAnalyzer.DiagnosticId, ids[0]);
     }
 
     /// <summary>
     /// Tests that invocation without member access in disposal detection is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_DisposalViaDelegate_StillReportsWarning()
     {
         string test = """
@@ -962,14 +961,14 @@ public class BiDiDriver006AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that await DisposeAsync with variable intermediate step IS detected (not a limitation).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithIntermediateAwaitDisposeAsync_NoDiagnostic()
     {
         string test = """
@@ -1028,14 +1027,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that traditional using statement with explicit variable declaration is recognized.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_WithTraditionalUsingExplicitVariable_NoDiagnostic()
     {
         string test = """
@@ -1094,14 +1093,14 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver returning wrong generic type name is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_ReturningWrongGenericTypeName_NoDiagnostic()
     {
         string test = """
@@ -1155,10 +1154,10 @@ public class BiDiDriver006AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task EventObserver_WithNonDisposalMethodCall_ReportsWarning()
     {
         // Exercises the path in HasDisposalCall where expressionName == variableName
@@ -1226,7 +1225,7 @@ public class BiDiDriver006AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }
 

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver006CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver006CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver006 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver006CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix adds using declaration.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventObserver_CodeFixAddsUsingDeclaration()
     {
         string testCode = """
@@ -127,10 +125,10 @@ public class BiDiDriver006CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task ObserverDeclaredAsField_NoDiagnostic()
     {
         // BIDI006 only watches local variable declarations; field-level declarations

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver007AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver007AnalyzerTests.cs
@@ -12,14 +12,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver007 analyzer that detects blocking operations in event handlers.
 /// </summary>
-[TestFixture]
 public class BiDiDriver007AnalyzerTests
 {
     /// <summary>
     /// Tests that blocking operations in event handlers report a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithThreadSleep_ReportsWarning()
     {
         string test = """
@@ -91,14 +90,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Task.Wait in event handlers reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithTaskWait_ReportsWarning()
     {
         string test = """
@@ -170,14 +169,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that .Result property access in event handlers reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithTaskResult_ReportsWarning()
     {
         string test = """
@@ -249,14 +248,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that handlers with RunHandlerAsynchronously option do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithRunHandlerAsynchronouslyOption_NoDiagnostic()
     {
         string test = """
@@ -323,14 +322,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that GetAwaiter().GetResult() pattern reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithGetAwaiterGetResult_ReportsWarning()
     {
         string test = """
@@ -402,14 +401,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-AddObserver invocations are not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonAddObserverInvocation_NoDiagnostic()
     {
         string test = """
@@ -469,14 +468,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that method returning non-EventObserver is not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodReturningNonEventObserver_NoDiagnostic()
     {
         string test = """
@@ -531,14 +530,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that parenthesized lambda expressions are analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParenthesizedLambda_WithBlockingOperation_ReportsWarning()
     {
         string test = """
@@ -610,14 +609,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple blocking operations report multiple warnings.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithMultipleBlockingOperations_ReportsMultipleWarnings()
     {
         string test = """
@@ -697,14 +696,14 @@ public class BiDiDriver007AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that named methods with blocking operations report a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NamedMethod_WithThreadSleep_ReportsWarning()
     {
         string test = """
@@ -779,14 +778,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that named methods with Task.Wait report a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NamedMethod_WithTaskWait_ReportsWarning()
     {
         string test = """
@@ -860,14 +859,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that named methods with Task.Result report a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NamedMethod_WithTaskResult_ReportsWarning()
     {
         string test = """
@@ -941,14 +940,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that named methods with no blocking operations do not report a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NamedMethod_WithNoBlockingOperations_NoDiagnostic()
     {
         string test = """
@@ -1020,14 +1019,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that member access method references with blocking operations report a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MemberAccessMethodReference_WithBlockingOperation_ReportsWarning()
     {
         string test = """
@@ -1102,53 +1101,53 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests SupportedDiagnostics property.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI007()
     {
         BiDiDriver007_BlockingOperationsInEventHandlersAnalyzer analyzer = new();
         System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> diagnostics = analyzer.SupportedDiagnostics;
 
-        Assert.That(diagnostics, Has.Length.EqualTo(1));
-        Assert.That(diagnostics[0].Id, Is.EqualTo(BiDiDriver007_BlockingOperationsInEventHandlersAnalyzer.DiagnosticId));
+        Assert.Single(diagnostics);
+        Assert.Equal(BiDiDriver007_BlockingOperationsInEventHandlersAnalyzer.DiagnosticId, diagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider property.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver007_BlockingOperationsInEventHandlersCodeFixProvider provider = new();
         Microsoft.CodeAnalysis.CodeFixes.FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.Not.Null);
-        Assert.That(fixAllProvider, Is.EqualTo(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer));
+        Assert.NotNull(fixAllProvider);
+        Assert.Equal(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI007()
     {
         BiDiDriver007_BlockingOperationsInEventHandlersCodeFixProvider provider = new();
         System.Collections.Immutable.ImmutableArray<string> ids = provider.FixableDiagnosticIds;
 
-        Assert.That(ids, Has.Length.EqualTo(1));
-        Assert.That(ids[0], Is.EqualTo(BiDiDriver007_BlockingOperationsInEventHandlersAnalyzer.DiagnosticId));
+        Assert.Single(ids);
+        Assert.Equal(BiDiDriver007_BlockingOperationsInEventHandlersAnalyzer.DiagnosticId, ids[0]);
     }
 
     /// <summary>
     /// Tests that AddObserver invoked via delegate is not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_ViaDelegate_NoDiagnostic()
     {
         string test = """
@@ -1209,14 +1208,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with unresolved method symbol is not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_UnresolvedMethod_NoDiagnostic()
     {
         string test = """
@@ -1276,14 +1275,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with no arguments is not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_NoArguments_NoDiagnostic()
     {
         string test = """
@@ -1339,14 +1338,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that handler with expression body method is analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ExpressionBodyMethod_WithBlockingOperation_ReportsWarning()
     {
         string test = """
@@ -1421,14 +1420,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that local function with blocking operation reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LocalFunction_WithBlockingOperation_ReportsWarning()
     {
         string test = """
@@ -1503,14 +1502,14 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations with unresolved method symbols in handler body are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task HandlerBody_WithUnresolvedMethodInvocation_NoDiagnostic()
     {
         string test = """
@@ -1576,14 +1575,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that simple lambda expression without block body is handled.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SimpleLambdaExpression_WithoutBlockBody_NoDiagnostic()
     {
         string test = """
@@ -1645,14 +1644,14 @@ public class BiDiDriver007AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that expression with Task.Result in simple expression body is detected.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SimpleLambda_WithExpressionBodyTaskResult_ReportsWarning()
     {
         string test = """
@@ -1720,8 +1719,7 @@ public class BiDiDriver007AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }
-
 

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver007CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver007CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver007 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver007CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix adds RunHandlerAsynchronously option.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithThreadSleep_CodeFixAddsRunHandlerAsynchronously()
     {
         string testCode = """
@@ -151,14 +149,14 @@ public class BiDiDriver007CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix replaces existing options parameter.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithExistingOptions_CodeFixReplacesWithRunHandlerAsynchronously()
     {
         string testCode = """
@@ -289,14 +287,14 @@ public class BiDiDriver007CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix works with Task.Wait.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithTaskWait_CodeFixAddsRunHandlerAsynchronously()
     {
         string testCode = """
@@ -427,6 +425,6 @@ public class BiDiDriver007CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver008AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver008AnalyzerTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver008 analyzer that detects unsafe EvaluateResult casts.
 /// </summary>
-[TestFixture]
 public class BiDiDriver008AnalyzerTests
 {
     /// <summary>
     /// Tests that direct cast to EvaluateResultSuccess reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EvaluateResult_DirectCast_ReportsWarning()
     {
         string test = """
@@ -77,14 +75,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that 'as' cast to EvaluateResultSuccess reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EvaluateResult_AsCast_ReportsWarning()
     {
         string test = """
@@ -144,14 +142,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that pattern matching with 'is' does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EvaluateResult_PatternMatching_NoDiagnostic()
     {
         string test = """
@@ -205,14 +203,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that direct cast to EvaluateResultException reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EvaluateResult_CastToException_ReportsWarning()
     {
         string test = """
@@ -269,14 +267,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that cast inside try-catch does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EvaluateResult_CastInTryCatch_NoDiagnostic()
     {
         string test = """
@@ -335,14 +333,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that casts to non-EvaluateResult derived types do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task Cast_ToNonEvaluateResultDerivedType_NoDiagnostic()
     {
         string test = """
@@ -394,14 +392,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that casts from non-EvaluateResult types do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task Cast_FromNonEvaluateResultType_NoDiagnostic()
     {
         string test = """
@@ -453,14 +451,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that cast inside local function statements are detected.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task Cast_InsideLocalFunction_NoDiagnostic()
     {
         string test = """
@@ -525,14 +523,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that 'as' cast with null check is still flagged as warning to encourage pattern matching.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AsCast_WithNullCheck_StillReportsWarning()
     {
         string test = """
@@ -596,14 +594,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-invocation member access is not analyzed for casts.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonCast_NoDiagnostic()
     {
         string test = """
@@ -652,14 +650,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that direct cast with variable declaration triggers the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task DirectCast_WithVariableDeclaration_ReportsWarning()
     {
         string testCode = """
@@ -719,14 +717,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that 'as' cast with variable declaration triggers the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AsCast_WithVariableDeclaration_ReportsWarning()
     {
         string testCode = """
@@ -789,14 +787,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that cast to EvaluateResultException triggers the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task DirectCast_ToException_ReportsWarning()
     {
         string testCode = """
@@ -856,14 +854,14 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that cast with multiple dependent statements triggers the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task DirectCast_WithMultipleDependentStatements_ReportsWarning()
     {
         string testCode = """
@@ -927,28 +925,27 @@ public class BiDiDriver008AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 
     /// <summary>
     /// Tests SupportedDiagnostics property.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI008()
     {
         BiDiDriver008_UnsafeEvaluateResultCastAnalyzer analyzer = new();
         System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> diagnostics = analyzer.SupportedDiagnostics;
 
-        Assert.That(diagnostics, Has.Length.EqualTo(1));
-        Assert.That(diagnostics[0].Id, Is.EqualTo(BiDiDriver008_UnsafeEvaluateResultCastAnalyzer.DiagnosticId));
+        Assert.Single(diagnostics);
+        Assert.Equal(BiDiDriver008_UnsafeEvaluateResultCastAnalyzer.DiagnosticId, diagnostics[0].Id);
     }
 
     /// <summary>
     /// Tests that cast with unresolved target type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task DirectCast_UnresolvedTargetType_NoDiagnostic()
     {
         string test = """
@@ -985,14 +982,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that cast from unresolved expression type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task DirectCast_UnresolvedExpressionType_NoDiagnostic()
     {
         string test = """
@@ -1024,14 +1021,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that 'as' cast with unresolved target type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AsCast_UnresolvedTargetType_NoDiagnostic()
     {
         string test = """
@@ -1068,14 +1065,14 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that 'as' cast from unresolved expression type is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AsCast_UnresolvedExpressionType_NoDiagnostic()
     {
         string test = """
@@ -1107,33 +1104,32 @@ public class BiDiDriver008AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider property.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver008_UnsafeEvaluateResultCastCodeFixProvider provider = new();
         Microsoft.CodeAnalysis.CodeFixes.FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.Not.Null);
-        Assert.That(fixAllProvider, Is.EqualTo(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer));
+        Assert.NotNull(fixAllProvider);
+        Assert.Equal(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds property.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI008()
     {
         BiDiDriver008_UnsafeEvaluateResultCastCodeFixProvider provider = new();
         System.Collections.Immutable.ImmutableArray<string> ids = provider.FixableDiagnosticIds;
 
-        Assert.That(ids, Has.Length.EqualTo(1));
-        Assert.That(ids[0], Is.EqualTo(BiDiDriver008_UnsafeEvaluateResultCastAnalyzer.DiagnosticId));
+        Assert.Single(ids);
+        Assert.Equal(BiDiDriver008_UnsafeEvaluateResultCastAnalyzer.DiagnosticId, ids[0]);
     }
-
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver008CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver008CodeFixProviderTests.cs
@@ -6,14 +6,12 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver008 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver008CodeFixProviderTests
 {
     /// <summary>
@@ -21,7 +19,7 @@ public class BiDiDriver008CodeFixProviderTests
     /// Note: Full output validation disabled due to formatter line ending issues.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFixProvider_RegisteredForDirectCast()
     {
         string testCode = """
@@ -64,7 +62,7 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -72,7 +70,7 @@ public class BiDiDriver008CodeFixProviderTests
     /// Note: Full output validation disabled due to formatter line ending issues.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFixProvider_RegisteredForAsCast()
     {
         string testCode = """
@@ -118,14 +116,14 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests code fix for direct cast with variable declaration.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_DirectCast_AppliesPatternMatching()
     {
         string testCode = """
@@ -209,14 +207,14 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests code fix for 'as' cast with variable declaration.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_AsCast_AppliesPatternMatching()
     {
         string testCode = """
@@ -314,10 +312,10 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task CodeFix_DirectCast_WithTrailingStatement_PreservesTrailingStatements()
     {
         // Exercises the i > declarationIndex + dependentStatements.Count branch in
@@ -405,10 +403,10 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task CodeFix_AsCast_WithTrailingStatement_PreservesTrailingStatements()
     {
         // Exercises the i > declarationIndex + dependentStatements.Count branch in
@@ -510,10 +508,10 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task CodeFix_InlineCast_WrapsInIfStatement()
     {
         // Exercises the inline-cast path in ConvertCastToPatternMatchingAsync:
@@ -598,6 +596,6 @@ public class BiDiDriver008CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver009AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver009AnalyzerTests.cs
@@ -7,7 +7,6 @@ namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
@@ -15,7 +14,7 @@ using Microsoft.CodeAnalysis.Testing;
 /// </summary>
 public class BiDiDriver009AnalyzerTests
 {
-    [Test]
+    [Fact]
     public async Task ExecuteCommandAsync_BeforeStartAsync_ReportsError()
     {
         string testCode = """
@@ -45,7 +44,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ExecuteCommandAsync_AfterStartAsync_NoDiagnostic()
     {
         string testCode = """
@@ -70,7 +69,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommand_BeforeStartAsync_ReportsError()
     {
         string testCode = """
@@ -100,7 +99,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommand_AfterStartAsync_NoDiagnostic()
     {
         string testCode = """
@@ -125,7 +124,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_CommandBeforeStartOnOne_ReportsError()
     {
         string testCode = """
@@ -158,7 +157,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_BothStarted_NoDiagnostic()
     {
         string testCode = """
@@ -186,7 +185,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleCommands_BeforeStartAsync_ReportsMultipleErrors()
     {
         string testCode = """
@@ -224,7 +223,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode, expected1, expected2);
     }
 
-    [Test]
+    [Fact]
     public async Task NonCommandMethod_BeforeStartAsync_NoDiagnostic()
     {
         string testCode = """
@@ -248,7 +247,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverCommand_NoDiagnostic()
     {
         string testCode = """
@@ -278,7 +277,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task DriverWithoutInitializer_NoDiagnostic()
     {
         string testCode = """
@@ -301,7 +300,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task CommandInConditional_AfterStart_NoDiagnostic()
     {
         string testCode = """
@@ -330,7 +329,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task CommandInLoop_AfterStart_NoDiagnostic()
     {
         string testCode = """
@@ -359,7 +358,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task StartAsync_IsNotFlaggedAsCommand_NoDiagnostic()
     {
         string testCode = """
@@ -382,7 +381,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task StopAsync_BeforeStartAsync_NoDiagnostic()
     {
         string testCode = """
@@ -405,7 +404,7 @@ public class BiDiDriver009AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string testCode = """
@@ -423,5 +422,4 @@ public class BiDiDriver009AnalyzerTests
 
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver009_CommandExecutionBeforeStartAnalyzer>(testCode);
     }
-
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver009CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver009CodeFixProviderTests.cs
@@ -13,10 +13,9 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver009 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver009CodeFixProviderTests
 {
-    [Test]
+    [Fact]
     public async Task ExecuteCommandAsync_CodeFixMovesAfterStartAsync()
     {
         string testCode = """
@@ -72,10 +71,10 @@ public class BiDiDriver009CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommand_CodeFixMovesAfterStartAsync()
     {
         string testCode = """
@@ -131,10 +130,10 @@ public class BiDiDriver009CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task CommandBeforeStart_WithStatementAfterStart_CodeFixInsertsCorrectly()
     {
         string testCode = """
@@ -194,6 +193,6 @@ public class BiDiDriver009CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver010AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver010AnalyzerTests.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Testing;
 /// </summary>
 public class BiDiDriver010AnalyzerTests
 {
-    [Test]
+    [Fact]
     public async Task FireAndForgetModuleCommand_ReportsError()
     {
         string testCode = """
@@ -44,7 +44,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task AwaitedModuleCommand_NoDiagnostic()
     {
         string testCode = """
@@ -68,7 +68,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandAssignedToVariable_NoDiagnostic()
     {
         string testCode = """
@@ -93,7 +93,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandPassedAsArgument_NoDiagnostic()
     {
         string testCode = """
@@ -122,7 +122,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandReturned_NoDiagnostic()
     {
         string testCode = """
@@ -146,7 +146,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleFireAndForgetCommands_ReportsMultipleErrors()
     {
         string testCode = """
@@ -184,7 +184,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected1, expected2);
     }
 
-    [Test]
+    [Fact]
     public async Task FireAndForgetInExpressionStatement_ReportsError()
     {
         string testCode = """
@@ -214,7 +214,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task NonModuleMethod_NoDiagnostic()
     {
         string testCode = """
@@ -244,7 +244,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task NonGenericTaskReturningMethod_NoDiagnostic()
     {
         string testCode = """
@@ -268,7 +268,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandInConditional_FireAndForget_ReportsError()
     {
         string testCode = """
@@ -301,7 +301,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandInLoop_FireAndForget_ReportsError()
     {
         string testCode = """
@@ -334,7 +334,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandWithConfigureAwait_NoDiagnostic()
     {
         string testCode = """
@@ -358,7 +358,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandWithConfigureAwaitNotAwaited_ReportsError()
     {
         string testCode = """
@@ -388,7 +388,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandWithConversionAssigned_NoDiagnostic()
     {
         string testCode = """
@@ -413,7 +413,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandWithConversionPassedAsArgument_NoDiagnostic()
     {
         string testCode = """
@@ -442,7 +442,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandWithConversionAwaited_NoDiagnostic()
     {
         string testCode = """
@@ -467,7 +467,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandWithConversionReturned_NoDiagnostic()
     {
         string testCode = """
@@ -492,7 +492,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandContinueWithAwaited_NoDiagnostic()
     {
         string testCode = """
@@ -516,7 +516,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandContinueWithNotAwaited_ReportsError()
     {
         string testCode = """
@@ -546,7 +546,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandContinueWithAssigned_NoDiagnostic()
     {
         string testCode = """
@@ -570,7 +570,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandContinueWithReturned_NoDiagnostic()
     {
         string testCode = """
@@ -594,7 +594,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandContinueWithPassedAsArgument_NoDiagnostic()
     {
         string testCode = """
@@ -623,7 +623,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandContinueWithChainedNotAwaited_ReportsError()
     {
         string testCode = """
@@ -653,7 +653,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ClassNotEndingWithModule_NoDiagnostic()
     {
         string testCode = """
@@ -684,7 +684,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ClassEndingWithModuleButNoModuleBaseClass_NoDiagnostic()
     {
         string testCode = """
@@ -714,7 +714,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleCommandInVariableDeclarator_NoDiagnostic()
     {
         string testCode = """
@@ -739,7 +739,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task CustomModuleWithNonGenericTask_NoDiagnostic()
     {
         string testCode = """
@@ -770,7 +770,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task CustomModuleWithVoidMethod_NoDiagnostic()
     {
         string testCode = """
@@ -800,7 +800,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task CustomModuleWithNonAsyncMethod_NoDiagnostic()
     {
         string testCode = """
@@ -831,7 +831,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ModuleWithInterfaceInheritance_FireAndForget_ReportsError()
     {
         string testCode = """
@@ -873,7 +873,7 @@ public class BiDiDriver010AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver010_FireAndForgetAsyncModuleCommandAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task DeepModuleInheritanceHierarchy_FireAndForget_ReportsError()
     {
         string testCode = """

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver012AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver012AnalyzerTests.cs
@@ -7,7 +7,6 @@ namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
@@ -15,7 +14,7 @@ using Microsoft.CodeAnalysis.Testing;
 /// </summary>
 public class BiDiDriver012AnalyzerTests
 {
-    [Test]
+    [Fact]
     public async Task DisposeAsync_WithoutStopAsync_ReportsInfo()
     {
         string testCode = """
@@ -45,7 +44,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_WithStopAsync_NoDiagnostic()
     {
         string testCode = """
@@ -70,7 +69,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_WithStopAsyncInTryFinally_NoDiagnostic()
     {
         string testCode = """
@@ -101,7 +100,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_WithStopAsyncAfter_ReportsInfo()
     {
         string testCode = """
@@ -132,7 +131,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_DisposeAsyncWithoutStopAsync_ReportsMultipleInfo()
     {
         string testCode = """
@@ -171,7 +170,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode, expected1, expected2);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_OneWithStopAsync_ReportsInfoForOtherDriver()
     {
         string testCode = """
@@ -205,7 +204,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverDisposeAsync_NoDiagnostic()
     {
         string testCode = """
@@ -236,7 +235,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string testCode = """
@@ -255,7 +254,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_InConditional_WithoutStopAsync_ReportsInfo()
     {
         string testCode = """
@@ -289,7 +288,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_WithStopAsyncInSameConditional_NoDiagnostic()
     {
         string testCode = """
@@ -318,7 +317,7 @@ public class BiDiDriver012AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_StopAsyncOnDifferentDriver_ReportsInfo()
     {
         string testCode = """
@@ -350,5 +349,4 @@ public class BiDiDriver012AnalyzerTests
 
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver012_StopAsyncBeforeDisposeAsyncAnalyzer>(testCode, expected);
     }
-
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver012CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver012CodeFixProviderTests.cs
@@ -13,10 +13,9 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver012 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver012CodeFixProviderTests
 {
-    [Test]
+    [Fact]
     public async Task DisposeAsync_CodeFixInsertsStopAsync()
     {
         string testCode = """
@@ -71,10 +70,10 @@ public class BiDiDriver012CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task DisposeAsync_InConditional_CodeFixInsertsStopAsync()
     {
         string testCode = """
@@ -137,10 +136,10 @@ public class BiDiDriver012CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleDrivers_CodeFixInsertsStopAsyncForFlaggedDriver()
     {
         string testCode = """
@@ -203,6 +202,6 @@ public class BiDiDriver012CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver013AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver013AnalyzerTests.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Testing;
 /// </summary>
 public class BiDiDriver013AnalyzerTests
 {
-    [Test]
+    [Fact]
     public async Task NavigateAsync_WithoutCancellationToken_ReportsWarning()
     {
         string testCode = """
@@ -42,7 +42,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ReloadAsync_WithoutCancellationToken_ReportsWarning()
     {
         string testCode = """
@@ -70,7 +70,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task PrintAsync_WithoutCancellationToken_ReportsWarning()
     {
         string testCode = """
@@ -98,7 +98,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task StartAsync_WithoutCancellationToken_ReportsWarning()
     {
         string testCode = """
@@ -127,7 +127,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForAsync_WithoutCancellationToken_ReportsWarning()
     {
         string testCode = """
@@ -158,7 +158,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForCapturedTasksAsync_WithoutCancellationToken_ReportsWarning()
     {
         string testCode = """
@@ -189,7 +189,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task NonLongRunningMethod_WithoutCancellationToken_NoDiagnostic()
     {
         string testCode = """
@@ -213,7 +213,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task NonBiDiDriverMethod_WithoutCancellationToken_NoDiagnostic()
     {
         string testCode = """
@@ -244,7 +244,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleLongRunningOperations_WithoutCancellationToken_ReportsAllWarnings()
     {
         string testCode = """
@@ -281,7 +281,7 @@ public class BiDiDriver013AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver013_LongRunningOperationWithoutCancellationTokenAnalyzer>(testCode, expected0, expected1, expected2);
     }
 
-    [Test]
+    [Fact]
     public async Task MethodWithoutTokenOverload_NoDiagnostic()
     {
         string testCode = """

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver014AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver014AnalyzerTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver014 analyzer that detects parameterless constructor usage when a Reset property is available.
 /// </summary>
-[TestFixture]
 public class BiDiDriver014AnalyzerTests
 {
     /// <summary>
     /// Tests that parameterless constructor without property assignment reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParameterlessConstructor_WithoutPropertyAssignment_ReportsDiagnostic()
     {
         string test = """
@@ -102,14 +100,14 @@ public class BiDiDriver014AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that parameterless constructor with property assignment does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParameterlessConstructor_WithPropertyAssignment_NoDiagnostic()
     {
         string test = """
@@ -187,14 +185,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that using the Reset property directly does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task UsingResetProperty_NoDiagnostic()
     {
         string test = """
@@ -271,14 +269,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-CommandParameters types are not analyzed.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonCommandParametersType_NoDiagnostic()
     {
         string test = """
@@ -312,14 +310,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that CommandParameters without a Reset property do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CommandParametersWithoutResetProperty_NoDiagnostic()
     {
         string test = """
@@ -392,14 +390,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple variables are tracked independently.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleVariables_IndependentTracking()
     {
         string test = """
@@ -484,14 +482,14 @@ public class BiDiDriver014AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that setting any property suppresses the diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParameterlessConstructor_WithContextsPropertyAssignment_NoDiagnostic()
     {
         string test = """
@@ -569,14 +567,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that object initializer syntax is handled correctly (should not report diagnostic).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParameterlessConstructor_WithObjectInitializer_NoDiagnostic()
     {
         string test = """
@@ -656,14 +654,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that variable without initializer is handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task VariableWithoutInitializer_NoDiagnostic()
     {
         string test = """
@@ -736,15 +734,14 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 
     /// <summary>
     /// Tests that an inline parameterless constructor used directly as a method argument reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InlineParameterlessConstructor_AsMethodArgument_ReportsDiagnostic()
     {
         string test = """
@@ -824,14 +821,14 @@ public class BiDiDriver014AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that an inline constructor with an object initializer does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InlineConstructor_WithObjectInitializer_AsMethodArgument_NoDiagnostic()
     {
         string test = """
@@ -906,7 +903,7 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -915,7 +912,7 @@ public class BiDiDriver014AnalyzerTests
     /// command-level Reset property.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParameterlessConstructor_WithListPropertyAndResetProperty_ReportsDiagnostic()
     {
         string test = """
@@ -995,7 +992,7 @@ public class BiDiDriver014AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -1004,7 +1001,7 @@ public class BiDiDriver014AnalyzerTests
     /// the previous false positive that occurred when only .Add() was available.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ParameterlessConstructor_WithListPropertyAssignedViaObjectInitializer_NoDiagnostic()
     {
         string test = """
@@ -1082,6 +1079,6 @@ public class BiDiDriver014AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver014CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver014CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver014 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver014CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix replaces parameterless constructor with Reset property.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_ReplacesParameterlessConstructorWithResetProperty()
     {
         string testCode = """
@@ -171,14 +169,14 @@ public class BiDiDriver014CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix works with multiple variables and only fixes the flagged one.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_WithMultipleVariables_FixesOnlyFlaggedOne()
     {
         string testCode = """
@@ -335,6 +333,6 @@ public class BiDiDriver014CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver015AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver015AnalyzerTests.cs
@@ -16,14 +16,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver015 analyzer that detects string literals instead of ObservableEvent.EventName.
 /// </summary>
-[TestFixture]
 public class BiDiDriver015AnalyzerTests
 {
     /// <summary>
     /// Tests that string literal in SubscribeAsync reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StringLiteral_InSubscribeAsync_ReportsWarning()
     {
         string test = """
@@ -109,14 +108,14 @@ public class BiDiDriver015AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that using EventName property does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventNameProperty_InSubscribeAsync_NoDiagnostic()
     {
         string test = """
@@ -197,14 +196,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple string literals are all detected.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleStringLiterals_InSubscribeAsync_ReportsMultipleWarnings()
     {
         string test = """
@@ -304,14 +303,14 @@ public class BiDiDriver015AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that string literal for unknown event does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StringLiteral_ForUnknownEvent_NoDiagnostic()
     {
         string test = """
@@ -392,14 +391,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that mixed usage (EventName and string literals) works correctly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MixedUsage_EventNameAndStringLiteral_ReportsOnlyStringLiteral()
     {
         string test = """
@@ -494,15 +493,14 @@ public class BiDiDriver015AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 
     /// <summary>
     /// Tests that methods without driver variable are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NoDriverVariable_NoDiagnostic()
     {
         string test = """
@@ -553,14 +551,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a string literal in a C# 12 collection expression in SubscribeAsync reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StringLiteral_InCollectionExpression_ReportsWarning()
     {
         string test = """
@@ -646,14 +644,14 @@ public class BiDiDriver015AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that using EventName property in a C# 12 collection expression does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventNameProperty_InCollectionExpression_NoDiagnostic()
     {
         string test = """
@@ -734,7 +732,7 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -742,7 +740,7 @@ public class BiDiDriver015AnalyzerTests
     /// (i.e., referenced as a compiled assembly rather than defined in source).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StringLiteral_InSubscribeAsync_MetadataBacked_ReportsWarning()
     {
         string test = """
@@ -775,14 +773,14 @@ public class BiDiDriver015AnalyzerTests
         testState.TestState.AdditionalReferences.Add(await CreateFakeLibMetadataReference());
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that BIDI015 does not fire when EventName property is used, with metadata-backed types.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task EventNameProperty_InSubscribeAsync_MetadataBacked_NoDiagnostic()
     {
         string test = """
@@ -810,14 +808,14 @@ public class BiDiDriver015AnalyzerTests
         };
         testState.TestState.AdditionalReferences.Add(await CreateFakeLibMetadataReference());
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that explicit array creation syntax (new string[] { }) reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task StringLiteral_InExplicitArrayCreation_ReportsWarning()
     {
         string test = """
@@ -903,14 +901,14 @@ public class BiDiDriver015AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SubscribeAsync with no arguments does not crash the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_WithNoArguments_NoDiagnostic()
     {
         string test = """
@@ -956,14 +954,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SubscribeAsync with a variable instead of object creation does not crash the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SubscribeAsync_WithVariableArgument_NoDiagnostic()
     {
         string test = """
@@ -1015,14 +1013,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SubscribeCommandParameters with no arguments does not crash the analyzer.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SubscribeCommandParameters_WithNoArguments_NoDiagnostic()
     {
         string test = """
@@ -1073,14 +1071,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-method invocations are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonMethodInvocation_NoDiagnostic()
     {
         string test = """
@@ -1126,14 +1124,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that expression-bodied methods are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ExpressionBodiedMethod_NoDiagnostic()
     {
         string test = """
@@ -1180,14 +1178,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-literal expressions in event arrays are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonLiteralExpressionInArray_NoDiagnostic()
     {
         string test = """
@@ -1239,14 +1237,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that numeric literals in event arrays are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NumericLiteralInArray_NoDiagnostic()
     {
         string test = """
@@ -1297,14 +1295,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that driver variables without initializers are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task DriverVariableWithoutInitializer_NoDiagnostic()
     {
         string test = """
@@ -1386,14 +1384,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-driver types are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonDriverType_NoDiagnostic()
     {
         string test = """
@@ -1437,14 +1435,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations without member access (e.g., local function calls) are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LocalFunctionInvocation_NoDiagnostic()
     {
         string test = """
@@ -1497,14 +1495,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations where method symbol cannot be determined are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InvocationWithUnresolvedMethod_NoDiagnostic()
     {
         string test = """
@@ -1556,14 +1554,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that const string expressions (non-literal) in arrays are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ConstStringExpression_NoDiagnostic()
     {
         string test = """
@@ -1616,14 +1614,14 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that interpolated strings in arrays are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InterpolatedStringInArray_NoDiagnostic()
     {
         string test = """
@@ -1704,7 +1702,7 @@ public class BiDiDriver015AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver015CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver015CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver015 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver015CodeFixProviderTests
 {
     /// <summary>
     /// Tests that code fix replaces string literal with EventName property.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_ReplacesStringLiteralWithEventName()
     {
         string testCode = """
@@ -179,10 +177,10 @@ public class BiDiDriver015CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task StringLiteralWithNoObserver_NoDiagnostic()
     {
         // A string literal matching a known event name appears in SubscribeAsync,

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver016AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver016AnalyzerTests.cs
@@ -12,14 +12,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver016 analyzer that detects deadlock-prone synchronization patterns in event handlers.
 /// </summary>
-[TestFixture]
 public class BiDiDriver016AnalyzerTests
 {
     /// <summary>
     /// Tests that lock statement in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LockStatement_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -83,14 +82,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Monitor.Enter in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MonitorEnter_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -158,14 +157,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SemaphoreSlim.Wait in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SemaphoreSlimWait_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -233,14 +232,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SemaphoreSlim.WaitAsync in async event handler does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SemaphoreSlimWaitAsync_InAsyncEventHandler_NoDiagnostic()
     {
         string test = """
@@ -303,14 +302,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that lock statement in non-async event handler does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LockStatement_InNonAsyncEventHandler_NoDiagnostic()
     {
         string test = """
@@ -368,14 +367,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that deadlock patterns with RunHandlerAsynchronously do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LockStatement_WithRunHandlerAsynchronously_NoDiagnostic()
     {
         string test = """
@@ -441,14 +440,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that ManualResetEvent.WaitOne in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ManualResetEventWaitOne_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -509,14 +508,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Task.WaitAll in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task TaskWaitAll_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -577,14 +576,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple deadlock patterns are all detected.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MultipleDeadlockPatterns_InAsyncEventHandler_ReportsMultipleWarnings()
     {
         string test = """
@@ -664,14 +663,14 @@ public class BiDiDriver016AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Monitor.TryEnter in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MonitorTryEnter_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -732,14 +731,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Task.WaitAny in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task TaskWaitAny_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -797,14 +796,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Mutex.WaitOne in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MutexWaitOne_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -863,14 +862,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AutoResetEvent.WaitOne in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AutoResetEventWaitOne_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -928,14 +927,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SynchronizationContext.Send in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SynchronizationContextSend_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -996,14 +995,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Semaphore.WaitOne in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SemaphoreWaitOne_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -1062,14 +1061,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-async event handler with sync lambda does not report diagnostic even with lock.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LockStatement_InSyncLambdaHandler_NoDiagnostic()
     {
         string test = """
@@ -1124,14 +1123,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations that are not AddObserver are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonAddObserverInvocation_NoDiagnostic()
     {
         string test = """
@@ -1181,14 +1180,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations without member access are ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InvocationWithoutMemberAccess_NoDiagnostic()
     {
         string test = """
@@ -1219,14 +1218,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver that doesn't return EventObserver is ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserverWithDifferentReturnType_NoDiagnostic()
     {
         string test = """
@@ -1276,14 +1275,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with non-EventObserver return type is ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserverWithWrongReturnType_NoDiagnostic()
     {
         string test = """
@@ -1319,14 +1318,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with no arguments is ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserverWithNoArguments_NoDiagnostic()
     {
         string test = """
@@ -1373,14 +1372,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that handler without body (null body) is ignored.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task HandlerWithoutBody_NoDiagnostic()
     {
         string test = """
@@ -1429,14 +1428,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that method reference (not lambda) with async modifier is not detected (analyzer limitation - IsAsyncHandler only checks lambdas).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task MethodReference_WithLockStatement_NoDiagnostic()
     {
         string test = """
@@ -1493,14 +1492,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that local function reference (not lambda) with async modifier is not detected (analyzer limitation - IsAsyncHandler only checks lambdas).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LocalFunctionReference_WithLockStatement_NoDiagnostic()
     {
         string test = """
@@ -1557,14 +1556,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that WaitHandle.WaitOne (base class) in async event handler reports a warning.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task WaitHandleWaitOne_InAsyncEventHandler_ReportsWarning()
     {
         string test = """
@@ -1622,14 +1621,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that simple lambda (non-parenthesized) with async works correctly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task SimpleLambdaAsync_WithLockStatement_ReportsWarning()
     {
         string test = """
@@ -1686,14 +1685,14 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with RunHandlerAsynchronously option does not report diagnostics.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddObserver_WithRunHandlerAsynchronously_NoDiagnostic()
     {
         string test = """
@@ -1750,14 +1749,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that method reference to a property does not cause errors.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task PropertyReference_AsHandler_NoDiagnostic()
     {
         string test = """
@@ -1806,14 +1805,14 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that unresolved invocations inside handler body do not cause errors.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task UnresolvedInvocationInHandlerBody_NoDiagnostic()
     {
         string test = """
@@ -1864,10 +1863,10 @@ public class BiDiDriver016AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task LockStatement_WithObservableEventHandlerOptionsNone_ReportsWarning()
     {
         // Exercises the HasRunHandlerAsynchronouslyOption fallthrough when
@@ -1939,7 +1938,6 @@ public class BiDiDriver016AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver017AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver017AnalyzerTests.cs
@@ -12,14 +12,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver017 analyzer that suggests ??= when adding to nullable list properties.
 /// </summary>
-[TestFixture]
 public class BiDiDriver017AnalyzerTests
 {
     /// <summary>
     /// Tests that Add on nullable list property reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNullableListProperty_ReportsDiagnostic()
     {
         string test = """
@@ -93,14 +92,14 @@ public class BiDiDriver017AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on nullable list property with ??= does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNullableListProperty_WithNullCoalescing_NoDiagnostic()
     {
         string test = """
@@ -169,14 +168,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on non-nullable list property does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNonNullableListProperty_NoDiagnostic()
     {
         string test = """
@@ -209,14 +208,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on local variable (not property) does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToLocalVariable_NoDiagnostic()
     {
         string test = """
@@ -242,15 +241,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
-
 
     /// <summary>
     /// Tests that AddRange on nullable list property reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddRangeToNullableListProperty_ReportsDiagnostic()
     {
         string test = """
@@ -283,14 +281,14 @@ public class BiDiDriver017AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Insert on nullable list property reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InsertToNullableListProperty_ReportsDiagnostic()
     {
         string test = """
@@ -323,14 +321,14 @@ public class BiDiDriver017AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that InsertRange on nullable list property reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InsertRangeToNullableListProperty_ReportsDiagnostic()
     {
         string test = """
@@ -363,14 +361,14 @@ public class BiDiDriver017AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on nullable IList property reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNullableIListProperty_ReportsDiagnostic()
     {
         string test = """
@@ -403,14 +401,14 @@ public class BiDiDriver017AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on nullable ICollection property reports a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNullableICollectionProperty_ReportsDiagnostic()
     {
         string test = """
@@ -443,14 +441,14 @@ public class BiDiDriver017AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on non-nullable list property with initializer does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNonNullableListPropertyWithInitializer_NoDiagnostic()
     {
         string test = """
@@ -478,14 +476,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddRange with null-conditional does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddRangeWithNullConditional_NoDiagnostic()
     {
         string test = """
@@ -513,14 +511,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Insert with null-coalescing assignment does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InsertWithNullCoalescingAssignment_NoDiagnostic()
     {
         string test = """
@@ -548,14 +546,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that non-list method call does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NonListMethodCall_NoDiagnostic()
     {
         string test = """
@@ -582,14 +580,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that methods not in the add list (e.g., Remove) do not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task RemoveFromNullableListProperty_NoDiagnostic()
     {
         string test = """
@@ -617,14 +615,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add with null-conditional operator does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddWithNullConditional_NoDiagnostic()
     {
         string test = """
@@ -652,14 +650,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddRange with null-coalescing inside a larger expression does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddRangeNestedInCoalescingAssignment_NoDiagnostic()
     {
         string test = """
@@ -687,14 +685,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that InsertRange with null-coalescing inside a larger expression does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task InsertRangeNestedInCoalescingAssignment_NoDiagnostic()
     {
         string test = """
@@ -722,14 +720,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocation on expression with unresolved type does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddOnUnresolvedType_NoDiagnostic()
     {
         string test = """
@@ -756,14 +754,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on non-generic list does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToNonGenericCollectionProperty_NoDiagnostic()
     {
         string test = """
@@ -791,14 +789,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on nullable value type property does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddOnNullableValueTypeProperty_NoDiagnostic()
     {
         string test = """
@@ -826,14 +824,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on non-collection type does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddOnNonCollectionProperty_NoDiagnostic()
     {
         string test = """
@@ -865,14 +863,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that invocations without member access syntax are handled gracefully.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task LocalFunctionAdd_NoDiagnostic()
     {
         string test = """
@@ -899,14 +897,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on field (not property) does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToField_NoDiagnostic()
     {
         string test = """
@@ -934,14 +932,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on IEnumerable property (not IList or ICollection) does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddToIEnumerableProperty_NoDiagnostic()
     {
         string test = """
@@ -970,14 +968,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Clear method on nullable list property does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task ClearNullableListProperty_NoDiagnostic()
     {
         string test = """
@@ -1005,14 +1003,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that nested Add call (e.g., within another method) with null coalescing is detected correctly.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task NestedCoalescingWithAdd_NoDiagnostic()
     {
         string test = """
@@ -1041,14 +1039,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on nested conditional access property does not report a diagnostic.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddOnNestedConditionalAccessProperty_NoDiagnostic()
     {
         string test = """
@@ -1085,14 +1083,14 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that Add on property with unresolved type does not crash.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task AddOnPropertyWithUnresolvedType_NoDiagnostic()
     {
         string test = """
@@ -1120,6 +1118,6 @@ public class BiDiDriver017AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver017CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver017CodeFixProviderTests.cs
@@ -6,21 +6,19 @@
 namespace WebDriverBiDi.Analyzers.Tests;
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
 /// <summary>
 /// Tests for the BiDiDriver017 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver017CodeFixProviderTests
 {
     /// <summary>
     /// Tests that the code fix correctly applies ??= to the receiver.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Test]
+    [Fact]
     public async Task CodeFix_WrapsReceiverWithNullCoalescing()
     {
         string testCode = """
@@ -155,10 +153,10 @@ public class BiDiDriver017CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task NullableListOnUnrelatedType_NoDiagnostic()
     {
         // A nullable List<?>.Add() call on a class that does not inherit from

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver020AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver020AnalyzerTests.cs
@@ -12,10 +12,9 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver020 analyzer.
 /// </summary>
-[TestFixture]
 public class BiDiDriver020AnalyzerTests
 {
-    [Test]
+    [Fact]
     public async Task WaitForAsync_WithoutStartCapturing_ReportsError()
     {
         string testCode = """
@@ -47,7 +46,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForCapturedTasksAsync_WithoutStartCapturing_ReportsError()
     {
         string testCode = """
@@ -79,7 +78,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForAsync_AfterStartCapturing_NoDiagnostic()
     {
         string testCode = """
@@ -106,7 +105,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForCapturedTasksAsync_AfterStartCapturing_NoDiagnostic()
     {
         string testCode = """
@@ -133,7 +132,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForAsync_AfterStopCapturing_ReportsError()
     {
         // StartCapturing then StopCapturing leaves no active session.
@@ -168,7 +167,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForAsync_AfterStopAndRestart_NoDiagnostic()
     {
         string testCode = """
@@ -197,7 +196,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleObservers_OnlyOneWithoutStartCapturing_ReportsOneError()
     {
         string testCode = """
@@ -232,7 +231,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ObserverPassedAsParameter_NoDiagnostic()
     {
         // Parameter-passed observers are not tracked; we can't know their capture state.
@@ -257,7 +256,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string testCode = """
@@ -277,7 +276,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task GetCapturedTasks_WithoutStartCapturing_NoDiagnostic()
     {
         // GetCapturedTasks is synchronous and returns empty when no session is active — not an error.
@@ -303,7 +302,7 @@ public class BiDiDriver020AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver020_CaptureSessionNotStartedAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task BothWaitMethods_WithoutStartCapturing_ReportsTwoErrors()
     {
         string testCode = """

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver020CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver020CodeFixProviderTests.cs
@@ -13,10 +13,9 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver020 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver020CodeFixProviderTests
 {
-    [Test]
+    [Fact]
     public async Task WaitForAsync_WithoutStartCapturing_InsertsStartCapturing()
     {
         string testCode = """
@@ -75,10 +74,10 @@ public class BiDiDriver020CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForCapturedTasksAsync_WithoutStartCapturing_InsertsStartCapturing()
     {
         string testCode = """
@@ -137,10 +136,10 @@ public class BiDiDriver020CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task WaitForAsync_AfterStopCapturing_InsertsStartCapturingBeforeWait()
     {
         string testCode = """
@@ -205,6 +204,6 @@ public class BiDiDriver020CodeFixProviderTests
         testState.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(AnalyzerTestHelpers.GetWebDriverBiDiAssemblyPath()));
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver021AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver021AnalyzerTests.cs
@@ -12,10 +12,9 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver021 analyzer.
 /// </summary>
-[TestFixture]
 public class BiDiDriver021AnalyzerTests
 {
-    [Test]
+    [Fact]
     public async Task StartCapturing_NeverRead_ReportsWarning()
     {
         string testCode = """
@@ -45,7 +44,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task StartCapturing_FollowedByWaitForAsync_NoDiagnostic()
     {
         string testCode = """
@@ -72,7 +71,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task StartCapturing_FollowedByWaitForCapturedTasksAsync_NoDiagnostic()
     {
         string testCode = """
@@ -99,7 +98,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task StartCapturing_FollowedByGetCapturedTasks_NoDiagnostic()
     {
         string testCode = """
@@ -125,7 +124,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task StartCapturing_ThenStopCapturing_NeverRead_ReportsWarning()
     {
         string testCode = """
@@ -156,7 +155,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task StartCapturing_Twice_SecondNeverRead_ReportsOnlySecond()
     {
         // First session is satisfied; second is not.
@@ -191,7 +190,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task NoStartCapturing_NoDiagnostic()
     {
         string testCode = """
@@ -215,7 +214,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MultipleObservers_OnlyOneUnread_ReportsOneWarning()
     {
         string testCode = """
@@ -250,7 +249,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task ObserverPassedAsParameter_NoDiagnostic()
     {
         // Parameter-passed observers are not tracked.
@@ -273,7 +272,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task MethodWithoutBody_NoDiagnostic()
     {
         string testCode = """
@@ -293,7 +292,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task StartCapturing_ReadInNestedBlock_NoDiagnostic()
     {
         // The read is inside an if-block but the analyzer sees it within the same method body.
@@ -324,7 +323,7 @@ public class BiDiDriver021AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver021_CaptureSessionOpenedButNeverReadAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task TwoSessionsBothRead_NoDiagnostic()
     {
         string testCode = """

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver022AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver022AnalyzerTests.cs
@@ -12,14 +12,13 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver022 analyzer.
 /// </summary>
-[TestFixture]
 public class BiDiDriver022AnalyzerTests
 {
     // -----------------------------------------------------------------------
     // Positive cases — should report BIDI022
     // -----------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public async Task IndexerAssignment_OnCommandParametersAdditionalData_ReportsWarning()
     {
         string testCode = """
@@ -47,7 +46,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task AddMethod_OnCommandParametersAdditionalData_ReportsWarning()
     {
         string testCode = """
@@ -75,7 +74,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task TryAddMethod_OnCommandParametersAdditionalData_ReportsWarning()
     {
         string testCode = """
@@ -103,7 +102,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task IndexerAssignment_OnStoragePartialCookieAdditionalData_ReportsWarning()
     {
         // Verifies that the analyzer also fires for non-CommandParameters types that expose
@@ -138,7 +137,7 @@ public class BiDiDriver022AnalyzerTests
     // Negative cases — should produce no diagnostic
     // -----------------------------------------------------------------------
 
-    [Test]
+    [Fact]
     public async Task ReadingAdditionalDataByKey_NoDiagnostic()
     {
         // Reading back a value that was already written should not fire again.
@@ -169,7 +168,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode, expected);
     }
 
-    [Test]
+    [Fact]
     public async Task RemoveMethod_OnCommandParametersAdditionalData_NoDiagnostic()
     {
         // Remove does not add a new value, so no AOT risk is introduced.
@@ -192,7 +191,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ClearMethod_OnCommandParametersAdditionalData_NoDiagnostic()
     {
         // Clear removes values; it does not introduce new non-AOT-safe objects.
@@ -215,7 +214,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task IteratingAdditionalData_NoDiagnostic()
     {
         string testCode = """
@@ -241,7 +240,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task CountProperty_NoDiagnostic()
     {
         string testCode = """
@@ -263,7 +262,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task ContainsKey_NoDiagnostic()
     {
         string testCode = """
@@ -285,7 +284,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task IndexerAssignment_OnUnrelatedDictionary_NoDiagnostic()
     {
         // A locally-declared Dictionary<string, object?> that is not an AdditionalData property should not fire.
@@ -308,7 +307,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task AddMethod_OnUnrelatedDictionary_NoDiagnostic()
     {
         string testCode = """
@@ -330,7 +329,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task IndexerAssignment_OnPropertyNamed_OtherThanAdditionalData_NoDiagnostic()
     {
         // A property named "Data" (not "AdditionalData") with the same type should NOT fire.
@@ -359,7 +358,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task IndexerAssignment_OnAdditionalDataWithWrongValueType_NoDiagnostic()
     {
         // An "AdditionalData" property that returns Dictionary<string, string> (not object?)
@@ -389,7 +388,7 @@ public class BiDiDriver022AnalyzerTests
         await AnalyzerTestHelpers.VerifyAnalyzerAsync<BiDiDriver022_AdditionalDataMutationAnalyzer>(testCode);
     }
 
-    [Test]
+    [Fact]
     public async Task IndexerAssignment_ViaParenthesizedExpression_ReportsWarning()
     {
         // Accessing AdditionalData via a parenthesized expression exercises the

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver023AnalyzerTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver023AnalyzerTests.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver023 analyzer that detects module command calls inside event handlers.
 /// </summary>
-[TestFixture]
 public class BiDiDriver023AnalyzerTests
 {
     // Common stub definitions reused across tests.
@@ -76,7 +75,7 @@ public class BiDiDriver023AnalyzerTests
     /// <summary>
     /// Tests that a module command call inside an event handler reports a warning.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -113,13 +112,13 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that when RunHandlerAsynchronously is set no diagnostic is reported.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithRunHandlerAsynchronously_NoDiagnostic()
     {
         string test = $$"""
@@ -149,13 +148,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a non-AddObserver invocation is not analyzed.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task NonAddObserverInvocation_NoDiagnostic()
     {
         string test = $$"""
@@ -186,13 +185,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a method returning non-EventObserver is not analyzed.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task MethodReturningNonEventObserver_NoDiagnostic()
     {
         string test = $$"""
@@ -229,13 +228,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that multiple module commands in one handler report multiple warnings.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithMultipleModuleCommands_ReportsMultipleWarnings()
     {
         string test = $$"""
@@ -280,13 +279,13 @@ public class BiDiDriver023AnalyzerTests
         testState.ExpectedDiagnostics.Add(expected1);
         testState.ExpectedDiagnostics.Add(expected2);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a named method reference containing a module command reports a warning.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task NamedMethodHandler_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -328,13 +327,13 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a member-access method reference containing a module command reports a warning.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task MemberAccessMethodReference_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -376,13 +375,13 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a local function containing a module command reports a warning.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task LocalFunctionHandler_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -421,13 +420,13 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a parenthesized lambda handler with a module command reports a warning.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task ParenthesizedLambdaHandler_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -464,13 +463,13 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a handler with no module commands does not report a diagnostic.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithNoModuleCommands_NoDiagnostic()
     {
         string test = $$"""
@@ -502,13 +501,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a non-Task-returning module method does not report a diagnostic.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithNonTaskReturningModuleMethod_NoDiagnostic()
     {
         string test = $$"""
@@ -539,13 +538,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a custom class ending in "Module" without the Module base class is not flagged.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithCustomModuleNotInheritingModule_NoDiagnostic()
     {
         string test = $$"""
@@ -581,13 +580,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with no arguments is not analyzed.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task AddObserver_NoArguments_NoDiagnostic()
     {
         string test = $$"""
@@ -621,13 +620,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a module command in a deep inheritance hierarchy is reported.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithDeepInheritanceModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -678,13 +677,13 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that AddObserver with an unresolved method symbol is handled gracefully.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task AddObserver_UnresolvedMethodSymbol_NoDiagnostic()
     {
         string test = $$"""
@@ -720,13 +719,13 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a module non-generic Task method (e.g. Task DoAsync()) is not flagged.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithNonGenericTaskModuleMethod_NoDiagnostic()
     {
         string test = $$"""
@@ -764,7 +763,7 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -772,7 +771,7 @@ public class BiDiDriver023AnalyzerTests
     /// because GetHandlerBody reaches its default null arm (the expression is not a lambda
     /// or identifier/member-access method group).
     /// </summary>
-    [Test]
+    [Fact]
     public async Task AddObserver_HandlerReturnedByInvocation_NoDiagnostic()
     {
         string test = $$"""
@@ -805,7 +804,7 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -813,7 +812,7 @@ public class BiDiDriver023AnalyzerTests
     /// identifier resolves to an ILocalSymbol, not an IMethodSymbol, so GetMethodBodyFromSymbol
     /// returns null and no diagnostic is reported.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task AddObserver_LocalFuncVariableAsIdentifier_NoDiagnostic()
     {
         string test = $$"""
@@ -847,14 +846,14 @@ public class BiDiDriver023AnalyzerTests
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         };
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a named method with an expression body containing a module command reports a warning.
     /// Covers the expression-body (non-block) branch of GetMethodBodyFromSymbol.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task NamedMethod_ExpressionBody_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -894,14 +893,14 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that a local function with an expression body containing a module command reports a warning.
     /// Covers the expression-body (non-block) branch of GetMethodBodyFromSymbol for local functions.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task LocalFunction_ExpressionBody_WithModuleCommand_ReportsWarning()
     {
         string test = $$"""
@@ -938,19 +937,19 @@ public class BiDiDriver023AnalyzerTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that SupportedDiagnostics contains BIDI023.
     /// </summary>
-    [Test]
+    [Fact]
     public void SupportedDiagnostics_ContainsBIDI023()
     {
         BiDiDriver023_ModuleCommandInEventHandlerAnalyzer analyzer = new();
         System.Collections.Immutable.ImmutableArray<DiagnosticDescriptor> diagnostics = analyzer.SupportedDiagnostics;
 
-        Assert.That(diagnostics, Has.Length.EqualTo(1));
-        Assert.That(diagnostics[0].Id, Is.EqualTo(BiDiDriver023_ModuleCommandInEventHandlerAnalyzer.DiagnosticId));
+        Assert.Single(diagnostics);
+        Assert.Equal(BiDiDriver023_ModuleCommandInEventHandlerAnalyzer.DiagnosticId, diagnostics[0].Id);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver023CodeFixProviderTests.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/BiDiDriver023CodeFixProviderTests.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Testing;
 /// <summary>
 /// Tests for the BiDiDriver023 code fix provider.
 /// </summary>
-[TestFixture]
 public class BiDiDriver023CodeFixProviderTests
 {
     private const string CommonStubs = """
@@ -75,7 +74,7 @@ public class BiDiDriver023CodeFixProviderTests
     /// <summary>
     /// Tests that the code fix adds RunHandlerAsynchronously when it is not yet present.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithModuleCommand_CodeFixAddsRunHandlerAsynchronously()
     {
         string testCode = $$"""
@@ -134,13 +133,13 @@ public class BiDiDriver023CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests that the code fix replaces an existing options argument with RunHandlerAsynchronously.
     /// </summary>
-    [Test]
+    [Fact]
     public async Task EventHandler_WithExistingNoneOption_CodeFixReplacesWithRunHandlerAsynchronously()
     {
         string testCode = $$"""
@@ -199,32 +198,32 @@ public class BiDiDriver023CodeFixProviderTests
         };
         testState.ExpectedDiagnostics.Add(expected);
 
-        await testState.RunAsync();
+        await testState.RunAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
     /// Tests FixableDiagnosticIds contains BIDI023.
     /// </summary>
-    [Test]
+    [Fact]
     public void FixableDiagnosticIds_ContainsBIDI023()
     {
         BiDiDriver023_ModuleCommandInEventHandlerCodeFixProvider provider = new();
         System.Collections.Immutable.ImmutableArray<string> ids = provider.FixableDiagnosticIds;
 
-        Assert.That(ids, Has.Length.EqualTo(1));
-        Assert.That(ids[0], Is.EqualTo(BiDiDriver023_ModuleCommandInEventHandlerAnalyzer.DiagnosticId));
+        Assert.Single(ids);
+        Assert.Equal(BiDiDriver023_ModuleCommandInEventHandlerAnalyzer.DiagnosticId, ids[0]);
     }
 
     /// <summary>
     /// Tests GetFixAllProvider returns the batch fixer.
     /// </summary>
-    [Test]
+    [Fact]
     public void GetFixAllProvider_ReturnsBatchFixer()
     {
         BiDiDriver023_ModuleCommandInEventHandlerCodeFixProvider provider = new();
         Microsoft.CodeAnalysis.CodeFixes.FixAllProvider fixAllProvider = provider.GetFixAllProvider();
 
-        Assert.That(fixAllProvider, Is.Not.Null);
-        Assert.That(fixAllProvider, Is.EqualTo(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer));
+        Assert.NotNull(fixAllProvider);
+        Assert.Equal(Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders.BatchFixer, fixAllProvider);
     }
 }

--- a/test/WebDriverBiDi.Analyzers.Tests/Usings.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/Usings.cs
@@ -1,1 +1,1 @@
-global using NUnit.Framework;
+global using Xunit;

--- a/test/WebDriverBiDi.Analyzers.Tests/Usings.cs
+++ b/test/WebDriverBiDi.Analyzers.Tests/Usings.cs
@@ -1,1 +1,3 @@
 global using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/WebDriverBiDi.Analyzers.Tests/WebDriverBiDi.Analyzers.Tests.csproj
+++ b/test/WebDriverBiDi.Analyzers.Tests/WebDriverBiDi.Analyzers.Tests.csproj
@@ -9,19 +9,15 @@
 
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <EnableNUnitRunner>true</EnableNUnitRunner>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="coverlet.MTP" Version="10.0.1" />
   </ItemGroup>
 

--- a/test/WebDriverBiDi.Integration.Tests/AotCompilationEnvironmentFixture.cs
+++ b/test/WebDriverBiDi.Integration.Tests/AotCompilationEnvironmentFixture.cs
@@ -1,0 +1,88 @@
+// <copyright file="AotCompilationEnvironmentFixture.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Integration.Tests;
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Xunit.Sdk;
+
+public class AotCompilationEnvironmentFixture : IAsyncLifetime
+{
+    // The AOT test application must be published as a native binary at test time.
+    // We locate the project directory relative to the test assembly's base directory.
+    private static readonly string SmokeTestProjectDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "WebDriverBiDi.AotTestApplication"));
+
+    public string PublishDir { get; private set; } = string.Empty;
+
+    public string ExecutablePath { get; private set; } = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        // Publish to a dedicated directory to avoid conflicts with regular builds.
+        // Use -p:TreatWarningsAsErrors=true to convert static AOT warnings (IL2026,
+        // IL3050, IL2090, etc.) emitted by the trim/AOT analyzers during native
+        // compilation into a build failure. There should be zero warnings; a future
+        // change that adds a reflection-based JsonSerializer.Serialize(object) call
+        // will see this test fail immediately rather than shipping an AOT-broken
+        // binary.
+        this.PublishDir = Path.Combine(SmokeTestProjectDir, "bin", "AotTestPublish");
+
+        int publishExit = await RunProcessAsync(
+            "dotnet",
+            $"publish \"{SmokeTestProjectDir}\" -c Release -o \"{this.PublishDir}\" -p:TreatWarningsAsErrors=true",
+            workingDirectory: SmokeTestProjectDir,
+            timeoutSeconds: 300);
+
+        Assert.Equal(0, publishExit);
+
+        string executableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "WebDriverBiDi.AotTestApplication.exe"
+            : "WebDriverBiDi.AotTestApplication";
+        this.ExecutablePath = Path.Combine(this.PublishDir, executableName);
+
+        Assert.True(File.Exists(this.ExecutablePath));
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    internal static async Task<int> RunProcessAsync(string fileName, string arguments, string workingDirectory, int timeoutSeconds)
+    {
+        using Process process = new();
+        process.StartInfo.FileName = fileName;
+        process.StartInfo.Arguments = arguments;
+        process.StartInfo.WorkingDirectory = workingDirectory;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.CreateNoWindow = true;
+
+        process.Start();
+
+        // Read stdout/stderr concurrently to avoid deadlocks.
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+        bool exited = await Task.Run(() => process.WaitForExit(timeoutSeconds * 1000));
+
+        string stdout = await stdoutTask;
+        string stderr = await stderrTask;
+
+        TestContext.Current.SendDiagnosticMessage($"[{Path.GetFileName(fileName)}] stdout:\n{stdout}");
+        if (!string.IsNullOrWhiteSpace(stderr))
+        {
+            TestContext.Current.SendDiagnosticMessage($"[{Path.GetFileName(fileName)}] stderr:\n{stderr}");
+        }
+
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new XunitException($"Process '{fileName}' timed out after {timeoutSeconds}s.");
+        }
+
+        return process.ExitCode;
+    }
+}

--- a/test/WebDriverBiDi.Integration.Tests/AotCompilationEnvironmentTests.cs
+++ b/test/WebDriverBiDi.Integration.Tests/AotCompilationEnvironmentTests.cs
@@ -3,14 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-namespace WebDriverBiDi.Integration;
+namespace WebDriverBiDi.Integration.Tests;
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using PinchHitter;
 
-[TestFixture]
-public class AotCompilationEnvironmentTests
+public class AotCompilationEnvironmentTests : IAsyncLifetime
 {
     // The AOT test application must be published as a native binary at test time.
     // We locate the project directory relative to the test assembly's base directory.
@@ -19,9 +18,7 @@ public class AotCompilationEnvironmentTests
 
     private static string publishDir = string.Empty;
     private static string executablePath = string.Empty;
-
-    [OneTimeSetUp]
-    public async Task PublishAotBinaryAsync()
+    public async ValueTask InitializeAsync()
     {
         // Publish to a dedicated directory to avoid conflicts with regular builds.
         // Use -p:TreatWarningsAsErrors=true to convert static AOT warnings (IL2026,
@@ -38,18 +35,19 @@ public class AotCompilationEnvironmentTests
             workingDirectory: SmokeTestProjectDir,
             timeoutSeconds: 300);
 
-        Assert.That(publishExit, Is.EqualTo(0), "dotnet publish of AotTestApplication failed.");
+        Assert.Equal(0, publishExit);
 
         string executableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? "WebDriverBiDi.AotTestApplication.exe"
             : "WebDriverBiDi.AotTestApplication";
         executablePath = Path.Combine(publishDir, executableName);
 
-        Assert.That(File.Exists(executablePath), Is.True, $"Published AOT executable not found at: {executablePath}");
+        Assert.True(File.Exists(executablePath));
     }
 
-    [TestCase(TestBrowser.Firefox)]
-    [TestCase(TestBrowser.Chrome)]
+    [Theory]
+    [InlineData(TestBrowser.Firefox)]
+    [InlineData(TestBrowser.Chrome)]
     public async Task TestCanExecuteInAotCompilationEnvironment(TestBrowser browser)
     {
         // Ensure the browser is available before running each test
@@ -69,8 +67,10 @@ public class AotCompilationEnvironmentTests
             workingDirectory: publishDir,
             timeoutSeconds: 120);
 
-        Assert.That(runExit, Is.Zero, $"AotTestApplication ({testUrl}) exited with non-zero exit code.");
+        Assert.Equal(0, runExit);
     }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static async Task<int> RunProcessAsync(string fileName, string arguments, string workingDirectory, int timeoutSeconds)
     {
@@ -94,16 +94,16 @@ public class AotCompilationEnvironmentTests
         string stdout = await stdoutTask;
         string stderr = await stderrTask;
 
-        TestContext.Out.WriteLine($"[{Path.GetFileName(fileName)}] stdout:\n{stdout}");
+        TestContext.Current.SendDiagnosticMessage($"[{Path.GetFileName(fileName)}] stdout:\n{stdout}");
         if (!string.IsNullOrWhiteSpace(stderr))
         {
-            TestContext.Error.WriteLine($"[{Path.GetFileName(fileName)}] stderr:\n{stderr}");
+            TestContext.Current.SendDiagnosticMessage($"[{Path.GetFileName(fileName)}] stderr:\n{stderr}");
         }
 
         if (!exited)
         {
             process.Kill(entireProcessTree: true);
-            Assert.Fail($"Process '{fileName}' timed out after {timeoutSeconds}s.");
+            throw new Xunit.Sdk.XunitException($"Process '{fileName}' timed out after {timeoutSeconds}s.");
         }
 
         return process.ExitCode;

--- a/test/WebDriverBiDi.Integration.Tests/AotCompilationEnvironmentTests.cs
+++ b/test/WebDriverBiDi.Integration.Tests/AotCompilationEnvironmentTests.cs
@@ -5,44 +5,15 @@
 
 namespace WebDriverBiDi.Integration.Tests;
 
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using PinchHitter;
 
-public class AotCompilationEnvironmentTests : IAsyncLifetime
+public class AotCompilationEnvironmentTests : IClassFixture<AotCompilationEnvironmentFixture>
 {
-    // The AOT test application must be published as a native binary at test time.
-    // We locate the project directory relative to the test assembly's base directory.
-    private static readonly string SmokeTestProjectDir = Path.GetFullPath(
-        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "WebDriverBiDi.AotTestApplication"));
+    private readonly AotCompilationEnvironmentFixture fixture;
 
-    private static string publishDir = string.Empty;
-    private static string executablePath = string.Empty;
-    public async ValueTask InitializeAsync()
+    public AotCompilationEnvironmentTests(AotCompilationEnvironmentFixture fixture)
     {
-        // Publish to a dedicated directory to avoid conflicts with regular builds.
-        // Use -p:TreatWarningsAsErrors=true to convert static AOT warnings (IL2026,
-        // IL3050, IL2090, etc.) emitted by the trim/AOT analyzers during native
-        // compilation into a build failure. There should be zero warnings; a future
-        // change that adds a reflection-based JsonSerializer.Serialize(object) call
-        // will see this test fail immediately rather than shipping an AOT-broken
-        // binary.
-        publishDir = Path.Combine(SmokeTestProjectDir, "bin", "AotTestPublish");
-
-        int publishExit = await RunProcessAsync(
-            "dotnet",
-            $"publish \"{SmokeTestProjectDir}\" -c Release -o \"{publishDir}\" -p:TreatWarningsAsErrors=true",
-            workingDirectory: SmokeTestProjectDir,
-            timeoutSeconds: 300);
-
-        Assert.Equal(0, publishExit);
-
-        string executableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "WebDriverBiDi.AotTestApplication.exe"
-            : "WebDriverBiDi.AotTestApplication";
-        executablePath = Path.Combine(publishDir, executableName);
-
-        Assert.True(File.Exists(executablePath));
+        this.fixture = fixture;
     }
 
     [Theory]
@@ -61,51 +32,12 @@ public class AotCompilationEnvironmentTests : IAsyncLifetime
         string browserArg = BrowserTestHelper.ToBrowserString(browser);
         string testUrl = $"{browserArg} http://localhost:{server.Port}/test";
 
-        int runExit = await RunProcessAsync(
-            executablePath,
+        int runExit = await AotCompilationEnvironmentFixture.RunProcessAsync(
+            this.fixture.ExecutablePath,
             testUrl,
-            workingDirectory: publishDir,
+            workingDirectory: this.fixture.PublishDir,
             timeoutSeconds: 120);
 
         Assert.Equal(0, runExit);
-    }
-
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-    private static async Task<int> RunProcessAsync(string fileName, string arguments, string workingDirectory, int timeoutSeconds)
-    {
-        using Process process = new();
-        process.StartInfo.FileName = fileName;
-        process.StartInfo.Arguments = arguments;
-        process.StartInfo.WorkingDirectory = workingDirectory;
-        process.StartInfo.UseShellExecute = false;
-        process.StartInfo.RedirectStandardOutput = true;
-        process.StartInfo.RedirectStandardError = true;
-        process.StartInfo.CreateNoWindow = true;
-
-        process.Start();
-
-        // Read stdout/stderr concurrently to avoid deadlocks.
-        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
-        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-
-        bool exited = await Task.Run(() => process.WaitForExit(timeoutSeconds * 1000));
-
-        string stdout = await stdoutTask;
-        string stderr = await stderrTask;
-
-        TestContext.Current.SendDiagnosticMessage($"[{Path.GetFileName(fileName)}] stdout:\n{stdout}");
-        if (!string.IsNullOrWhiteSpace(stderr))
-        {
-            TestContext.Current.SendDiagnosticMessage($"[{Path.GetFileName(fileName)}] stderr:\n{stderr}");
-        }
-
-        if (!exited)
-        {
-            process.Kill(entireProcessTree: true);
-            throw new Xunit.Sdk.XunitException($"Process '{fileName}' timed out after {timeoutSeconds}s.");
-        }
-
-        return process.ExitCode;
     }
 }

--- a/test/WebDriverBiDi.Integration.Tests/BrowserTestHelper.cs
+++ b/test/WebDriverBiDi.Integration.Tests/BrowserTestHelper.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-namespace WebDriverBiDi.Integration;
+namespace WebDriverBiDi.Integration.Tests;
 
 using WebDriverBiDi.Client.Launchers;
 
@@ -31,7 +31,7 @@ public static class BrowserTestHelper
             string executablePath = GetBrowserExecutable(browser);
             if (string.IsNullOrEmpty(executablePath))
             {
-                Assert.Ignore($"Skipping {browser} test in CI - {GetExecutableEnvironmentVariable(browser)} not configured");
+                Assert.Skip($"Skipping {browser} test in CI - {GetExecutableEnvironmentVariable(browser)} not configured");
             }
         }
     }

--- a/test/WebDriverBiDi.Integration.Tests/DriverIntegrationTests.cs
+++ b/test/WebDriverBiDi.Integration.Tests/DriverIntegrationTests.cs
@@ -1,4 +1,4 @@
-namespace WebDriverBiDi.Integration;
+namespace WebDriverBiDi.Integration.Tests;
 
 using System.Net;
 using PinchHitter;
@@ -9,11 +9,11 @@ using WebDriverBiDi.Input;
 using WebDriverBiDi.Script;
 using WebDriverBiDi.Session;
 
-[TestFixture]
 public class DriverIntegrationTests
 {
-    [TestCase(TestBrowser.Firefox)]
-    [TestCase(TestBrowser.Chrome)]
+    [Theory]
+    [InlineData(TestBrowser.Firefox)]
+    [InlineData(TestBrowser.Chrome)]
     public async Task TestCanNavigate(TestBrowser browser)
     {
         // Ensure the browser is available before running each test
@@ -27,7 +27,7 @@ public class DriverIntegrationTests
 
         string navigatedUrl = string.Empty;
         await using EventObserver<NavigationEventArgs> navigationObserver = driver.BrowsingContext.OnLoad.AddObserver(e => navigatedUrl = e.Url);
-        await driver.Session.SubscribeAsync(new SubscribeCommandParameters(driver.BrowsingContext.OnLoad.EventName));
+        await driver.Session.SubscribeAsync(new SubscribeCommandParameters(driver.BrowsingContext.OnLoad.EventName), cancellationToken: TestContext.Current.CancellationToken);
 
         string browsingContextId = await this.GetBrowsingContext(driver);
 
@@ -36,19 +36,20 @@ public class DriverIntegrationTests
         {
             Wait = ReadinessState.Complete
         };
-        await driver.BrowsingContext.NavigateAsync(navigateParams);
+        await driver.BrowsingContext.NavigateAsync(navigateParams, cancellationToken: TestContext.Current.CancellationToken);
 
-        Task[] capturedTasks = await navigationObserver.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5));
-        Assert.That(capturedTasks, Has.Length.EqualTo(1));
-        Assert.That(navigatedUrl, Is.EqualTo($"http://localhost:{server.Port}/index.html"));
+        Task[] capturedTasks = await navigationObserver.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Assert.Single(capturedTasks);
+        Assert.Equal($"http://localhost:{server.Port}/index.html", navigatedUrl);
 
         // Attempt to gracefully close the browser. If the test fails, the
         // browser process will be cleaned up when the launcher is disposed.
-        await driver.Browser.CloseAsync();
+        await driver.Browser.CloseAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [TestCase(TestBrowser.Firefox)]
-    [TestCase(TestBrowser.Chrome)]
+    [Theory]
+    [InlineData(TestBrowser.Firefox)]
+    [InlineData(TestBrowser.Chrome)]
     public async Task TestCanExecuteScript(TestBrowser browser)
     {
         // Ensure the browser is available before running each test
@@ -65,7 +66,7 @@ public class DriverIntegrationTests
         {
             Wait = ReadinessState.Complete
         };
-        await driver.BrowsingContext.NavigateAsync(navigateParams);
+        await driver.BrowsingContext.NavigateAsync(navigateParams, cancellationToken: TestContext.Current.CancellationToken);
 
         string functionDefinition = "(first, second) => first + second";
         List<LocalValue> arguments =
@@ -77,20 +78,21 @@ public class DriverIntegrationTests
         CallFunctionCommandParameters callFunctionParams = new(functionDefinition, new ContextTarget(browsingContextId), true);
         callFunctionParams.Arguments.AddRange(arguments);
 
-        EvaluateResult scriptResult = await driver.Script.CallFunctionAsync(callFunctionParams);
-        Assert.That(scriptResult, Is.InstanceOf<EvaluateResultSuccess>());
+        EvaluateResult scriptResult = await driver.Script.CallFunctionAsync(callFunctionParams, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.IsType<EvaluateResultSuccess>(scriptResult);
         EvaluateResultSuccess successResult = (EvaluateResultSuccess)scriptResult;
-        Assert.That(successResult.Result, Is.InstanceOf<NumberRemoteValue>());
+        Assert.IsType<NumberRemoteValue>(successResult.Result);
         NumberRemoteValue resultValue = (NumberRemoteValue)successResult.Result;
-        Assert.That(resultValue.ToInt(), Is.EqualTo(8));
+        Assert.Equal(8, resultValue.ToInt());
 
         // Attempt to gracefully close the browser. If the test fails, the
         // browser process will be cleaned up when the launcher is disposed.
-        await driver.Browser.CloseAsync();
+        await driver.Browser.CloseAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [TestCase(TestBrowser.Firefox)]
-    [TestCase(TestBrowser.Chrome)]
+    [Theory]
+    [InlineData(TestBrowser.Firefox)]
+    [InlineData(TestBrowser.Chrome)]
     public async Task TestCanClickLink(TestBrowser browser)
     {
         // Ensure the browser is available before running each test
@@ -107,15 +109,15 @@ public class DriverIntegrationTests
         {
             Wait = ReadinessState.Complete
         };
-        await driver.BrowsingContext.NavigateAsync(navigateParams);
-        await driver.Session.SubscribeAsync(new SubscribeCommandParameters(driver.BrowsingContext.OnLoad.EventName));
+        await driver.BrowsingContext.NavigateAsync(navigateParams, cancellationToken: TestContext.Current.CancellationToken);
+        await driver.Session.SubscribeAsync(new SubscribeCommandParameters(driver.BrowsingContext.OnLoad.EventName), cancellationToken: TestContext.Current.CancellationToken);
 
         string navigatedUrl = string.Empty;
         await using EventObserver<NavigationEventArgs> navigationObserver = driver.BrowsingContext.OnLoad.AddObserver(e => navigatedUrl = e.Url);
 
         LocateNodesCommandParameters locateNodesParams = new(browsingContextId, new CssLocator("a"));
-        LocateNodesCommandResult locateResult = await driver.BrowsingContext.LocateNodesAsync(locateNodesParams);
-        Assert.That(locateResult.Nodes, Has.Count.EqualTo(1));
+        LocateNodesCommandResult locateResult = await driver.BrowsingContext.LocateNodesAsync(locateNodesParams, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Single(locateResult.Nodes);
 
         NodeRemoteValue nodeRemoteValue = locateResult.Nodes[0];
         SharedReference elementReference = nodeRemoteValue.ToSharedReference();
@@ -125,19 +127,20 @@ public class DriverIntegrationTests
         inputBuilder.AddClickOnElementAction(elementReference);
         PerformActionsCommandParameters actionsParams = new(browsingContextId);
         actionsParams.Actions.AddRange(inputBuilder.Build());
-        await driver.Input.PerformActionsAsync(actionsParams);
+        await driver.Input.PerformActionsAsync(actionsParams, cancellationToken: TestContext.Current.CancellationToken);
 
-        Task[] capturedTasks = await navigationObserver.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5));
-        Assert.That(capturedTasks, Has.Length.EqualTo(1));
-        Assert.That(navigatedUrl, Is.EqualTo($"http://localhost:{server.Port}/details.html"));
+        Task[] capturedTasks = await navigationObserver.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Assert.Single(capturedTasks);
+        Assert.Equal($"http://localhost:{server.Port}/details.html", navigatedUrl);
 
         // Attempt to gracefully close the browser. If the test fails, the
         // browser process will be cleaned up when the launcher is disposed.
-        await driver.Browser.CloseAsync();
+        await driver.Browser.CloseAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [TestCase(TestBrowser.Firefox)]
-    [TestCase(TestBrowser.Chrome)]
+    [Theory]
+    [InlineData(TestBrowser.Firefox)]
+    [InlineData(TestBrowser.Chrome)]
     public async Task TestCanSubmitForm(TestBrowser browser)
     {
         // Ensure the browser is available before running each test
@@ -154,15 +157,15 @@ public class DriverIntegrationTests
         {
             Wait = ReadinessState.Complete
         };
-        await driver.BrowsingContext.NavigateAsync(navigateParams);
-        await driver.Session.SubscribeAsync(new SubscribeCommandParameters(driver.BrowsingContext.OnLoad.EventName));
+        await driver.BrowsingContext.NavigateAsync(navigateParams, cancellationToken: TestContext.Current.CancellationToken);
+        await driver.Session.SubscribeAsync(new SubscribeCommandParameters(driver.BrowsingContext.OnLoad.EventName), cancellationToken: TestContext.Current.CancellationToken);
 
         string navigatedUrl = string.Empty;
         await using EventObserver<NavigationEventArgs> navigationObserver = driver.BrowsingContext.OnLoad.AddObserver(e => navigatedUrl = e.Url);
 
         LocateNodesCommandParameters locateNodesParams = new(browsingContextId, new CssLocator("input#dataToSend"));
-        LocateNodesCommandResult locateResult = await driver.BrowsingContext.LocateNodesAsync(locateNodesParams);
-        Assert.That(locateResult.Nodes, Has.Count.EqualTo(1));
+        LocateNodesCommandResult locateResult = await driver.BrowsingContext.LocateNodesAsync(locateNodesParams, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Single(locateResult.Nodes);
 
         NodeRemoteValue nodeRemoteValue = locateResult.Nodes[0];
         SharedReference elementReference = nodeRemoteValue.ToSharedReference();
@@ -173,11 +176,11 @@ public class DriverIntegrationTests
         inputBuilder.AddSendKeysToActiveElementAction("Hello WebDriver BiDi" + Keys.Enter);
         PerformActionsCommandParameters actionsParams = new(browsingContextId);
         actionsParams.Actions.AddRange(inputBuilder.Build());
-        await driver.Input.PerformActionsAsync(actionsParams);
+        await driver.Input.PerformActionsAsync(actionsParams, cancellationToken: TestContext.Current.CancellationToken);
 
-        Task[] capturedTasks = await navigationObserver.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5));
-        Assert.That(capturedTasks, Has.Length.EqualTo(1));
-        Assert.That(navigatedUrl, Is.EqualTo($"http://localhost:{server.Port}/processForm"));
+        Task[] capturedTasks = await navigationObserver.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Assert.Single(capturedTasks);
+        Assert.Equal($"http://localhost:{server.Port}/processForm", navigatedUrl);
 
         LocateNodesCommandParameters locateFormResultParams = new(browsingContextId, new CssLocator("span"))
         {
@@ -186,19 +189,19 @@ public class DriverIntegrationTests
                 MaxDomDepth = SerializationOptions.InfiniteMaxDomDepth,
             },
         };
-        LocateNodesCommandResult locateFormResult = await driver.BrowsingContext.LocateNodesAsync(locateFormResultParams);
-        Assert.That(locateFormResult.Nodes, Has.Count.EqualTo(1));
+        LocateNodesCommandResult locateFormResult = await driver.BrowsingContext.LocateNodesAsync(locateFormResultParams, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Single(locateFormResult.Nodes);
 
         NodeRemoteValue resultNodeRemoteValue = locateFormResult.Nodes[0];
         NodeProperties resultNodeProperties = resultNodeRemoteValue.GetNodeProperties();
-        Assert.That(resultNodeProperties.Children, Is.Not.Null);
-        Assert.That(resultNodeProperties.Children, Has.Count.EqualTo(1));
+        Assert.NotNull(resultNodeProperties.Children);
+        Assert.Single(resultNodeProperties.Children);
         NodeRemoteValue textContentValue = resultNodeProperties.Children[0];
-        Assert.That(textContentValue.GetNodeProperties().NodeValue, Is.EqualTo("Hello WebDriver BiDi"));
+        Assert.Equal("Hello WebDriver BiDi", textContentValue.GetNodeProperties().NodeValue);
 
         // Attempt to gracefully close the browser. If the test fails, the
         // browser process will be cleaned up when the launcher is disposed.
-        await driver.Browser.CloseAsync();
+        await driver.Browser.CloseAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
     private async Task<string> GetBrowsingContext(BiDiDriver driver)

--- a/test/WebDriverBiDi.Integration.Tests/Usings.cs
+++ b/test/WebDriverBiDi.Integration.Tests/Usings.cs
@@ -1,1 +1,1 @@
-global using NUnit.Framework;
+global using Xunit;

--- a/test/WebDriverBiDi.Integration.Tests/WebDriverBiDi.Integration.Tests.csproj
+++ b/test/WebDriverBiDi.Integration.Tests/WebDriverBiDi.Integration.Tests.csproj
@@ -8,19 +8,11 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <EnableNUnitRunner>true</EnableNUnitRunner>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="PinchHitter" Version="0.0.19" />
   </ItemGroup>
 

--- a/test/WebDriverBiDi.Logging.Tests/CollectionDefinitions.cs
+++ b/test/WebDriverBiDi.Logging.Tests/CollectionDefinitions.cs
@@ -1,0 +1,11 @@
+// <copyright file="CollectionDefinitions.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Logging;
+
+[CollectionDefinition("NonParallel", DisableParallelization = true)]
+public class NonParallelCollectionDefinition
+{
+}

--- a/test/WebDriverBiDi.Logging.Tests/Usings.cs
+++ b/test/WebDriverBiDi.Logging.Tests/Usings.cs
@@ -1,3 +1,1 @@
-global using NUnit.Framework;
-
-[assembly: NonParallelizable]
+global using Xunit;

--- a/test/WebDriverBiDi.Logging.Tests/WebDriverBiDi.Logging.Tests.csproj
+++ b/test/WebDriverBiDi.Logging.Tests/WebDriverBiDi.Logging.Tests.csproj
@@ -9,20 +9,12 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <EnableNUnitRunner>true</EnableNUnitRunner>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="coverlet.MTP" Version="10.0.1" />
   </ItemGroup>
 

--- a/test/WebDriverBiDi.Logging.Tests/WebDriverBiDiEventSourceLoggerTests.cs
+++ b/test/WebDriverBiDi.Logging.Tests/WebDriverBiDiEventSourceLoggerTests.cs
@@ -7,22 +7,21 @@ using Microsoft.Extensions.Logging;
 using WebDriverBiDi;
 using WebDriverBiDi.Logging.TestUtilities;
 
-[TestFixture]
-[NonParallelizable]
+[Collection("NonParallel")]
 public class WebDriverBiDiEventSourceLoggerTests
 {
     private static TestLogger.LogEntry GetLastEntryForEvent(TestLogger logger, string eventName)
     {
-        return logger.Entries.Where(e => e.EventId.Name == eventName).Last();
+        return logger.Entries.Last(e => e.EventId.Name == eventName);
     }
 
-    [Test]
+    [Fact]
     public void Constructor_WhenLoggerIsNull_ThrowsArgumentNullException()
     {
-        Assert.That(() => new WebDriverBiDiEventSourceLogger(null!), Throws.ArgumentNullException);
+        Assert.Throws<ArgumentNullException>(() => new WebDriverBiDiEventSourceLogger(null!));
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_ForwardsInformationalEventToLogger()
     {
         TestLogger fakeLogger = new();
@@ -32,15 +31,15 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "ConnectionOpening");
-        Assert.That(entry.LogLevel, Is.EqualTo(LogLevel.Information));
-        Assert.That(entry.EventId.Id, Is.EqualTo(1));
-        Assert.That(entry.EventId.Name, Is.EqualTo("ConnectionOpening"));
-        Assert.That(entry.Message, Does.Contain("ConnectionOpening"));
-        Assert.That(entry.Message, Does.Contain("conn-123"));
-        Assert.That(entry.Message, Does.Contain("ws://localhost:9222"));
+        Assert.Equal(LogLevel.Information, entry.LogLevel);
+        Assert.Equal(1, entry.EventId.Id);
+        Assert.Equal("ConnectionOpening", entry.EventId.Name);
+        Assert.Contains("ConnectionOpening", entry.Message);
+        Assert.Contains("conn-123", entry.Message);
+        Assert.Contains("ws://localhost:9222", entry.Message);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_ForwardsVerboseEventAsDebugLevel()
     {
         TestLogger fakeLogger = new();
@@ -50,11 +49,11 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "CommandSending");
-        Assert.That(entry.LogLevel, Is.EqualTo(LogLevel.Debug));
-        Assert.That(entry.EventId.Name, Is.EqualTo("CommandSending"));
+        Assert.Equal(LogLevel.Debug, entry.LogLevel);
+        Assert.Equal("CommandSending", entry.EventId.Name);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_ForwardsWarningEventAsWarningLevel()
     {
         TestLogger fakeLogger = new();
@@ -64,11 +63,11 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "CommandTimeout");
-        Assert.That(entry.LogLevel, Is.EqualTo(LogLevel.Warning));
-        Assert.That(entry.EventId.Name, Is.EqualTo("CommandTimeout"));
+        Assert.Equal(LogLevel.Warning, entry.LogLevel);
+        Assert.Equal("CommandTimeout", entry.EventId.Name);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_ForwardsErrorEventAsErrorLevel()
     {
         TestLogger fakeLogger = new();
@@ -78,11 +77,11 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "ConnectionError");
-        Assert.That(entry.LogLevel, Is.EqualTo(LogLevel.Error));
-        Assert.That(entry.EventId.Name, Is.EqualTo("ConnectionError"));
+        Assert.Equal(LogLevel.Error, entry.LogLevel);
+        Assert.Equal("ConnectionError", entry.EventId.Name);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_IncludesPayloadInState()
     {
         TestLogger fakeLogger = new();
@@ -92,17 +91,17 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "ConnectionOpening");
-        Assert.That(entry.State, Is.InstanceOf<Dictionary<string, object?>>());
+        Assert.IsType<Dictionary<string, object?>>(entry.State);
 
         Dictionary<string, object?> state = (Dictionary<string, object?>)entry.State!;
-        Assert.That(state["EventId"], Is.EqualTo(1));
-        Assert.That(state["EventName"], Is.EqualTo("ConnectionOpening"));
-        Assert.That(state["EventSource"], Is.EqualTo("WebDriverBiDi"));
-        Assert.That(state["connectionId"], Is.EqualTo("conn-456"));
-        Assert.That(state["url"], Is.EqualTo("ws://example.com"));
+        Assert.Equal(1, state["EventId"]);
+        Assert.Equal("ConnectionOpening", state["EventName"]);
+        Assert.Equal("WebDriverBiDi", state["EventSource"]);
+        Assert.Equal("conn-456", state["connectionId"]);
+        Assert.Equal("ws://example.com", state["url"]);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_FormatsMessageWithEventNameAndPayload()
     {
         TestLogger fakeLogger = new();
@@ -112,11 +111,11 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "TransportStopped");
-        Assert.That(entry.Message, Does.StartWith("TransportStopped"));
-        Assert.That(entry.Message, Does.Contain("Normal shutdown"));
+        Assert.StartsWith("TransportStopped", entry.Message);
+        Assert.Contains("Normal shutdown", entry.Message);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_RespectsMinimumLevel_WhenSetToWarning()
     {
         TestLogger fakeLogger = new();
@@ -128,10 +127,10 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "CommandTimeout");
-        Assert.That(entry.EventId.Name, Is.EqualTo("CommandTimeout"));
+        Assert.Equal("CommandTimeout", entry.EventId.Name);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_RespectsMinimumLevel_WhenSetToInformational()
     {
         TestLogger fakeLogger = new();
@@ -142,10 +141,10 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "ConnectionOpening");
-        Assert.That(entry.EventId.Name, Is.EqualTo("ConnectionOpening"));
+        Assert.Equal("ConnectionOpening", entry.EventId.Name);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_HandlesEventWithMultiplePayloadProperties()
     {
         TestLogger fakeLogger = new();
@@ -156,34 +155,34 @@ public class WebDriverBiDiEventSourceLoggerTests
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "CommandError");
         Dictionary<string, object?> state = (Dictionary<string, object?>)entry.State!;
-        Assert.That(state["commandId"], Is.EqualTo("1"));
-        Assert.That(state["method"], Is.EqualTo("session.status"));
-        Assert.That(state["errorType"], Is.EqualTo("invalid session id"));
-        Assert.That(state["errorMessage"], Is.EqualTo("Session not found"));
+        Assert.Equal("1", state["commandId"]);
+        Assert.Equal("session.status", state["method"]);
+        Assert.Equal("invalid session id", state["errorType"]);
+        Assert.Equal("Session not found", state["errorMessage"]);
     }
 
-    [Test]
+    [Fact]
     public void MapEventLevel_MapsCriticalToLogLevelCritical()
     {
         LogLevel result = InvokeMapEventLevel(EventLevel.Critical);
-        Assert.That(result, Is.EqualTo(LogLevel.Critical));
+        Assert.Equal(LogLevel.Critical, result);
     }
 
-    [Test]
+    [Fact]
     public void MapEventLevel_MapsLogAlwaysToLogLevelInformation()
     {
         LogLevel result = InvokeMapEventLevel(EventLevel.LogAlways);
-        Assert.That(result, Is.EqualTo(LogLevel.Information));
+        Assert.Equal(LogLevel.Information, result);
     }
 
-    [Test]
+    [Fact]
     public void MapEventLevel_MapsUnknownLevelToLogLevelTrace()
     {
         LogLevel result = InvokeMapEventLevel((EventLevel)99);
-        Assert.That(result, Is.EqualTo(LogLevel.Trace));
+        Assert.Equal(LogLevel.Trace, result);
     }
 
-    [Test]
+    [Fact]
     public void FormatMessage_ReturnsFallbackWhenEventNameMissing()
     {
         Dictionary<string, object?> state = new()
@@ -193,10 +192,10 @@ public class WebDriverBiDiEventSourceLoggerTests
         };
 
         string result = InvokeFormatMessage(state, null);
-        Assert.That(result, Is.EqualTo("WebDriverBiDi event"));
+        Assert.Equal("WebDriverBiDi event", result);
     }
 
-    [Test]
+    [Fact]
     public void FormatMessage_ReturnsFallbackWhenEventNameIsNotString()
     {
         Dictionary<string, object?> state = new()
@@ -207,10 +206,10 @@ public class WebDriverBiDiEventSourceLoggerTests
         };
 
         string result = InvokeFormatMessage(state, null);
-        Assert.That(result, Is.EqualTo("WebDriverBiDi event"));
+        Assert.Equal("WebDriverBiDi event", result);
     }
 
-    [Test]
+    [Fact]
     public void FormatMessage_SkipsNullPayloadValues()
     {
         Dictionary<string, object?> state = new()
@@ -223,9 +222,9 @@ public class WebDriverBiDiEventSourceLoggerTests
         };
 
         string result = InvokeFormatMessage(state, null);
-        Assert.That(result, Does.Contain("TestEvent"));
-        Assert.That(result, Does.Contain("Key1=value1"));
-        Assert.That(result, Does.Not.Contain("Key2"));
+        Assert.Contains("TestEvent", result);
+        Assert.Contains("Key1=value1", result);
+        Assert.DoesNotContain("Key2", result);
     }
 
     private static LogLevel InvokeMapEventLevel(EventLevel level)
@@ -244,7 +243,7 @@ public class WebDriverBiDiEventSourceLoggerTests
         return (string)method.Invoke(null, new object?[] { state, exception })!;
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_IgnoresEventsFromNonWebDriverBiDiEventSource()
     {
         TestLogger fakeLogger = new();
@@ -256,18 +255,18 @@ public class WebDriverBiDiEventSourceLoggerTests
             TestEventSource.Log.EmitTestEvent();
         }
 
-        Assert.That(capturedArgs, Is.Not.Null);
-        Assert.That(capturedArgs!.EventSource.Name, Is.Not.EqualTo("WebDriverBiDi"));
+        Assert.NotNull(capturedArgs);
+        Assert.NotEqual("WebDriverBiDi", capturedArgs!.EventSource.Name);
 
         MethodInfo onEventWritten = typeof(WebDriverBiDiEventSourceLogger).GetMethod(
             "OnEventWritten",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
         onEventWritten.Invoke(eventSourceLogger, new object[] { capturedArgs });
 
-        Assert.That(fakeLogger.Entries, Is.Empty);
+        Assert.Empty(fakeLogger.Entries);
     }
 
-    [Test]
+    [Fact]
     public void OnEventWritten_HandlesEventWithNullPayload()
     {
         TestLogger fakeLogger = new();
@@ -277,10 +276,10 @@ public class WebDriverBiDiEventSourceLoggerTests
         }
 
         TestLogger.LogEntry entry = GetLastEntryForEvent(fakeLogger, "ConnectionClosed");
-        Assert.That(entry.State, Is.InstanceOf<Dictionary<string, object?>>());
+        Assert.IsType<Dictionary<string, object?>>(entry.State);
         Dictionary<string, object?> state = (Dictionary<string, object?>)entry.State!;
-        Assert.That(state["EventId"], Is.EqualTo(4));
-        Assert.That(state["EventName"], Is.EqualTo("ConnectionClosed"));
+        Assert.Equal(4, state["EventId"]);
+        Assert.Equal("ConnectionClosed", state["EventName"]);
     }
 
     [EventSource(Name = "TestWebDriverBiDiLogger")]
@@ -303,7 +302,6 @@ public class WebDriverBiDiEventSourceLoggerTests
 
         public void EmitTestEvent() => this.TestEvent();
     }
-
 
     private sealed class TestEventListenerForOtherSource : EventListener
     {

--- a/test/WebDriverBiDi.Logging.Tests/WebDriverBiDiLoggingExtensionsTests.cs
+++ b/test/WebDriverBiDi.Logging.Tests/WebDriverBiDiLoggingExtensionsTests.cs
@@ -7,27 +7,26 @@ using Microsoft.Extensions.Logging;
 using WebDriverBiDi;
 using WebDriverBiDi.Logging.TestUtilities;
 
-[TestFixture]
-[NonParallelizable]
+[Collection("NonParallel")]
 public class WebDriverBiDiLoggingExtensionsTests
 {
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_WhenBuilderIsNull_ThrowsArgumentNullException()
     {
         ILoggingBuilder? builder = null;
 
-        Assert.That(() => builder!.AddWebDriverBiDi(), Throws.ArgumentNullException);
+        Assert.Throws<ArgumentNullException>(() => builder!.AddWebDriverBiDi());
     }
 
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_WithMinimumLevel_WhenBuilderIsNull_ThrowsArgumentNullException()
     {
         ILoggingBuilder? builder = null;
 
-        Assert.That(() => builder!.AddWebDriverBiDi(EventLevel.Verbose), Throws.ArgumentNullException);
+        Assert.Throws<ArgumentNullException>(() => builder!.AddWebDriverBiDi(EventLevel.Verbose));
     }
 
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_ReturnsBuilderForChaining()
     {
         ServiceCollection services = new();
@@ -35,10 +34,10 @@ public class WebDriverBiDiLoggingExtensionsTests
 
         ILoggingBuilder result = builder.AddWebDriverBiDi();
 
-        Assert.That(result, Is.SameAs(builder));
+        Assert.Same(builder, result);
     }
 
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_WithMinimumLevel_ReturnsBuilderForChaining()
     {
         ServiceCollection services = new();
@@ -46,10 +45,10 @@ public class WebDriverBiDiLoggingExtensionsTests
 
         ILoggingBuilder result = builder.AddWebDriverBiDi(EventLevel.Warning);
 
-        Assert.That(result, Is.SameAs(builder));
+        Assert.Same(builder, result);
     }
 
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_RegistersWebDriverBiDiEventSourceLogger()
     {
         ServiceCollection services = new();
@@ -57,11 +56,11 @@ public class WebDriverBiDiLoggingExtensionsTests
         using (ServiceProvider provider = services.BuildServiceProvider())
         {
             WebDriverBiDiEventSourceLogger? logger = provider.GetService<WebDriverBiDiEventSourceLogger>();
-            Assert.That(logger, Is.Not.Null);
+            Assert.NotNull(logger);
         }
     }
 
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_RegistersAsSingleton()
     {
         ServiceCollection services = new();
@@ -70,11 +69,11 @@ public class WebDriverBiDiLoggingExtensionsTests
         {
             WebDriverBiDiEventSourceLogger first = provider.GetRequiredService<WebDriverBiDiEventSourceLogger>();
             WebDriverBiDiEventSourceLogger second = provider.GetRequiredService<WebDriverBiDiEventSourceLogger>();
-            Assert.That(first, Is.SameAs(second));
+            Assert.Same(second, first);
         }
     }
 
-    [Test]
+    [Fact]
     public void AddWebDriverBiDi_WithMinimumLevel_RegistersLoggerWithCorrectLevel()
     {
         ServiceCollection services = new();
@@ -96,7 +95,7 @@ public class WebDriverBiDiLoggingExtensionsTests
         TestLogger.LogEntry entry = fakeLogger.Entries
             .Where(e => e.EventId.Name == "CommandTimeout")
             .Last();
-        Assert.That(entry.EventId.Name, Is.EqualTo("CommandTimeout"));
+        Assert.Equal("CommandTimeout", entry.EventId.Name);
     }
 
     /// <summary>

--- a/test/WebDriverBiDi.NamedPipeTestApplication/Program.cs
+++ b/test/WebDriverBiDi.NamedPipeTestApplication/Program.cs
@@ -25,6 +25,7 @@ _ = Task.Run(() =>
 byte[] buffer = new byte[16 * 1024]; // 16 KB buffer
 
 using MemoryStream memoryStream = new();
+
 _ = Task.Run(async () =>
 {
     while (!cancellationSource.IsCancellationRequested)

--- a/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
+++ b/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
@@ -32,7 +32,7 @@ public class BiDiDriverTests
         {
             ReturnCustomValue = true
         };
-        
+
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         Assert.False(driver.IsStarted);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
@@ -45,7 +45,7 @@ public class BiDiDriverTests
     public async Task TestCanExecuteCommand()
     {
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += async (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += async (sender, e) =>
         {
             string eventJson = """
                                {
@@ -65,7 +65,7 @@ public class BiDiDriverTests
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken);
+        TestCommandResult result = await driver.ExecuteCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("command result value", result.Value);
     }
 
@@ -73,7 +73,7 @@ public class BiDiDriverTests
     public async Task TestCanExecuteCommandWithError()
     {
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += async (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += async (sender, e) =>
         {
             string errorJson = """
                                {
@@ -93,7 +93,7 @@ public class BiDiDriverTests
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
-        WebDriverBiDiCommandException? caughtException = await Assert.ThrowsAsync<WebDriverBiDiCommandException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiCommandException? caughtException = await Assert.ThrowsAsync<WebDriverBiDiCommandException>(async () => await driver.ExecuteCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken));
         Assert.NotNull(caughtException);
 
         Assert.Contains("'unknown command' error executing command module.command: This is a test error message", caughtException.Message);
@@ -112,7 +112,7 @@ public class BiDiDriverTests
     public async Task TestCanExecuteCommandThatReturnsThrownExceptionThrows()
     {
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += async (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += async (sender, e) =>
         {
             string exceptionJson = """
                                    {
@@ -133,7 +133,7 @@ public class BiDiDriverTests
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
-        Assert.Contains("Response did not contain properly formed JSON for response type", (await Assert.ThrowsAnyAsync<WebDriverBiDiSerializationException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Response did not contain properly formed JSON for response type", (await Assert.ThrowsAnyAsync<WebDriverBiDiSerializationException>(async () => await driver.ExecuteCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        driver.OnUnexpectedErrorReceived.AddObserver((ErrorReceivedEventArgs e) =>
+        driver.OnUnexpectedErrorReceived.AddObserver(e =>
         {
             response = e.ErrorData;
             taskCompletionSource.TrySetResult();
@@ -181,7 +181,7 @@ public class BiDiDriverTests
         Transport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask);
-        driver.OnEventReceived.AddObserver((e) =>
+        driver.OnEventReceived.AddObserver(e =>
         {
             receivedEvent = e.EventName;
             receivedData = e.EventData;
@@ -248,7 +248,7 @@ public class BiDiDriverTests
         };
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask);
-        driver.OnEventReceived.AddObserver((e) =>
+        driver.OnEventReceived.AddObserver(e =>
         {
             receivedEvent = e.EventName;
             receivedData = e.EventData;
@@ -287,7 +287,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        driver.OnUnknownMessageReceived.AddObserver((e) =>
+        driver.OnUnknownMessageReceived.AddObserver(e =>
         {
             receivedMessage = e.Message;
             taskCompletionSource.TrySetResult();
@@ -317,7 +317,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        driver.OnUnknownMessageReceived.AddObserver((e) =>
+        driver.OnUnknownMessageReceived.AddObserver(e =>
         {
             receivedMessage = e.Message;
             taskCompletionSource.TrySetResult();
@@ -495,7 +495,7 @@ public class BiDiDriverTests
         };
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
-        Assert.Contains("was canceled before a result was received", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("was canceled before a result was received", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -507,7 +507,7 @@ public class BiDiDriverTests
         };
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
-        Assert.Contains("is unexpectedly null", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("is unexpectedly null", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -515,7 +515,7 @@ public class BiDiDriverTests
     {
         await using BiDiDriver driver = new(TimeSpan.Zero, new Transport(new TestWebSocketConnection()));
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
-        Assert.Contains("Timed out executing command test.command", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Timed out executing command test.command", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -526,7 +526,7 @@ public class BiDiDriverTests
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
-        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
 
         string lateResponse = """{"type":"success","id":1,"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(lateResponse);
@@ -544,7 +544,7 @@ public class BiDiDriverTests
         };
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
-        Assert.Equal("Could not convert error response from transport for SendCommandAndWait to ErrorResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Equal("Could not convert error response from transport for SendCommandAndWait to ErrorResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -565,7 +565,7 @@ public class BiDiDriverTests
         };
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
-        Assert.Equal("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Equal("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -576,10 +576,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(100), transport);
-        driver.OnLogMessage.AddObserver((e) =>
-        {
-            logs.Add(e);
-        });
+        driver.OnLogMessage.AddObserver(logs.Add);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseLogMessageEventAsync("test log message", WebDriverBiDiLogLevel.Warn);
         Assert.Single(logs);
@@ -632,7 +629,7 @@ public class BiDiDriverTests
             await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             List<string> driverLog = [];
-            driver.OnLogMessage.AddObserver((e) =>
+            driver.OnLogMessage.AddObserver(e =>
             {
                 if (e.Level >= WebDriverBiDiLogLevel.Error)
                 {
@@ -643,7 +640,7 @@ public class BiDiDriverTests
 
             TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             string unknownMessage = string.Empty;
-            driver.OnUnknownMessageReceived.AddObserver((e) =>
+            driver.OnUnknownMessageReceived.AddObserver(e =>
             {
                 unknownMessage = e.Message;
                 unknownMessageTaskCompletionSource.TrySetResult();
@@ -699,13 +696,13 @@ public class BiDiDriverTests
             await driver.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
             await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-            driver.BrowsingContext.OnLoad.AddObserver((e) =>
+            driver.BrowsingContext.OnLoad.AddObserver(e =>
             {
             });
 
             TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             List<string> driverLog = [];
-            driver.OnLogMessage.AddObserver((e) =>
+            driver.OnLogMessage.AddObserver(e =>
             {
                 if (e.Level >= WebDriverBiDiLogLevel.Error)
                 {
@@ -716,7 +713,7 @@ public class BiDiDriverTests
 
             TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             string unknownMessage = string.Empty;
-            driver.OnUnknownMessageReceived.AddObserver((e) =>
+            driver.OnUnknownMessageReceived.AddObserver(e =>
             {
                 unknownMessage = e.Message;
                 unknownMessageTaskCompletionSource.TrySetResult();
@@ -773,7 +770,7 @@ public class BiDiDriverTests
 
             TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             List<string> driverLog = [];
-            driver.OnLogMessage.AddObserver((e) =>
+            driver.OnLogMessage.AddObserver(e =>
             {
                 if (e.Level >= WebDriverBiDiLogLevel.Error)
                 {
@@ -784,7 +781,7 @@ public class BiDiDriverTests
 
             TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             string unknownMessage = string.Empty;
-            driver.OnUnknownMessageReceived.AddObserver((e) =>
+            driver.OnUnknownMessageReceived.AddObserver(e =>
             {
                 unknownMessage = e.Message;
                 unknownMessageTaskCompletionSource.TrySetResult();
@@ -980,7 +977,7 @@ public class BiDiDriverTests
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -991,7 +988,7 @@ public class BiDiDriverTests
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1092,7 +1089,7 @@ public class BiDiDriverTests
         TestTransport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
-        driver.OnLogMessage.AddObserver((e) =>
+        driver.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
         });
@@ -1236,7 +1233,7 @@ public class BiDiDriverTests
         cts.Cancel();
 
         TestCommandParameters commandParams = new("module.command");
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(commandParams, cancellationToken: cts.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.ExecuteCommandAsync(commandParams, cancellationToken: cts.Token));
     }
 
     [Fact]
@@ -1250,7 +1247,7 @@ public class BiDiDriverTests
         cts.Cancel();
 
         TestCommandParameters commandParams = new("module.command");
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(commandParams, TimeSpan.FromSeconds(5), cts.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.ExecuteCommandAsync(commandParams, TimeSpan.FromSeconds(5), cts.Token));
     }
 
     [Fact]
@@ -1307,7 +1304,7 @@ public class BiDiDriverTests
     public async Task TestExecuteCommandAsyncWithExplicitPositiveTimeoutSucceeds()
     {
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += async (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += async (sender, e) =>
         {
             string eventJson = """
                                {
@@ -1332,7 +1329,7 @@ public class BiDiDriverTests
     public async Task TestExecuteCommandAsyncWithInfiniteTimeoutDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += async (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += async (sender, e) =>
         {
             string eventJson = """
                                {
@@ -1597,7 +1594,7 @@ public class BiDiDriverTests
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new("module.command");
-        Task<TestCommandResult> executeTask = Task.Run(() => driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
+        Task<TestCommandResult> executeTask = Task.Run(() => driver.ExecuteCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken));
 
         await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
+++ b/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
@@ -3,7 +3,6 @@ namespace WebDriverBiDi;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
-using NUnit.Framework.Internal;
 using PinchHitter;
 using TestUtilities;
 using WebDriverBiDi.Bluetooth;
@@ -23,10 +22,9 @@ using WebDriverBiDi.Storage;
 using WebDriverBiDi.UserAgentClientHints;
 using WebDriverBiDi.WebExtension;
 
-[TestFixture]
 public class BiDiDriverTests
 {
-    [Test]
+    [Fact]
     public async Task TestCanDetermineIsStarted()
     {
         TestTransport transport = new(new TestWebSocketConnection())
@@ -34,14 +32,14 @@ public class BiDiDriverTests
             ReturnCustomValue = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        Assert.That(driver.IsStarted, Is.False);
-        await driver.StartAsync("ws:localhost");
-        Assert.That(driver.IsStarted, Is.True);
-        await driver.StopAsync();
-        Assert.That(driver.IsStarted, Is.False);
+        Assert.False(driver.IsStarted);
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(driver.IsStarted);
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(driver.IsStarted);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteCommand()
     {
         TestWebSocketConnection connection = new();
@@ -61,15 +59,15 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command);
-        Assert.That(result.Value, Is.EqualTo("command result value"));
+        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("command result value", result.Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteCommandWithError()
     {
         TestWebSocketConnection connection = new();
@@ -89,28 +87,26 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
-        WebDriverBiDiCommandException? caughtException = Assert.ThrowsAsync<WebDriverBiDiCommandException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command));
-        Assert.That(caughtException, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(caughtException!.Message, Does.Contain("'unknown command' error executing command module.command: This is a test error message"));
-            Assert.That(caughtException.ErrorCode, Is.EqualTo(ErrorCode.UnknownCommand));
-            Assert.That(caughtException.ProtocolErrorType, Is.EqualTo("unknown command"));
-            Assert.That(caughtException.ProtocolErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(caughtException.RemoteStackTrace, Is.EqualTo("remote stack trace"));
-            Assert.That(caughtException.ErrorDetails, Is.Not.Null);
-            Assert.That(caughtException.ErrorDetails.ErrorType, Is.EqualTo("unknown command"));
-            Assert.That(caughtException.ErrorDetails.ErrorCode, Is.EqualTo(ErrorCode.UnknownCommand));
-            Assert.That(caughtException.ErrorDetails.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(caughtException.ErrorDetails.StackTrace, Is.EqualTo("remote stack trace"));
-        }
+        WebDriverBiDiCommandException? caughtException = await Assert.ThrowsAsync<WebDriverBiDiCommandException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.NotNull(caughtException);
+
+        Assert.Contains("'unknown command' error executing command module.command: This is a test error message", caughtException.Message);
+        Assert.Equal(ErrorCode.UnknownCommand, caughtException.ErrorCode);
+        Assert.Equal("unknown command", caughtException.ProtocolErrorType);
+        Assert.Equal("This is a test error message", caughtException.ProtocolErrorMessage);
+        Assert.Equal("remote stack trace", caughtException.RemoteStackTrace);
+        Assert.NotNull(caughtException.ErrorDetails);
+        Assert.Equal("unknown command", caughtException.ErrorDetails.ErrorType);
+        Assert.Equal(ErrorCode.UnknownCommand, caughtException.ErrorDetails.ErrorCode);
+        Assert.Equal("This is a test error message", caughtException.ErrorDetails.ErrorMessage);
+        Assert.Equal("remote stack trace", caughtException.ErrorDetails.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteCommandThatReturnsThrownExceptionThrows()
     {
         TestWebSocketConnection connection = new();
@@ -131,14 +127,14 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command), Throws.InstanceOf<WebDriverBiDiSerializationException>().With.Message.Contains("Response did not contain properly formed JSON for response type"));
+        Assert.Contains("Response did not contain properly formed JSON for response type", (await Assert.ThrowsAnyAsync<WebDriverBiDiSerializationException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteReceiveErrorWithoutCommand()
     {
         ErrorResult? response = null;
@@ -151,7 +147,7 @@ public class BiDiDriverTests
             response = e.ErrorData;
             syncEvent.Set();
         });
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string errorJson = """
                            {
@@ -164,16 +160,14 @@ public class BiDiDriverTests
         await connection.RaiseDataReceivedEventAsync(errorJson);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
 
-        Assert.That(response, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(response!.ErrorCode, Is.EqualTo(ErrorCode.UnknownCommand));
-            Assert.That(response!.ErrorType, Is.EqualTo("unknown command"));
-            Assert.That(response.ErrorMessage, Is.EqualTo("This is a test error message"));
-        }
+        Assert.NotNull(response);
+
+        Assert.Equal(ErrorCode.UnknownCommand, response.ErrorCode);
+        Assert.Equal("unknown command", response.ErrorType);
+        Assert.Equal("This is a test error message", response.ErrorMessage);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveKnownEvent()
     {
         string receivedEvent = string.Empty;
@@ -191,7 +185,7 @@ public class BiDiDriverTests
             receivedData = e.EventData;
             syncEvent.Set();
         });
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string eventJson = """
                            {
@@ -204,39 +198,40 @@ public class BiDiDriverTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(receivedEvent, Is.EqualTo(eventName));
-            Assert.That(receivedData, Is.Not.Null);
-            Assert.That(receivedData, Is.TypeOf<TestEventArgs>());
-        }
+
+        Assert.Equal(eventName, receivedEvent);
+        Assert.NotNull(receivedData);
+        Assert.IsType<TestEventArgs>(receivedData);
+
         TestEventArgs? convertedData = receivedData as TestEventArgs;
-        Assert.That(convertedData!.ParamName, Is.EqualTo("paramValue"));
+        Assert.NotNull(convertedData);
+        Assert.Equal("paramValue", convertedData.ParamName);
     }
 
-    [Test]
-    public void TestRegisteringDuplicateEventThrows()
+    [Fact]
+    public async Task TestRegisteringDuplicateEventThrows()
     {
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask);
-        Assert.That(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask), Throws.InstanceOf<ArgumentException>().With.Message.StartsWith("An event named 'module.event' has already been registered."));
+        ArgumentException exception = Assert.ThrowsAny<ArgumentException>(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask));
+        Assert.StartsWith("An event named 'module.event' has already been registered.", exception.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisteringEventAfterStartingDriverThrows()
     {
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask), Throws.InstanceOf<InvalidOperationException>());
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.ThrowsAny<InvalidOperationException>(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask));
     }
 
-    [Test]
+    [Fact]
     public async Task TestDriverWillProcessPendingMessagesOnStop()
     {
         string receivedEvent = string.Empty;
@@ -257,7 +252,7 @@ public class BiDiDriverTests
             receivedData = e.EventData;
             syncEvent.Set();
         });
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string eventJson = """
                            {
@@ -269,19 +264,19 @@ public class BiDiDriverTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        await driver.StopAsync();
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(receivedEvent, Is.EqualTo(eventName));
-            Assert.That(receivedData, Is.Not.Null);
-            Assert.That(receivedData, Is.TypeOf<TestEventArgs>());
-        }
+
+        Assert.Equal(eventName, receivedEvent);
+        Assert.NotNull(receivedData);
+        Assert.IsType<TestEventArgs>(receivedData);
+
         TestEventArgs? convertedData = receivedData as TestEventArgs;
-        Assert.That(convertedData!.ParamName, Is.EqualTo("paramValue"));
+        Assert.NotNull(convertedData);
+        Assert.Equal("paramValue", convertedData.ParamName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestUnregisteredEventRaisesUnknownMessageEvent()
     {
         string receivedMessage = string.Empty;
@@ -295,7 +290,7 @@ public class BiDiDriverTests
             receivedMessage = e.Message;
             syncEvent.Set();
         });
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string serialized = """
                             {
@@ -308,10 +303,10 @@ public class BiDiDriverTests
                             """;
         await connection.RaiseDataReceivedEventAsync(serialized);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        Assert.That(receivedMessage, Is.EqualTo(serialized));
+        Assert.Equal(serialized, receivedMessage);
     }
 
-    [Test]
+    [Fact]
     public async Task TestUnconformingDataRaisesUnknownMessageEvent()
     {
         string receivedMessage = string.Empty;
@@ -325,7 +320,7 @@ public class BiDiDriverTests
             receivedMessage = e.Message;
             syncEvent.Set();
         });
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string serialized = """
                             {
@@ -337,10 +332,10 @@ public class BiDiDriverTests
                             """;
         await connection.RaiseDataReceivedEventAsync(serialized);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        Assert.That(receivedMessage, Is.EqualTo(serialized));
+        Assert.Equal(serialized, receivedMessage);
     }
 
-    [Test]
+    [Fact]
     public async Task TestNotificationOfEventHandlerError()
     {
         EventObserverErrorInfo? errorInfo = null;
@@ -368,7 +363,7 @@ public class BiDiDriverTests
             errorInfo = e.ErrorInfo with { };
             handlerReturnedEvent.Set();
         });
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string eventJson = """
                            {
@@ -387,101 +382,97 @@ public class BiDiDriverTests
         await connection.RaiseDataReceivedEventAsync(eventJson);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
         bool handlerReturned = handlerReturnedEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handlerReturned, Is.True);
-            Assert.That(errorInfo, Is.Not.Null);
-            Assert.That(errorInfo!.ObserverId, Is.EqualTo(browsingContextObserver.Id));
-            Assert.That(errorInfo.Exception, Is.TypeOf<InvalidOperationException>());
-            Assert.That(errorInfo.ObservableEventName, Is.EqualTo("browsingContext.contextCreated"));
-            Assert.That(errorInfo.ObserverDescription, Is.EqualTo("Test observer"));
-        }
+
+        Assert.True(handlerReturned);
+        Assert.NotNull(errorInfo);
+        Assert.Equal(browsingContextObserver.Id, errorInfo.ObserverId);
+        Assert.IsType<InvalidOperationException>(errorInfo.Exception);
+        Assert.Equal("browsingContext.contextCreated", errorInfo.ObservableEventName);
+        Assert.Equal("Test observer", errorInfo.ObserverDescription);
     }
 
-    [Test]
+    [Fact]
     public async Task TestModuleAvailability()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         try
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(driver.Bluetooth, Is.InstanceOf<BluetoothModule>());
-                Assert.That(driver.Browser, Is.InstanceOf<BrowserModule>());
-                Assert.That(driver.BrowsingContext, Is.InstanceOf<BrowsingContextModule>());
-                Assert.That(driver.DigitalCredentials, Is.InstanceOf<DigitalCredentialsModule>());
-                Assert.That(driver.Emulation, Is.InstanceOf<EmulationModule>());
-                Assert.That(driver.Input, Is.InstanceOf<InputModule>());
-                Assert.That(driver.Log, Is.InstanceOf<LogModule>());
-                Assert.That(driver.Network, Is.InstanceOf<NetworkModule>());
-                Assert.That(driver.Permissions, Is.InstanceOf<PermissionsModule>());
-                Assert.That(driver.Script, Is.InstanceOf<ScriptModule>());
-                Assert.That(driver.Session, Is.InstanceOf<SessionModule>());
-                Assert.That(driver.Speculation, Is.InstanceOf<SpeculationModule>());
-                Assert.That(driver.Storage, Is.InstanceOf<StorageModule>());
-                Assert.That(driver.UserAgentClientHints, Is.InstanceOf<UserAgentClientHintsModule>());
-                Assert.That(driver.WebExtension, Is.InstanceOf<WebExtensionModule>());
-            }
+
+            Assert.IsType<BluetoothModule>(driver.Bluetooth);
+            Assert.IsType<BrowserModule>(driver.Browser);
+            Assert.IsType<BrowsingContextModule>(driver.BrowsingContext);
+            Assert.IsType<DigitalCredentialsModule>(driver.DigitalCredentials);
+            Assert.IsType<EmulationModule>(driver.Emulation);
+            Assert.IsType<InputModule>(driver.Input);
+            Assert.IsType<LogModule>(driver.Log);
+            Assert.IsType<NetworkModule>(driver.Network);
+            Assert.IsType<PermissionsModule>(driver.Permissions);
+            Assert.IsType<ScriptModule>(driver.Script);
+            Assert.IsType<SessionModule>(driver.Session);
+            Assert.IsType<SpeculationModule>(driver.Speculation);
+            Assert.IsType<StorageModule>(driver.Storage);
+            Assert.IsType<UserAgentClientHintsModule>(driver.UserAgentClientHints);
+            Assert.IsType<WebExtensionModule>(driver.WebExtension);
         }
         finally
         {
-            await driver.StopAsync();
+            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
         }
     }
 
-    [Test]
-    public void TestCanRegisterModule()
+    [Fact]
+    public async Task TestCanRegisterModule()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterModule(new TestProtocolModule(driver));
-        Assert.That(driver.GetModule<TestProtocolModule>("protocol"), Is.InstanceOf<TestProtocolModule>());
+        Assert.IsType<TestProtocolModule>(driver.GetModule<TestProtocolModule>("protocol"));
     }
 
-    [Test]
-    public void TestRegisteringModuleWithDuplicateNameThrows()
+    [Fact]
+    public async Task TestRegisteringModuleWithDuplicateNameThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterModule(new TestProtocolModule(driver, 0, false));
-        Assert.That(() => driver.RegisterModule(new TestProtocolModule(driver)), Throws.InstanceOf<ArgumentException>().With.Message.StartsWith("A module with the name 'protocol' has already been registered"));
+        Assert.StartsWith("A module with the name 'protocol' has already been registered", Assert.ThrowsAny<ArgumentException>(() => driver.RegisterModule(new TestProtocolModule(driver))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisteringModuleAfterStartingDriverThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(() => driver.RegisterModule(new TestProtocolModule(driver, 0, false)), Throws.InstanceOf<InvalidOperationException>());
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.ThrowsAny<InvalidOperationException>(() => driver.RegisterModule(new TestProtocolModule(driver, 0, false)));
     }
 
-    [Test]
-    public void TestGettingInvalidModuleNameThrows()
+    [Fact]
+    public async Task TestGettingInvalidModuleNameThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.GetModule<TestProtocolModule>("protocol"), Throws.InstanceOf<ArgumentException>().With.Message.Contains("Module 'protocol' is not registered with this driver"));
+        Assert.Contains("Module 'protocol' is not registered with this driver", Assert.ThrowsAny<ArgumentException>(() => driver.GetModule<TestProtocolModule>("protocol")).Message);
     }
 
-    [Test]
-    public void TestGettingInvalidModuleTypeThrows()
+    [Fact]
+    public async Task TestGettingInvalidModuleTypeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterModule(new TestProtocolModule(driver));
-        Assert.That(() => driver.GetModule<SessionModule>("protocol"), Throws.InstanceOf<InvalidCastException>().With.Message.EqualTo("Module 'protocol' is registered with this driver, but the module object is not of type WebDriverBiDi.Session.SessionModule"));
+        Assert.Equal("Module 'protocol' is registered with this driver, but the module object is not of type WebDriverBiDi.Session.SessionModule", Assert.ThrowsAny<InvalidCastException>(() => driver.GetModule<SessionModule>("protocol")).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestReceivingNullValueFromSendingCommandThrows()
     {
         TestTransport transport = new(new TestWebSocketConnection())
@@ -489,11 +480,12 @@ public class BiDiDriverTests
             ReturnCustomValue = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws:localhost");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("is unexpectedly null"));
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("is unexpectedly null", exception.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanceledCommandThrows()
     {
         TestTransport transport = new(new TestWebSocketConnection())
@@ -501,11 +493,11 @@ public class BiDiDriverTests
             ShouldCancelCommand = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws:localhost");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("was canceled before a result was received"));
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains("was canceled before a result was received", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestUncompletedCommandThrows()
     {
         TestTransport transport = new(new TestWebSocketConnection())
@@ -513,35 +505,33 @@ public class BiDiDriverTests
             ReturnUncompletedCommand = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws:localhost");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("is unexpectedly null"));
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains("is unexpectedly null", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecutingCommandWillThrowWhenTimeout()
     {
         BiDiDriver driver = new(TimeSpan.Zero, new Transport(new TestWebSocketConnection()));
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiTimeoutException>().With.Message.Contains("Timed out executing command test.command"));
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains("Timed out executing command test.command", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTimedOutCommandIgnoresLateResponse()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(
-            async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")),
-            Throws.InstanceOf<WebDriverBiDiTimeoutException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
 
         string lateResponse = """{"type":"success","id":1,"result":{"parameterName":"parameterValue"}}""";
-        Assert.That(async () => await connection.RaiseDataReceivedEventAsync(lateResponse), Throws.Nothing);
+        await connection.RaiseDataReceivedEventAsync(lateResponse);
     }
 
-    [Test]
+    [Fact]
     public async Task TestReceivingInvalidErrorValueFromSendingCommandThrows()
     {
         TestCommandResult result = new();
@@ -552,22 +542,20 @@ public class BiDiDriverTests
             CustomReturnValue = result
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Could not convert error response from transport for SendCommandAndWait to ErrorResult"));
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Could not convert error response from transport for SendCommandAndWait to ErrorResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestReceivingInvalidResultTypeFromSendingCommandThrows()
     {
         TestCommandResultInvalid result = new()
         {
             Value = "invalid",
         };
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Value, Is.EqualTo("invalid"));
-            Assert.That(result with { }, Is.EqualTo(result));
-        }
+
+        Assert.Equal("invalid", result.Value);
+        Assert.Equal(result, result with { });
 
         TestTransport transport = new(new TestWebSocketConnection())
         {
@@ -575,11 +563,11 @@ public class BiDiDriverTests
             CustomReturnValue = result
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult"));
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDriverCanEmitLogMessagesFromProtocol()
     {
         DateTime testStart = DateTime.UtcNow;
@@ -591,19 +579,17 @@ public class BiDiDriverTests
         {
             logs.Add(e);
         });
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseLogMessageEventAsync("test log message", WebDriverBiDiLogLevel.Warn);
-        Assert.That(logs, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(logs[0].Message, Is.EqualTo("test log message"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Warn));
-            Assert.That(logs[0].Timestamp, Is.GreaterThanOrEqualTo(testStart));
-            Assert.That(logs[0].ComponentName, Is.EqualTo("TestWebSocketConnection"));
-        }
+        Assert.Single(logs);
+
+        Assert.Equal("test log message", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Warn, logs[0].Level);
+        Assert.True(logs[0].Timestamp >= testStart);
+        Assert.Equal("TestWebSocketConnection", logs[0].ComponentName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDriverCanUseDefaultTransport()
     {
         ManualResetEvent connectionSyncEvent = new(false);
@@ -615,16 +601,16 @@ public class BiDiDriverTests
         await server.StartAsync();
 
         BiDiDriver driver = new();
-        await driver.StartAsync($"ws://localhost:{server.Port}");
+        await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         bool connectionEventRaised = connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await driver.StopAsync();
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await server.StopAsync();
         dataReceivedObserver.Unobserve();
-        Assert.That(connectionEventRaised, Is.True);
+        Assert.True(connectionEventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMalformedEventResponseLogsError()
     {
         string connectionId = string.Empty;
@@ -642,7 +628,7 @@ public class BiDiDriverTests
 
         try
         {
-            await driver.StartAsync($"ws://localhost:{server.Port}");
+            await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
             connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
             ManualResetEvent logSyncEvent = new(false);
             List<string> driverLog = [];
@@ -678,22 +664,20 @@ public class BiDiDriverTests
                                """;
             await server.SendWebSocketDataAsync(connectionId, eventJson);
             bool eventsRaised = WaitHandle.WaitAll(new WaitHandle[] { logSyncEvent, unknownMessageSyncEvent }, TimeSpan.FromSeconds(1));
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(eventsRaised, Is.True);
-                Assert.That(driverLog, Has.Count.EqualTo(1));
-                Assert.That(driverLog[0], Contains.Substring("Unexpected error parsing event JSON"));
-                Assert.That(unknownMessage, Is.Not.Empty);
-            }
+
+            Assert.True(eventsRaised);
+            Assert.Single(driverLog);
+            Assert.Contains("Unexpected error parsing event JSON", driverLog[0]);
+            Assert.NotEmpty(unknownMessage);
         }
         finally
         {
-            await driver.StopAsync();
+            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
             await server.StopAsync();
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestMalformedNonCommandErrorResponseLogsError()
     {
         string connectionId = string.Empty;
@@ -711,7 +695,7 @@ public class BiDiDriverTests
 
         try
         {
-            await driver.StartAsync($"ws://localhost:{server.Port}");
+            await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
             connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
 
             driver.BrowsingContext.OnLoad.AddObserver((e) =>
@@ -751,22 +735,20 @@ public class BiDiDriverTests
                           """;
             await server.SendWebSocketDataAsync(connectionId, json);
             bool eventsRaised = WaitHandle.WaitAll(new WaitHandle[] { logSyncEvent, unknownMessageSyncEvent }, TimeSpan.FromSeconds(1));
-            Assert.That(eventsRaised, Is.True);
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(driverLog, Has.Count.EqualTo(1));
-                Assert.That(driverLog[0], Contains.Substring("Unexpected error parsing error JSON"));
-                Assert.That(unknownMessage, Is.Not.Empty);
-            }
+            Assert.True(eventsRaised);
+
+            Assert.Single(driverLog);
+            Assert.Contains("Unexpected error parsing error JSON", driverLog[0]);
+            Assert.NotEmpty(unknownMessage);
         }
         finally
         {
-            await driver.StopAsync();
+            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
             await server.StopAsync();
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestMalformedIncomingMessageLogsError()
     {
         string connectionId = string.Empty;
@@ -784,7 +766,7 @@ public class BiDiDriverTests
 
         try
         {
-            await driver.StartAsync($"ws://localhost:{server.Port}");
+            await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
             connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
 
             ManualResetEvent logSyncEvent = new(false);
@@ -818,66 +800,64 @@ public class BiDiDriverTests
                                """;
             await server.SendWebSocketDataAsync(connectionId, unparsableJson);
             bool eventsRaised = WaitHandle.WaitAll([logSyncEvent, unknownMessageSyncEvent], TimeSpan.FromSeconds(1));
-            Assert.That(eventsRaised, Is.True);
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(driverLog, Has.Count.EqualTo(1));
-                Assert.That(driverLog[0], Contains.Substring("Unexpected error parsing JSON message"));
-                Assert.That(unknownMessage, Is.Not.Empty);
-            }
+            Assert.True(eventsRaised);
+
+            Assert.Single(driverLog);
+            Assert.Contains("Unexpected error parsing JSON message", driverLog[0]);
+            Assert.NotEmpty(unknownMessage);
         }
         finally
         {
-            await driver.StopAsync();
+            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
             await server.StopAsync();
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanModifyEventHandlerExceptionBehavior()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(driver.EventHandlerExceptionBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+        Assert.Equal(TransportErrorBehavior.Ignore, driver.EventHandlerExceptionBehavior);
         driver.EventHandlerExceptionBehavior = TransportErrorBehavior.Collect;
-        Assert.That(transport.EventHandlerExceptionBehavior, Is.EqualTo(TransportErrorBehavior.Collect));
+        Assert.Equal(TransportErrorBehavior.Collect, transport.EventHandlerExceptionBehavior);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanModifyUnexpectedErrorExceptionBehavior()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(driver.UnexpectedErrorBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+        Assert.Equal(TransportErrorBehavior.Ignore, driver.UnexpectedErrorBehavior);
         driver.UnexpectedErrorBehavior = TransportErrorBehavior.Collect;
-        Assert.That(transport.UnexpectedErrorBehavior, Is.EqualTo(TransportErrorBehavior.Collect));
+        Assert.Equal(TransportErrorBehavior.Collect, transport.UnexpectedErrorBehavior);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanModifyProtocolErrorExceptionBehavior()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(driver.ProtocolErrorBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+        Assert.Equal(TransportErrorBehavior.Ignore, driver.ProtocolErrorBehavior);
         driver.ProtocolErrorBehavior = TransportErrorBehavior.Collect;
-        Assert.That(transport.ProtocolErrorBehavior, Is.EqualTo(TransportErrorBehavior.Collect));
+        Assert.Equal(TransportErrorBehavior.Collect, transport.ProtocolErrorBehavior);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanModifyUnknownMessageExceptionBehavior()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(driver.UnknownMessageBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+        Assert.Equal(TransportErrorBehavior.Ignore, driver.UnknownMessageBehavior);
         driver.UnknownMessageBehavior = TransportErrorBehavior.Collect;
-        Assert.That(transport.UnknownMessageBehavior, Is.EqualTo(TransportErrorBehavior.Collect));
+        Assert.Equal(TransportErrorBehavior.Collect, transport.UnknownMessageBehavior);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteParallelCommands()
     {
         // delayCommandInFlight: set by the delay command's handler as soon as it starts,
@@ -889,19 +869,19 @@ public class BiDiDriverTests
         using ManualResetEventSlim delayResponseGate = new(false);
 
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += (sender, e) =>
         {
             Task.Run(async () =>
             {
                 DateTime start = DateTime.Now;
-                if (e.SentCommandName!.Contains("delay"))
+                if (e.SentCommandName is not null && e.SentCommandName.Contains("delay"))
                 {
                     delayCommandInFlight.Set();
-                    delayResponseGate.Wait(TimeSpan.FromSeconds(5));
+                    delayResponseGate.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
                 }
                 else
                 {
-                    delayCommandInFlight.Wait(TimeSpan.FromSeconds(5));
+                    delayCommandInFlight.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
                 }
 
                 TimeSpan elapsed = DateTime.Now - start;
@@ -921,7 +901,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string delayCommandName = "module.delayCommand";
         TestCommandParameters delayCommand = new(delayCommandName);
@@ -931,89 +911,87 @@ public class BiDiDriverTests
 
         Task<TestCommandResult>[] parallelTasks =
         [
-            driver.ExecuteCommandAsync(delayCommand),
-            driver.ExecuteCommandAsync(command),
+            driver.ExecuteCommandAsync(delayCommand, cancellationToken: TestContext.Current.CancellationToken),
+            driver.ExecuteCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken),
         ];
 
-        int indexOfFirstFinishedTask = Task.WaitAny(parallelTasks);
+        Task<TestCommandResult> firstFinished = await Task.WhenAny(parallelTasks).WaitAsync(TestContext.Current.CancellationToken);
+        int indexOfFirstFinishedTask = Array.IndexOf(parallelTasks, firstFinished);
         delayResponseGate.Set();
-        bool allTasksCompleted = Task.WaitAll(parallelTasks, TimeSpan.FromSeconds(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(allTasksCompleted, Is.True);
-            Assert.That(indexOfFirstFinishedTask, Is.EqualTo(1));
-            Assert.That(parallelTasks[0].Result.Value, Is.EqualTo($"command result value for {delayCommandName}"));
-            Assert.That(parallelTasks[1].Result.Value, Is.EqualTo($"command result value for {commandName}"));
-            Assert.That(parallelTasks[0].Result.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(parallelTasks[1].Result.ElapsedMilliseconds!));
-        }
+        TestCommandResult[] results = await Task.WhenAll(parallelTasks).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, indexOfFirstFinishedTask);
+        Assert.Equal($"command result value for {delayCommandName}", results[0].Value);
+        Assert.Equal($"command result value for {commandName}", results[1].Value);
+        Assert.True(results[0].ElapsedMilliseconds >= results[1].ElapsedMilliseconds);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeStartedDriver()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(async () => await driver.StartAsync("ws://localhost:5555"), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeDriverWithoutStarting()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.DisposeAsync();
-        Assert.That(async () => await driver.StartAsync("ws://localhost:5555"), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(async () => await driver.DisposeAsync(), Throws.Nothing);
+        await driver.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestStopThenDisposeDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        await driver.StopAsync();
-        Assert.That(async () => await driver.DisposeAsync(), Throws.Nothing);
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandWithTimeoutAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100)), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanUseAwaitUsingPattern()
     {
         TestWebSocketConnection connection = new();
@@ -1035,26 +1013,27 @@ public class BiDiDriverTests
 
         await using (BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport))
         {
-            await driver.StartAsync("ws://localhost:5555");
-            TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("module.command"));
-            commandValue = result.Value!;
+            await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+            TestCommandResult result = await driver.ExecuteCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
+            Assert.NotNull(result.Value);
+            commandValue = result.Value;
         }
 
-        Assert.That(commandValue, Is.EqualTo("command result value"));
+        Assert.Equal("command result value", commandValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisteringModuleAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(() => driver.RegisterModule(new TestProtocolModule(driver)), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.ThrowsAny<ObjectDisposedException>(() => driver.RegisterModule(new TestProtocolModule(driver)));
     }
 
-    [Test]
+    [Fact]
     public async Task TestGettingModuleAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
@@ -1062,97 +1041,98 @@ public class BiDiDriverTests
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
         driver.RegisterModule(module);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(() => driver.GetModule<TestProtocolModule>(module.ModuleName), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.ThrowsAny<ObjectDisposedException>(() => driver.GetModule<TestProtocolModule>(module.ModuleName));
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisteringEventAfterDisposeThrows()
     {
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = (eventData) => Task.CompletedTask;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        Assert.That(() => driver.RegisterEvent("protocol.event", eventInvoker), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.ThrowsAny<ObjectDisposedException>(() => driver.RegisterEvent("protocol.event", eventInvoker));
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeDisposesTransport()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(transport.IsDisposed, Is.False);
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(transport.IsDisposed);
         await driver.DisposeAsync();
-        Assert.That(transport.IsDisposed, Is.True);
+        Assert.True(transport.IsDisposed);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeDisposesTransportWithoutStarting()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(transport.IsDisposed, Is.False);
+        Assert.False(transport.IsDisposed);
         await driver.DisposeAsync();
-        Assert.That(transport.IsDisposed, Is.True);
+        Assert.True(transport.IsDisposed);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeLogsExceptionFromStopAsync()
     {
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         driver.OnLogMessage.AddObserver((e) =>
         {
             logs.Add(e);
         });
         transport.ThrowOnDisconnect = true;
         await driver.DisposeAsync();
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Unexpected exception during disposal")
                    && log.Message.Contains("Simulated disconnect failure")
                    && log.Level == WebDriverBiDiLogLevel.Warn
-                   && log.ComponentName == BiDiDriver.LoggerComponentName));
+                   && log.ComponentName == BiDiDriver.LoggerComponentName);
     }
 
-    [Test]
-    public void TestRegisterTypeInfoResolverBeforeStarting()
+    [Fact]
+    public async Task TestRegisterTypeInfoResolverBeforeStarting()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver()), Throws.Nothing);
+        await driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterTypeInfoResolverAfterStartingThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
-        Assert.That(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver()), Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("Cannot register a type info resolver after the transport is connected"));
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        InvalidOperationException exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Cannot register a type info resolver after the transport is connected", exception.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterTypeInfoResolverAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.DisposeAsync();
-        Assert.That(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver()), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteCommandWithUntypedCommandParameters()
     {
         TestWebSocketConnection connection = new();
@@ -1172,14 +1152,14 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         CommandParameters command = new TestCommandParameters("module.command");
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command);
-        Assert.That(result.Value, Is.EqualTo("command result value"));
+        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("command result value", result.Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteCommandWithUntypedCommandParametersAndTimeout()
     {
         TestWebSocketConnection connection = new();
@@ -1199,39 +1179,39 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         CommandParameters command = new TestCommandParameters("module.command");
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(1500));
-        Assert.That(result.Value, Is.EqualTo("command result value"));
+        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(1500), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("command result value", result.Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandWithUntypedParametersAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         CommandParameters command = new TestCommandParameters("test.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandWithUntypedParametersAndTimeoutAfterDisposeThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         CommandParameters command = new TestCommandParameters("test.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(100)), Throws.InstanceOf<ObjectDisposedException>());
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
-    public void TestStartAsyncThrowsWhenCancellationTokenIsCanceled()
+    [Fact]
+    public async Task TestStartAsyncThrowsWhenCancellationTokenIsCanceled()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -1239,38 +1219,38 @@ public class BiDiDriverTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        Assert.That(async () => await driver.StartAsync("ws://localhost:5555", cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.StartAsync("ws://localhost:5555", cts.Token));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandThrowsWhenCancellationTokenIsCanceled()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
         TestCommandParameters commandParams = new("module.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(commandParams, cancellationToken: cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(commandParams, cancellationToken: cts.Token));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandWithTimeoutThrowsWhenCancellationTokenIsCanceled()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
         TestCommandParameters commandParams = new("module.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(commandParams, TimeSpan.FromSeconds(5), cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(commandParams, TimeSpan.FromSeconds(5), cts.Token));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandCancelsCommandOnCancellation()
     {
         using ManualResetEventSlim commandSent = new(false);
@@ -1278,38 +1258,38 @@ public class BiDiDriverTests
         connection.DataSendComplete += (_, _) => commandSent.Set();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         using CancellationTokenSource cts = new();
         CommandParameters command = new TestCommandParameters("module.command");
 
         Task<TestCommandResult> executeTask = driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(30), cts.Token);
-        commandSent.Wait(TimeSpan.FromSeconds(5));
+        commandSent.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         cts.Cancel();
 
-        Assert.That(async () => await executeTask, Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await executeTask);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAsyncWithNullCommandParametersThrows()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(null!), Throws.InstanceOf<ArgumentNullException>());
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(null!, cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAsyncWithNegativeTimeoutThrows()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         CommandParameters command = new TestCommandParameters("module.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(-5)), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        await Assert.ThrowsAnyAsync<ArgumentOutOfRangeException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(-5), cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAsyncWithZeroTimeoutDoesNotThrowArgumentOutOfRangeException()
     {
         TestWebSocketConnection connection = new();
@@ -1330,12 +1310,12 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.Zero), Throws.InstanceOf<WebDriverBiDiTimeoutException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.Zero, cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAsyncWithExplicitPositiveTimeoutSucceeds()
     {
         TestWebSocketConnection connection = new();
@@ -1354,13 +1334,13 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(5));
-        Assert.That(result.Value, Is.EqualTo("command result value"));
+        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("command result value", result.Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAsyncWithInfiniteTimeoutDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
@@ -1379,12 +1359,12 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, Timeout.InfiniteTimeSpan), Throws.Nothing);
+        await driver.ExecuteCommandAsync<TestCommandResult>(command, Timeout.InfiniteTimeSpan, cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCommandAsyncWithNullTimeoutDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
@@ -1405,108 +1385,108 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, null), Throws.Nothing);
+        await driver.ExecuteCommandAsync<TestCommandResult>(command, null, cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterEventWithNullEventNameThrows()
     {
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = (eventData) => Task.CompletedTask;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.RegisterEvent(null!, eventInvoker), Throws.InstanceOf<ArgumentException>());
+        Assert.ThrowsAny<ArgumentException>(() => driver.RegisterEvent(null!, eventInvoker));
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterEventWithEmptyEventNameThrows()
     {
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = (eventData) => Task.CompletedTask;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.RegisterEvent(string.Empty, eventInvoker), Throws.InstanceOf<ArgumentException>());
+        Assert.ThrowsAny<ArgumentException>(() => driver.RegisterEvent(string.Empty, eventInvoker));
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterEventWithNullEventInvokerThrows()
     {
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = null!;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.RegisterEvent("protocol.event", eventInvoker), Throws.InstanceOf<ArgumentNullException>());
+        Assert.ThrowsAny<ArgumentNullException>(() => driver.RegisterEvent("protocol.event", eventInvoker!));
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterModuleWithNullModuleThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.RegisterModule(null!), Throws.InstanceOf<ArgumentNullException>());
+        Assert.ThrowsAny<ArgumentNullException>(() => driver.RegisterModule(null!));
     }
 
-    [Test]
+    [Fact]
     public async Task TestGetModuleWithNullModuleNameThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.GetModule<TestProtocolModule>(null!), Throws.InstanceOf<ArgumentException>());
+        Assert.ThrowsAny<ArgumentException>(() => driver.GetModule<TestProtocolModule>(null!));
     }
 
-    [Test]
+    [Fact]
     public async Task TestGetModuleWithEmptyModuleNameThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.GetModule<TestProtocolModule>(string.Empty), Throws.InstanceOf<ArgumentException>());
+        Assert.ThrowsAny<ArgumentException>(() => driver.GetModule<TestProtocolModule>(string.Empty));
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterTypeInfoResolverWithNullResolverThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        Assert.That(() => driver.RegisterTypeInfoResolverAsync(null!), Throws.InstanceOf<ArgumentNullException>());
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => driver.RegisterTypeInfoResolverAsync(null!, cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
-    public void TestCreatingWithNegativeDefaultCommandTimeoutThrows()
+    [Fact]
+    public async Task TestCreatingWithNegativeDefaultCommandTimeoutThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(() => new BiDiDriver(TimeSpan.FromSeconds(-1), transport), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        Assert.ThrowsAny<ArgumentOutOfRangeException>(() => new BiDiDriver(TimeSpan.FromSeconds(-1), transport));
     }
 
-    [Test]
-    public void TestCreatingWithZeroDefaultCommandTimeoutDoesNotThrow()
+    [Fact]
+    public async Task TestCreatingWithZeroDefaultCommandTimeoutDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(() => new BiDiDriver(TimeSpan.Zero, transport), Throws.Nothing);
+        new BiDiDriver(TimeSpan.Zero, transport);
     }
 
-    [Test]
-    public void TestCreatingWithInfiniteDefaultCommandTimeoutDoesNotThrow()
+    [Fact]
+    public async Task TestCreatingWithInfiniteDefaultCommandTimeoutDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(() => new BiDiDriver(Timeout.InfiniteTimeSpan, transport), Throws.Nothing);
+        new BiDiDriver(Timeout.InfiniteTimeSpan, transport);
     }
 
-    [Test]
-    public void TestCreatingWithNullTransportThrows()
+    [Fact]
+    public async Task TestCreatingWithNullTransportThrows()
     {
-        Assert.That(() => _ = new BiDiDriver(TimeSpan.FromSeconds(1), null!), Throws.InstanceOf<ArgumentNullException>());
+        Assert.ThrowsAny<ArgumentNullException>(() => _ = new BiDiDriver(TimeSpan.FromSeconds(1), null!));
     }
 
-    [Test]
+    [Fact]
     public async Task TestConcurrentExecuteCommandAsyncRoutesResponsesByCommandId()
     {
         // This stress test exercises the ID-correlation path in BiDiDriver.ExecuteCommandAsync
@@ -1525,18 +1505,18 @@ public class BiDiDriverTests
         object captureLock = new();
 
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
+        connection.DataSendComplete += (sender, e) =>
         {
             // Because sends serialize under the transport's connection semaphore, this
             // handler runs exclusively per send. It is safe to read connection.DataSent
             // here — no other sender can overwrite it until we release the semaphore by
             // returning. We still take an explicit lock so the Dictionary mutation is
             // safe against any future changes to the send path.
-            JsonDocument document = JsonDocument.Parse(connection.DataSent!);
-            string senderValue = document.RootElement.GetProperty("params").GetProperty("parameterName").GetString()!;
+            JsonDocument document = JsonDocument.Parse(connection.DataSent ??= string.Empty);
+            string? senderValue = document.RootElement.GetProperty("params").GetProperty("parameterName").GetString();
             lock (captureLock)
             {
-                commandIdToSenderValue[e.SentCommandId] = senderValue;
+                commandIdToSenderValue[e.SentCommandId] = senderValue ??= string.Empty;
             }
 
             allSendsCompleted.Signal();
@@ -1544,7 +1524,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(Timeout.InfiniteTimeSpan, transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         // Fire N tasks concurrently. Each sender tags its command with a unique
         // parameterName so we can prove end-to-end that the response it receives was
@@ -1556,7 +1536,7 @@ public class BiDiDriverTests
             int capturedIndex = i;
             string senderValue = $"sender-{capturedIndex}";
             expectedValues[capturedIndex] = senderValue;
-            senderTasks[capturedIndex] = Task.Run(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("module.command", senderValue)));
+            senderTasks[capturedIndex] = Task.Run(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("module.command", senderValue), cancellationToken: TestContext.Current.CancellationToken));
         }
 
         // Block deterministically until every send has completed. After this Wait()
@@ -1565,12 +1545,12 @@ public class BiDiDriverTests
         // bound is a safety net to prevent a CI hang if something goes wrong; under normal
         // operation Wait returns as soon as all signals arrive. If Wait returns false, the
         // remaining assertions in the test are not meaningful, so fail fast here.
-        if (!allSendsCompleted.Wait(TimeSpan.FromSeconds(30)))
+        if (!allSendsCompleted.Wait(TimeSpan.FromSeconds(30), cancellationToken: TestContext.Current.CancellationToken))
         {
-            Assert.Fail("all sends should complete before the safety timeout");
+            throw new Xunit.Sdk.XunitException("all sends should complete before the safety timeout");
         }
 
-        Assert.That(transport.PendingCommandCount, Is.EqualTo(concurrentCallerCount));
+        Assert.Equal(concurrentCallerCount, transport.PendingCommandCount);
 
         // Deliver responses in reverse send order to exercise out-of-order delivery.
         // Each response carries the sender's own parameterName as its "value" field, so
@@ -1595,19 +1575,17 @@ public class BiDiDriverTests
         // is the final deterministic synchronization point. The assertions then check
         // that each caller i received a result whose Value equals its own sender tag.
         TestCommandResult[] results = await Task.WhenAll(senderTasks);
-        Assert.That(transport.PendingCommandCount, Is.Zero, "all commands resolved after responses delivered");
-        using (Assert.EnterMultipleScope())
+        Assert.Equal(0, transport.PendingCommandCount);
+
+        for (int i = 0; i < concurrentCallerCount; i++)
         {
-            for (int i = 0; i < concurrentCallerCount; i++)
-            {
-                Assert.That(results[i].Value, Is.EqualTo(expectedValues[i]), $"caller {i} should receive its own sender tag back");
-            }
+            Assert.Equal(expectedValues[i], results[i].Value);
         }
 
-        await driver.StopAsync();
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMidCommandRemoteDisconnectFaultsExecuteCommandWithConnectionException()
     {
         // Verify that a remote disconnect while a command is pending causes
@@ -1628,25 +1606,25 @@ public class BiDiDriverTests
         // elapsed. The assertion timeout below is much shorter, so a broken
         // path fails fast rather than timing out the whole suite.
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new("module.command");
-        Task<TestCommandResult> executeTask = Task.Run(() => driver.ExecuteCommandAsync<TestCommandResult>(command));
+        Task<TestCommandResult> executeTask = Task.Run(() => driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
 
-        Assert.That(commandQueued.Wait(TimeSpan.FromSeconds(1)), Is.True, "command should reach the send path before we raise the disconnect");
+        Assert.True(commandQueued.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken));
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
-        WebDriverBiDiConnectionException? caught = Assert.ThrowsAsync<WebDriverBiDiConnectionException>(async () =>
+        WebDriverBiDiConnectionException? caught = await Assert.ThrowsAsync<WebDriverBiDiConnectionException>(async () =>
         {
-            Task completed = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromSeconds(2)));
-            Assert.That(completed, Is.SameAs(executeTask), "ExecuteCommandAsync should fault well before the 30-second command timeout");
+            Task completed = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+            Assert.Same(executeTask, completed);
             await executeTask;
         });
-        Assert.That(caught!.Message, Does.Contain("Remote end closed the connection"));
+        Assert.Contains("Remote end closed the connection", caught.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRacedCapturedTaskFaultIsReportedViaEventHandlerError()
     {
         // A handler task that races into the capture buffer after WaitForAsync collected
@@ -1669,7 +1647,7 @@ public class BiDiDriverTests
                 if (e.BrowsingContextId == "racedContextId")
                 {
                     handlerStarted.Set();
-                    await Task.Run(() => allowFault.Wait(TimeSpan.FromSeconds(5)));
+                    await Task.Run(() => allowFault.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
                     throw new InvalidOperationException("raced task fault");
                 }
             },
@@ -1681,7 +1659,7 @@ public class BiDiDriverTests
             errorReported.Set();
         });
 
-        await driver.StartAsync("ws://localhost:5555");
+        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
 
         string collectedEventJson = """
             {
@@ -1723,23 +1701,20 @@ public class BiDiDriverTests
         await connection.RaiseDataReceivedEventAsync(collectedEventJson);
         // Deliver the raced event — its handler starts and blocks.
         await connection.RaiseDataReceivedEventAsync(racedEventJson);
-        handlerStarted.Wait(TimeSpan.FromSeconds(5));
+        handlerStarted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         // WaitForAsync collects 1 task, auto-closes, drains the raced task.
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5));
-        Assert.That(tasks, Has.Length.EqualTo(1));
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        _ = Assert.Single(tasks);
 
         // Let the raced handler fault.
         allowFault.Set();
-        bool reported = errorReported.Wait(TimeSpan.FromSeconds(5));
+        bool reported = errorReported.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(reported, Is.True, "raced task fault must be reported via OnEventHandlerErrorOccurred");
-            Assert.That(errorInfo, Is.Not.Null);
-            Assert.That(errorInfo!.Exception, Is.InstanceOf<InvalidOperationException>().With.Message.EqualTo("raced task fault"));
-            Assert.That(errorInfo.ObservableEventName, Is.EqualTo("browsingContext.contextCreated"));
-        }
+        Assert.True(reported);
+        Assert.NotNull(errorInfo);
+        InvalidOperationException ex = Assert.IsType<InvalidOperationException>(errorInfo.Exception);
+        Assert.Equal("raced task fault", ex.Message);
+        Assert.Equal("browsingContext.contextCreated", errorInfo.ObservableEventName);
     }
-
 }

--- a/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
+++ b/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
@@ -1296,21 +1296,6 @@ public class BiDiDriverTests
     public async Task TestExecuteCommandAsyncWithZeroTimeoutDoesNotThrowArgumentOutOfRangeException()
     {
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += async (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
-        {
-            // force a delay in responding to ensure that the timeout is actually being applied
-            await Task.Yield();
-            string eventJson = """
-                               {
-                                 "type": "success",
-                                 "id": 1,
-                                 "result": {
-                                   "value": "command result value"
-                                 }
-                               }
-                               """;
-            await connection.RaiseDataReceivedEventAsync(eventJson);
-        };
         TestTransport transport = new(connection);
         await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
+++ b/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
@@ -22,6 +22,7 @@ using WebDriverBiDi.Storage;
 using WebDriverBiDi.UserAgentClientHints;
 using WebDriverBiDi.WebExtension;
 
+[Collection("EventSourceTests")]
 public class BiDiDriverTests
 {
     [Fact]
@@ -33,9 +34,9 @@ public class BiDiDriverTests
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         Assert.False(driver.IsStarted);
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.True(driver.IsStarted);
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(driver.IsStarted);
     }
 
@@ -59,7 +60,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
@@ -87,7 +88,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
@@ -127,7 +128,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters command = new(commandName);
@@ -138,16 +139,16 @@ public class BiDiDriverTests
     public async Task TestCanExecuteReceiveErrorWithoutCommand()
     {
         ErrorResult? response = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.OnUnexpectedErrorReceived.AddObserver((ErrorReceivedEventArgs e) =>
         {
             response = e.ErrorData;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string errorJson = """
                            {
@@ -158,7 +159,7 @@ public class BiDiDriverTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(errorJson);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.NotNull(response);
 
@@ -172,7 +173,7 @@ public class BiDiDriverTests
     {
         string receivedEvent = string.Empty;
         object? receivedData = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
@@ -183,21 +184,21 @@ public class BiDiDriverTests
         {
             receivedEvent = e.EventName;
             receivedData = e.EventData;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string eventJson = """
                            {
                              "type": "event",
                              "method": "module.event",
                              "params": {
-                               "paramName": "paramValue" 
-                             } 
+                               "paramName": "paramValue"
+                             }
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(eventName, receivedEvent);
         Assert.NotNull(receivedData);
@@ -227,7 +228,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.ThrowsAny<InvalidOperationException>(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask));
     }
 
@@ -236,7 +237,7 @@ public class BiDiDriverTests
     {
         string receivedEvent = string.Empty;
         object? receivedData = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
@@ -250,9 +251,9 @@ public class BiDiDriverTests
         {
             receivedEvent = e.EventName;
             receivedData = e.EventData;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string eventJson = """
                            {
@@ -264,8 +265,8 @@ public class BiDiDriverTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+        await driver.StopAsync(TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(eventName, receivedEvent);
         Assert.NotNull(receivedData);
@@ -280,7 +281,7 @@ public class BiDiDriverTests
     public async Task TestUnregisteredEventRaisesUnknownMessageEvent()
     {
         string receivedMessage = string.Empty;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -288,9 +289,9 @@ public class BiDiDriverTests
         driver.OnUnknownMessageReceived.AddObserver((e) =>
         {
             receivedMessage = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string serialized = """
                             {
@@ -302,7 +303,7 @@ public class BiDiDriverTests
                             }
                             """;
         await connection.RaiseDataReceivedEventAsync(serialized);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(serialized, receivedMessage);
     }
 
@@ -310,7 +311,7 @@ public class BiDiDriverTests
     public async Task TestUnconformingDataRaisesUnknownMessageEvent()
     {
         string receivedMessage = string.Empty;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -318,9 +319,9 @@ public class BiDiDriverTests
         driver.OnUnknownMessageReceived.AddObserver((e) =>
         {
             receivedMessage = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string serialized = """
                             {
@@ -331,7 +332,7 @@ public class BiDiDriverTests
                             }
                             """;
         await connection.RaiseDataReceivedEventAsync(serialized);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(serialized, receivedMessage);
     }
 
@@ -339,8 +340,8 @@ public class BiDiDriverTests
     public async Task TestNotificationOfEventHandlerError()
     {
         EventObserverErrorInfo? errorInfo = null;
-        ManualResetEvent syncEvent = new(false);
-        ManualResetEvent handlerReturnedEvent = new(false);
+        TaskCompletionSource handlerFaultedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource errorReportedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -354,16 +355,16 @@ public class BiDiDriverTests
             finally
             {
                 await Task.Yield();
-                syncEvent.Set();
+                handlerFaultedTaskCompletionSource.TrySetResult();
             }
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously, "Test observer");
 
         driver.OnEventHandlerErrorOccurred.AddObserver(e =>
         {
             errorInfo = e.ErrorInfo with { };
-            handlerReturnedEvent.Set();
+            errorReportedTaskCompletionSource.TrySetResult();
         });
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string eventJson = """
                            {
@@ -380,10 +381,9 @@ public class BiDiDriverTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        bool handlerReturned = handlerReturnedEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+        await handlerFaultedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await errorReportedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(handlerReturned);
         Assert.NotNull(errorInfo);
         Assert.Equal(browsingContextObserver.Id, errorInfo.ObserverId);
         Assert.IsType<InvalidOperationException>(errorInfo.Exception);
@@ -397,7 +397,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         try
         {
 
@@ -419,7 +419,7 @@ public class BiDiDriverTests
         }
         finally
         {
-            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+            await driver.StopAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -449,7 +449,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.ThrowsAny<InvalidOperationException>(() => driver.RegisterModule(new TestProtocolModule(driver, 0, false)));
     }
 
@@ -480,7 +480,7 @@ public class BiDiDriverTests
             ReturnCustomValue = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
         Assert.Contains("is unexpectedly null", exception.Message);
     }
@@ -493,7 +493,7 @@ public class BiDiDriverTests
             ShouldCancelCommand = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.Contains("was canceled before a result was received", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
@@ -505,7 +505,7 @@ public class BiDiDriverTests
             ReturnUncompletedCommand = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.Contains("is unexpectedly null", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
@@ -513,7 +513,7 @@ public class BiDiDriverTests
     public async Task TestExecutingCommandWillThrowWhenTimeout()
     {
         BiDiDriver driver = new(TimeSpan.Zero, new Transport(new TestWebSocketConnection()));
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.Contains("Timed out executing command test.command", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
@@ -523,7 +523,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
 
@@ -542,7 +542,7 @@ public class BiDiDriverTests
             CustomReturnValue = result
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.Equal("Could not convert error response from transport for SendCommandAndWait to ErrorResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
@@ -563,7 +563,7 @@ public class BiDiDriverTests
             CustomReturnValue = result
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.Equal("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
@@ -579,7 +579,7 @@ public class BiDiDriverTests
         {
             logs.Add(e);
         });
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseLogMessageEventAsync("test log message", WebDriverBiDiLogLevel.Warn);
         Assert.Single(logs);
 
@@ -592,8 +592,8 @@ public class BiDiDriverTests
     [Fact]
     public async Task TestDriverCanUseDefaultTransport()
     {
-        ManualResetEvent connectionSyncEvent = new(false);
-        void connectionHandler(ClientConnectionEventArgs e) { connectionSyncEvent.Set(); }
+        TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        void connectionHandler(ClientConnectionEventArgs e) { connectionTaskCompletionSource.TrySetResult(); }
         static void handler(ServerDataReceivedEventArgs e) { }
         Server server = new();
         ServerEventObserver<ServerDataReceivedEventArgs> dataReceivedObserver = server.OnDataReceived.AddObserver(handler);
@@ -601,24 +601,23 @@ public class BiDiDriverTests
         await server.StartAsync();
 
         BiDiDriver driver = new();
-        await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
-        bool connectionEventRaised = connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
+        await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await driver.StopAsync(TestContext.Current.CancellationToken);
 
         await server.StopAsync();
         dataReceivedObserver.Unobserve();
-        Assert.True(connectionEventRaised);
     }
 
     [Fact]
     public async Task TestMalformedEventResponseLogsError()
     {
         string connectionId = string.Empty;
-        ManualResetEvent connectionSyncEvent = new(false);
+        TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         void connectionHandler(ClientConnectionEventArgs e)
         {
             connectionId = e.ConnectionId;
-            connectionSyncEvent.Set();
+            connectionTaskCompletionSource.TrySetResult();
         }
 
         Server server = new();
@@ -628,25 +627,25 @@ public class BiDiDriverTests
 
         try
         {
-            await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
-            connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
-            ManualResetEvent logSyncEvent = new(false);
+            await driver.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
+            await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             List<string> driverLog = [];
             driver.OnLogMessage.AddObserver((e) =>
             {
                 if (e.Level >= WebDriverBiDiLogLevel.Error)
                 {
                     driverLog.Add(e.Message);
-                    logSyncEvent.Set();
+                    logTaskCompletionSource.TrySetResult();
                 }
             });
 
-            ManualResetEvent unknownMessageSyncEvent = new(false);
+            TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             string unknownMessage = string.Empty;
             driver.OnUnknownMessageReceived.AddObserver((e) =>
             {
                 unknownMessage = e.Message;
-                unknownMessageSyncEvent.Set();
+                unknownMessageTaskCompletionSource.TrySetResult();
             });
 
             // This payload omits the required "timestamp" field, which should cause an exception
@@ -663,16 +662,17 @@ public class BiDiDriverTests
                                }
                                """;
             await server.SendWebSocketDataAsync(connectionId, eventJson);
-            bool eventsRaised = WaitHandle.WaitAll(new WaitHandle[] { logSyncEvent, unknownMessageSyncEvent }, TimeSpan.FromSeconds(1));
+            await Task.WhenAll(
+                logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+                unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-            Assert.True(eventsRaised);
             Assert.Single(driverLog);
             Assert.Contains("Unexpected error parsing event JSON", driverLog[0]);
             Assert.NotEmpty(unknownMessage);
         }
         finally
         {
-            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+            await driver.StopAsync(TestContext.Current.CancellationToken);
             await server.StopAsync();
         }
     }
@@ -681,11 +681,11 @@ public class BiDiDriverTests
     public async Task TestMalformedNonCommandErrorResponseLogsError()
     {
         string connectionId = string.Empty;
-        ManualResetEvent connectionSyncEvent = new(false);
+        TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         void connectionHandler(ClientConnectionEventArgs e)
         {
             connectionId = e.ConnectionId;
-            connectionSyncEvent.Set();
+            connectionTaskCompletionSource.TrySetResult();
         }
 
         Server server = new();
@@ -695,30 +695,30 @@ public class BiDiDriverTests
 
         try
         {
-            await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
-            connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
+            await driver.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
+            await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             driver.BrowsingContext.OnLoad.AddObserver((e) =>
             {
             });
 
-            ManualResetEvent logSyncEvent = new(false);
+            TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             List<string> driverLog = [];
             driver.OnLogMessage.AddObserver((e) =>
             {
                 if (e.Level >= WebDriverBiDiLogLevel.Error)
                 {
                     driverLog.Add(e.Message);
-                    logSyncEvent.Set();
+                    logTaskCompletionSource.TrySetResult();
                 }
             });
 
-            ManualResetEvent unknownMessageSyncEvent = new(false);
+            TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             string unknownMessage = string.Empty;
             driver.OnUnknownMessageReceived.AddObserver((e) =>
             {
                 unknownMessage = e.Message;
-                unknownMessageSyncEvent.Set();
+                unknownMessageTaskCompletionSource.TrySetResult();
             });
 
             // This payload uses an object for the error field, which should cause an exception
@@ -734,8 +734,9 @@ public class BiDiDriverTests
                           }
                           """;
             await server.SendWebSocketDataAsync(connectionId, json);
-            bool eventsRaised = WaitHandle.WaitAll(new WaitHandle[] { logSyncEvent, unknownMessageSyncEvent }, TimeSpan.FromSeconds(1));
-            Assert.True(eventsRaised);
+            await Task.WhenAll(
+                logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+                unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
             Assert.Single(driverLog);
             Assert.Contains("Unexpected error parsing error JSON", driverLog[0]);
@@ -743,7 +744,7 @@ public class BiDiDriverTests
         }
         finally
         {
-            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+            await driver.StopAsync(TestContext.Current.CancellationToken);
             await server.StopAsync();
         }
     }
@@ -752,11 +753,11 @@ public class BiDiDriverTests
     public async Task TestMalformedIncomingMessageLogsError()
     {
         string connectionId = string.Empty;
-        ManualResetEvent connectionSyncEvent = new(false);
+        TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         void connectionHandler(ClientConnectionEventArgs e)
         {
             connectionId = e.ConnectionId;
-            connectionSyncEvent.Set();
+            connectionTaskCompletionSource.TrySetResult();
         }
 
         Server server = new();
@@ -766,26 +767,26 @@ public class BiDiDriverTests
 
         try
         {
-            await driver.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
-            connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
+            await driver.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
+            await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-            ManualResetEvent logSyncEvent = new(false);
+            TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             List<string> driverLog = [];
             driver.OnLogMessage.AddObserver((e) =>
             {
                 if (e.Level >= WebDriverBiDiLogLevel.Error)
                 {
                     driverLog.Add(e.Message);
-                    logSyncEvent.Set();
+                    logTaskCompletionSource.TrySetResult();
                 }
             });
 
-            ManualResetEvent unknownMessageSyncEvent = new(false);
+            TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             string unknownMessage = string.Empty;
             driver.OnUnknownMessageReceived.AddObserver((e) =>
             {
                 unknownMessage = e.Message;
-                unknownMessageSyncEvent.Set();
+                unknownMessageTaskCompletionSource.TrySetResult();
             });
 
             // This payload uses unparsable JSON, which should cause an exception
@@ -799,8 +800,9 @@ public class BiDiDriverTests
                                }
                                """;
             await server.SendWebSocketDataAsync(connectionId, unparsableJson);
-            bool eventsRaised = WaitHandle.WaitAll([logSyncEvent, unknownMessageSyncEvent], TimeSpan.FromSeconds(1));
-            Assert.True(eventsRaised);
+            await Task.WhenAll(
+                logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+                unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
             Assert.Single(driverLog);
             Assert.Contains("Unexpected error parsing JSON message", driverLog[0]);
@@ -808,7 +810,7 @@ public class BiDiDriverTests
         }
         finally
         {
-            await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+            await driver.StopAsync(TestContext.Current.CancellationToken);
             await server.StopAsync();
         }
     }
@@ -865,8 +867,8 @@ public class BiDiDriverTests
         // proving both commands were in-flight simultaneously before either responded.
         // delayResponseGate: held until after Task.WaitAny confirms the fast command
         // finished first, then released so the delay command can respond.
-        using ManualResetEventSlim delayCommandInFlight = new(false);
-        using ManualResetEventSlim delayResponseGate = new(false);
+        TaskCompletionSource delayCommandInFlightTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource delayResponseGateTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -876,12 +878,12 @@ public class BiDiDriverTests
                 DateTime start = DateTime.Now;
                 if (e.SentCommandName is not null && e.SentCommandName.Contains("delay"))
                 {
-                    delayCommandInFlight.Set();
-                    delayResponseGate.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+                    delayCommandInFlightTaskCompletionSource.TrySetResult();
+                    await delayResponseGateTaskCompletionSource.Task;
                 }
                 else
                 {
-                    delayCommandInFlight.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+                    await delayCommandInFlightTaskCompletionSource.Task;
                 }
 
                 TimeSpan elapsed = DateTime.Now - start;
@@ -901,7 +903,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string delayCommandName = "module.delayCommand";
         TestCommandParameters delayCommand = new(delayCommandName);
@@ -917,7 +919,7 @@ public class BiDiDriverTests
 
         Task<TestCommandResult> firstFinished = await Task.WhenAny(parallelTasks).WaitAsync(TestContext.Current.CancellationToken);
         int indexOfFirstFinishedTask = Array.IndexOf(parallelTasks, firstFinished);
-        delayResponseGate.Set();
+        delayResponseGateTaskCompletionSource.TrySetResult();
         TestCommandResult[] results = await Task.WhenAll(parallelTasks).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, indexOfFirstFinishedTask);
@@ -932,9 +934,9 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -944,7 +946,7 @@ public class BiDiDriverTests
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.DisposeAsync();
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -953,7 +955,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         await driver.DisposeAsync();
     }
@@ -964,8 +966,8 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
+        await driver.StopAsync(TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
     }
 
@@ -975,7 +977,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
     }
@@ -986,9 +988,9 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1013,7 +1015,7 @@ public class BiDiDriverTests
 
         await using (BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport))
         {
-            await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+            await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
             TestCommandResult result = await driver.ExecuteCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
             Assert.NotNull(result.Value);
             commandValue = result.Value;
@@ -1028,7 +1030,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         Assert.ThrowsAny<ObjectDisposedException>(() => driver.RegisterModule(new TestProtocolModule(driver)));
     }
@@ -1041,7 +1043,7 @@ public class BiDiDriverTests
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
         driver.RegisterModule(module);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         Assert.ThrowsAny<ObjectDisposedException>(() => driver.GetModule<TestProtocolModule>(module.ModuleName));
     }
@@ -1053,7 +1055,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         Assert.ThrowsAny<ObjectDisposedException>(() => driver.RegisterEvent("protocol.event", eventInvoker));
     }
@@ -1064,7 +1066,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.False(transport.IsDisposed);
         await driver.DisposeAsync();
         Assert.True(transport.IsDisposed);
@@ -1088,7 +1090,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         driver.OnLogMessage.AddObserver((e) =>
         {
             logs.Add(e);
@@ -1108,7 +1110,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
+        await driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1117,8 +1119,8 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
-        InvalidOperationException exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken));
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
+        InvalidOperationException exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken));
         Assert.Contains("Cannot register a type info resolver after the transport is connected", exception.Message);
     }
 
@@ -1129,7 +1131,7 @@ public class BiDiDriverTests
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.DisposeAsync();
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1152,7 +1154,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         CommandParameters command = new TestCommandParameters("module.command");
         TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken);
@@ -1179,10 +1181,10 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         CommandParameters command = new TestCommandParameters("module.command");
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(1500), cancellationToken: TestContext.Current.CancellationToken);
+        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(1500), TestContext.Current.CancellationToken);
         Assert.Equal("command result value", result.Value);
     }
 
@@ -1192,7 +1194,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         CommandParameters command = new TestCommandParameters("test.command");
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
@@ -1204,10 +1206,10 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         CommandParameters command = new TestCommandParameters("test.command");
-        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1228,7 +1230,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
@@ -1242,7 +1244,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
@@ -1253,18 +1255,18 @@ public class BiDiDriverTests
     [Fact]
     public async Task TestExecuteCommandCancelsCommandOnCancellation()
     {
-        using ManualResetEventSlim commandSent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
-        connection.DataSendComplete += (_, _) => commandSent.Set();
+        connection.DataSendComplete += (_, _) => taskCompletionSource.TrySetResult();
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         using CancellationTokenSource cts = new();
         CommandParameters command = new TestCommandParameters("module.command");
 
         Task<TestCommandResult> executeTask = driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(30), cts.Token);
-        commandSent.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await executeTask);
@@ -1286,7 +1288,7 @@ public class BiDiDriverTests
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         CommandParameters command = new TestCommandParameters("module.command");
-        await Assert.ThrowsAnyAsync<ArgumentOutOfRangeException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(-5), cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ArgumentOutOfRangeException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(-5), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1310,9 +1312,9 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.Zero, cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.Zero, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1334,9 +1336,9 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal("command result value", result.Value);
     }
 
@@ -1359,9 +1361,9 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        await driver.ExecuteCommandAsync<TestCommandResult>(command, Timeout.InfiniteTimeSpan, cancellationToken: TestContext.Current.CancellationToken);
+        await driver.ExecuteCommandAsync<TestCommandResult>(command, Timeout.InfiniteTimeSpan, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1385,9 +1387,9 @@ public class BiDiDriverTests
         };
         TestTransport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
-        await driver.ExecuteCommandAsync<TestCommandResult>(command, null, cancellationToken: TestContext.Current.CancellationToken);
+        await driver.ExecuteCommandAsync<TestCommandResult>(command, null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1453,7 +1455,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => driver.RegisterTypeInfoResolverAsync(null!, cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => driver.RegisterTypeInfoResolverAsync(null!, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1524,7 +1526,7 @@ public class BiDiDriverTests
 
         Transport transport = new(connection);
         BiDiDriver driver = new(Timeout.InfiniteTimeSpan, transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         // Fire N tasks concurrently. Each sender tags its command with a unique
         // parameterName so we can prove end-to-end that the response it receives was
@@ -1545,7 +1547,7 @@ public class BiDiDriverTests
         // bound is a safety net to prevent a CI hang if something goes wrong; under normal
         // operation Wait returns as soon as all signals arrive. If Wait returns false, the
         // remaining assertions in the test are not meaningful, so fail fast here.
-        if (!allSendsCompleted.Wait(TimeSpan.FromSeconds(30), cancellationToken: TestContext.Current.CancellationToken))
+        if (!allSendsCompleted.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken))
         {
             throw new Xunit.Sdk.XunitException("all sends should complete before the safety timeout");
         }
@@ -1582,7 +1584,7 @@ public class BiDiDriverTests
             Assert.Equal(expectedValues[i], results[i].Value);
         }
 
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1593,11 +1595,11 @@ public class BiDiDriverTests
         // promptly, rather than hanging until the command timeout expires. This is the
         // driver-level passthrough of the transport behavior covered by
         // TransportTests.TestRemoteDisconnectFailsPendingCommands.
-        ManualResetEventSlim commandQueued = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         connection.DataSendComplete += (object? sender, TestWebSocketConnectionDataSentEventArgs e) =>
         {
-            commandQueued.Set();
+            taskCompletionSource.TrySetResult();
         };
 
         Transport transport = new(connection);
@@ -1606,12 +1608,12 @@ public class BiDiDriverTests
         // elapsed. The assertion timeout below is much shorter, so a broken
         // path fails fast rather than timing out the whole suite.
         BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new("module.command");
         Task<TestCommandResult> executeTask = Task.Run(() => driver.ExecuteCommandAsync<TestCommandResult>(command, cancellationToken: TestContext.Current.CancellationToken));
 
-        Assert.True(commandQueued.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
@@ -1633,9 +1635,9 @@ public class BiDiDriverTests
         // WaitForAsync must attach a new reporting continuation so the fault surfaces
         // via OnEventHandlerErrorOccurred instead of being silently swallowed.
         EventObserverErrorInfo? errorInfo = null;
-        using ManualResetEventSlim handlerStarted = new(false);
-        using ManualResetEventSlim allowFault = new(false);
-        using ManualResetEventSlim errorReported = new(false);
+        TaskCompletionSource handlerStartedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource allowFaultTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource errorReportedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -1646,8 +1648,8 @@ public class BiDiDriverTests
             {
                 if (e.BrowsingContextId == "racedContextId")
                 {
-                    handlerStarted.Set();
-                    await Task.Run(() => allowFault.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
+                    handlerStartedTaskCompletionSource.TrySetResult();
+                    await allowFaultTaskCompletionSource.Task;
                     throw new InvalidOperationException("raced task fault");
                 }
             },
@@ -1656,10 +1658,10 @@ public class BiDiDriverTests
         driver.OnEventHandlerErrorOccurred.AddObserver(e =>
         {
             errorInfo = e.ErrorInfo with { };
-            errorReported.Set();
+            errorReportedTaskCompletionSource.TrySetResult();
         });
 
-        await driver.StartAsync("ws://localhost:5555", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string collectedEventJson = """
             {
@@ -1701,17 +1703,15 @@ public class BiDiDriverTests
         await connection.RaiseDataReceivedEventAsync(collectedEventJson);
         // Deliver the raced event — its handler starts and blocks.
         await connection.RaiseDataReceivedEventAsync(racedEventJson);
-        handlerStarted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await handlerStartedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // WaitForAsync collects 1 task, auto-closes, drains the raced task.
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         _ = Assert.Single(tasks);
 
         // Let the raced handler fault.
-        allowFault.Set();
-        bool reported = errorReported.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.True(reported);
+        allowFaultTaskCompletionSource.TrySetResult();
+        await errorReportedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.NotNull(errorInfo);
         InvalidOperationException ex = Assert.IsType<InvalidOperationException>(errorInfo.Exception);
         Assert.Equal("raced task fault", ex.Message);

--- a/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
+++ b/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
@@ -32,7 +32,8 @@ public class BiDiDriverTests
         {
             ReturnCustomValue = true
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         Assert.False(driver.IsStarted);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.True(driver.IsStarted);
@@ -59,7 +60,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
@@ -87,7 +88,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
@@ -127,7 +128,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
@@ -142,7 +143,7 @@ public class BiDiDriverTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.OnUnexpectedErrorReceived.AddObserver((ErrorReceivedEventArgs e) =>
         {
             response = e.ErrorData;
@@ -178,7 +179,7 @@ public class BiDiDriverTests
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask);
         driver.OnEventReceived.AddObserver((e) =>
         {
@@ -215,7 +216,7 @@ public class BiDiDriverTests
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask);
         ArgumentException exception = Assert.ThrowsAny<ArgumentException>(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask));
         Assert.StartsWith("An event named 'module.event' has already been registered.", exception.Message);
@@ -227,7 +228,7 @@ public class BiDiDriverTests
         string eventName = "module.event";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.ThrowsAny<InvalidOperationException>(() => driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask));
     }
@@ -245,7 +246,7 @@ public class BiDiDriverTests
         {
             MessageProcessingDelay = TimeSpan.FromMilliseconds(100)
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterEvent<TestEventArgs>(eventName, (e) => Task.CompletedTask);
         driver.OnEventReceived.AddObserver((e) =>
         {
@@ -285,7 +286,7 @@ public class BiDiDriverTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.OnUnknownMessageReceived.AddObserver((e) =>
         {
             receivedMessage = e.Message;
@@ -315,7 +316,7 @@ public class BiDiDriverTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.OnUnknownMessageReceived.AddObserver((e) =>
         {
             receivedMessage = e.Message;
@@ -345,7 +346,7 @@ public class BiDiDriverTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         EventObserver<BrowsingContextEventArgs> browsingContextObserver = driver.BrowsingContext.OnContextCreated.AddObserver(async e =>
         {
             try
@@ -396,7 +397,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         try
         {
@@ -428,7 +429,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterModule(new TestProtocolModule(driver));
         Assert.IsType<TestProtocolModule>(driver.GetModule<TestProtocolModule>("protocol"));
     }
@@ -438,7 +439,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterModule(new TestProtocolModule(driver, 0, false));
         Assert.StartsWith("A module with the name 'protocol' has already been registered", Assert.ThrowsAny<ArgumentException>(() => driver.RegisterModule(new TestProtocolModule(driver))).Message);
     }
@@ -448,7 +449,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.ThrowsAny<InvalidOperationException>(() => driver.RegisterModule(new TestProtocolModule(driver, 0, false)));
     }
@@ -458,7 +459,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.Contains("Module 'protocol' is not registered with this driver", Assert.ThrowsAny<ArgumentException>(() => driver.GetModule<TestProtocolModule>("protocol")).Message);
     }
 
@@ -467,7 +468,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         driver.RegisterModule(new TestProtocolModule(driver));
         Assert.Equal("Module 'protocol' is registered with this driver, but the module object is not of type WebDriverBiDi.Session.SessionModule", Assert.ThrowsAny<InvalidCastException>(() => driver.GetModule<SessionModule>("protocol")).Message);
     }
@@ -479,7 +480,7 @@ public class BiDiDriverTests
         {
             ReturnCustomValue = true
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
         Assert.Contains("is unexpectedly null", exception.Message);
@@ -492,7 +493,7 @@ public class BiDiDriverTests
         {
             ShouldCancelCommand = true
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.Contains("was canceled before a result was received", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
@@ -504,7 +505,7 @@ public class BiDiDriverTests
         {
             ReturnUncompletedCommand = true
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.Contains("is unexpectedly null", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
@@ -512,7 +513,7 @@ public class BiDiDriverTests
     [Fact]
     public async Task TestExecutingCommandWillThrowWhenTimeout()
     {
-        BiDiDriver driver = new(TimeSpan.Zero, new Transport(new TestWebSocketConnection()));
+        await using BiDiDriver driver = new(TimeSpan.Zero, new Transport(new TestWebSocketConnection()));
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.Contains("Timed out executing command test.command", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
@@ -522,7 +523,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
@@ -541,7 +542,7 @@ public class BiDiDriverTests
             ReturnCustomValue = true,
             CustomReturnValue = result
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.Equal("Could not convert error response from transport for SendCommandAndWait to ErrorResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
@@ -562,7 +563,7 @@ public class BiDiDriverTests
             ReturnCustomValue = true,
             CustomReturnValue = result
         };
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.Equal("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
@@ -574,7 +575,7 @@ public class BiDiDriverTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(100), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(100), transport);
         driver.OnLogMessage.AddObserver((e) =>
         {
             logs.Add(e);
@@ -593,14 +594,14 @@ public class BiDiDriverTests
     public async Task TestDriverCanUseDefaultTransport()
     {
         TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        void connectionHandler(ClientConnectionEventArgs e) { connectionTaskCompletionSource.TrySetResult(); }
-        static void handler(ServerDataReceivedEventArgs e) { }
+        void ConnectionHandler(ClientConnectionEventArgs e) { connectionTaskCompletionSource.TrySetResult(); }
+        static void Handler(ServerDataReceivedEventArgs e) { }
         Server server = new();
-        ServerEventObserver<ServerDataReceivedEventArgs> dataReceivedObserver = server.OnDataReceived.AddObserver(handler);
-        server.OnClientConnected.AddObserver(connectionHandler);
+        ServerEventObserver<ServerDataReceivedEventArgs> dataReceivedObserver = server.OnDataReceived.AddObserver(Handler);
+        server.OnClientConnected.AddObserver(ConnectionHandler);
         await server.StartAsync();
 
-        BiDiDriver driver = new();
+        await using BiDiDriver driver = new();
         await driver.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         await connectionTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await driver.StopAsync(TestContext.Current.CancellationToken);
@@ -614,16 +615,16 @@ public class BiDiDriverTests
     {
         string connectionId = string.Empty;
         TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        void connectionHandler(ClientConnectionEventArgs e)
+        void ConnectionHandler(ClientConnectionEventArgs e)
         {
             connectionId = e.ConnectionId;
             connectionTaskCompletionSource.TrySetResult();
         }
 
         Server server = new();
-        server.OnClientConnected.AddObserver(connectionHandler);
+        server.OnClientConnected.AddObserver(ConnectionHandler);
         await server.StartAsync();
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30));
 
         try
         {
@@ -682,16 +683,16 @@ public class BiDiDriverTests
     {
         string connectionId = string.Empty;
         TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        void connectionHandler(ClientConnectionEventArgs e)
+        void ConnectionHandler(ClientConnectionEventArgs e)
         {
             connectionId = e.ConnectionId;
             connectionTaskCompletionSource.TrySetResult();
         }
 
         Server server = new();
-        server.OnClientConnected.AddObserver(connectionHandler);
+        server.OnClientConnected.AddObserver(ConnectionHandler);
         await server.StartAsync();
-        BiDiDriver driver = new();
+        await using BiDiDriver driver = new();
 
         try
         {
@@ -754,16 +755,16 @@ public class BiDiDriverTests
     {
         string connectionId = string.Empty;
         TaskCompletionSource connectionTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        void connectionHandler(ClientConnectionEventArgs e)
+        void ConnectionHandler(ClientConnectionEventArgs e)
         {
             connectionId = e.ConnectionId;
             connectionTaskCompletionSource.TrySetResult();
         }
 
         Server server = new();
-        server.OnClientConnected.AddObserver(connectionHandler);
+        server.OnClientConnected.AddObserver(ConnectionHandler);
         await server.StartAsync();
-        BiDiDriver driver = new();
+        await using BiDiDriver driver = new();
 
         try
         {
@@ -820,7 +821,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.Equal(TransportErrorBehavior.Ignore, driver.EventHandlerExceptionBehavior);
         driver.EventHandlerExceptionBehavior = TransportErrorBehavior.Collect;
         Assert.Equal(TransportErrorBehavior.Collect, transport.EventHandlerExceptionBehavior);
@@ -831,7 +832,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.Equal(TransportErrorBehavior.Ignore, driver.UnexpectedErrorBehavior);
         driver.UnexpectedErrorBehavior = TransportErrorBehavior.Collect;
         Assert.Equal(TransportErrorBehavior.Collect, transport.UnexpectedErrorBehavior);
@@ -842,7 +843,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.Equal(TransportErrorBehavior.Ignore, driver.ProtocolErrorBehavior);
         driver.ProtocolErrorBehavior = TransportErrorBehavior.Collect;
         Assert.Equal(TransportErrorBehavior.Collect, transport.ProtocolErrorBehavior);
@@ -853,7 +854,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.Equal(TransportErrorBehavior.Ignore, driver.UnknownMessageBehavior);
         driver.UnknownMessageBehavior = TransportErrorBehavior.Collect;
         Assert.Equal(TransportErrorBehavior.Collect, transport.UnknownMessageBehavior);
@@ -902,7 +903,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         string delayCommandName = "module.delayCommand";
@@ -933,7 +934,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken));
@@ -944,7 +945,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.DisposeAsync();
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken));
     }
@@ -954,7 +955,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         await driver.DisposeAsync();
@@ -965,7 +966,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.StopAsync(TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
@@ -976,7 +977,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), cancellationToken: TestContext.Current.CancellationToken));
@@ -987,7 +988,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command"), TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
@@ -1029,7 +1030,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         Assert.ThrowsAny<ObjectDisposedException>(() => driver.RegisterModule(new TestProtocolModule(driver)));
@@ -1040,7 +1041,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
         driver.RegisterModule(module);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
@@ -1054,7 +1055,7 @@ public class BiDiDriverTests
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = (eventData) => Task.CompletedTask;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         Assert.ThrowsAny<ObjectDisposedException>(() => driver.RegisterEvent("protocol.event", eventInvoker));
@@ -1065,7 +1066,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         Assert.False(transport.IsDisposed);
         await driver.DisposeAsync();
@@ -1077,7 +1078,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.False(transport.IsDisposed);
         await driver.DisposeAsync();
         Assert.True(transport.IsDisposed);
@@ -1089,7 +1090,7 @@ public class BiDiDriverTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         driver.OnLogMessage.AddObserver((e) =>
         {
@@ -1109,7 +1110,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken);
     }
 
@@ -1118,7 +1119,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         InvalidOperationException exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken));
         Assert.Contains("Cannot register a type info resolver after the transport is connected", exception.Message);
@@ -1129,7 +1130,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.DisposeAsync();
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => driver.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken));
     }
@@ -1153,7 +1154,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         CommandParameters command = new TestCommandParameters("module.command");
@@ -1180,7 +1181,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(1500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         CommandParameters command = new TestCommandParameters("module.command");
@@ -1193,7 +1194,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         CommandParameters command = new TestCommandParameters("test.command");
@@ -1205,7 +1206,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         await driver.DisposeAsync();
         CommandParameters command = new TestCommandParameters("test.command");
@@ -1217,7 +1218,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
@@ -1229,7 +1230,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
@@ -1243,7 +1244,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
@@ -1259,7 +1260,7 @@ public class BiDiDriverTests
         TestWebSocketConnection connection = new();
         connection.DataSendComplete += (_, _) => taskCompletionSource.TrySetResult();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         using CancellationTokenSource cts = new();
@@ -1277,7 +1278,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await Assert.ThrowsAnyAsync<ArgumentNullException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(null!, cancellationToken: TestContext.Current.CancellationToken));
     }
 
@@ -1286,7 +1287,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         CommandParameters command = new TestCommandParameters("module.command");
         await Assert.ThrowsAnyAsync<ArgumentOutOfRangeException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(-5), TestContext.Current.CancellationToken));
     }
@@ -1311,7 +1312,7 @@ public class BiDiDriverTests
             await connection.RaiseDataReceivedEventAsync(eventJson);
         };
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
         await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.Zero, TestContext.Current.CancellationToken));
@@ -1335,7 +1336,7 @@ public class BiDiDriverTests
             await connection.RaiseDataReceivedEventAsync(eventJson);
         };
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
         TestCommandResult result = await driver.ExecuteCommandAsync<TestCommandResult>(command, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
@@ -1360,7 +1361,7 @@ public class BiDiDriverTests
             await connection.RaiseDataReceivedEventAsync(eventJson);
         };
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
         await driver.ExecuteCommandAsync<TestCommandResult>(command, Timeout.InfiniteTimeSpan, TestContext.Current.CancellationToken);
@@ -1386,7 +1387,7 @@ public class BiDiDriverTests
             await connection.RaiseDataReceivedEventAsync(eventJson);
         };
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
         CommandParameters command = new TestCommandParameters("module.command");
         await driver.ExecuteCommandAsync<TestCommandResult>(command, null, TestContext.Current.CancellationToken);
@@ -1398,7 +1399,7 @@ public class BiDiDriverTests
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = (eventData) => Task.CompletedTask;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.ThrowsAny<ArgumentException>(() => driver.RegisterEvent(null!, eventInvoker));
     }
 
@@ -1408,7 +1409,7 @@ public class BiDiDriverTests
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = (eventData) => Task.CompletedTask;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.ThrowsAny<ArgumentException>(() => driver.RegisterEvent(string.Empty, eventInvoker));
     }
 
@@ -1418,7 +1419,7 @@ public class BiDiDriverTests
         Func<EventInfo<TestEventArgs>, Task> eventInvoker = null!;
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.ThrowsAny<ArgumentNullException>(() => driver.RegisterEvent("protocol.event", eventInvoker!));
     }
 
@@ -1427,7 +1428,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.ThrowsAny<ArgumentNullException>(() => driver.RegisterModule(null!));
     }
 
@@ -1436,7 +1437,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.ThrowsAny<ArgumentException>(() => driver.GetModule<TestProtocolModule>(null!));
     }
 
@@ -1445,7 +1446,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         Assert.ThrowsAny<ArgumentException>(() => driver.GetModule<TestProtocolModule>(string.Empty));
     }
 
@@ -1454,7 +1455,7 @@ public class BiDiDriverTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         await Assert.ThrowsAnyAsync<ArgumentNullException>(() => driver.RegisterTypeInfoResolverAsync(null!, TestContext.Current.CancellationToken));
     }
 
@@ -1525,7 +1526,7 @@ public class BiDiDriverTests
         };
 
         Transport transport = new(connection);
-        BiDiDriver driver = new(Timeout.InfiniteTimeSpan, transport);
+        await using BiDiDriver driver = new(Timeout.InfiniteTimeSpan, transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         // Fire N tasks concurrently. Each sender tags its command with a unique
@@ -1607,7 +1608,7 @@ public class BiDiDriverTests
         // command sat in the pending collection, the test would hang until this
         // elapsed. The assertion timeout below is much shorter, so a broken
         // path fails fast rather than timing out the whole suite.
-        BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(30), transport);
         await driver.StartAsync("ws://localhost:5555", TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new("module.command");
@@ -1641,7 +1642,7 @@ public class BiDiDriverTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
 
         driver.BrowsingContext.OnContextCreated.AddObserver(
             async (BrowsingContextEventArgs e) =>

--- a/test/WebDriverBiDi.Tests/Bluetooth/BluetoothManufacturerDataTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/BluetoothManufacturerDataTests.cs
@@ -3,44 +3,51 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class BluetoothManufacturerDataTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         BluetoothManufacturerData properties = new(123, "myData");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("key"));
-            Assert.That(serialized["key"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["key"]!.Value<uint>(), Is.EqualTo(123));
-            Assert.That(serialized, Contains.Key("data"));
-            Assert.That(serialized["data"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["data"]!.Value<string>(), Is.EqualTo("myData"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("key"));
+        JToken? key = serialized["key"];
+        Assert.NotNull(key);
+        Assert.Equal(JTokenType.Integer, key.Type);
+        Assert.Equal(123u, key.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("data"));
+        JToken? data = serialized["data"];
+        Assert.NotNull(data);
+        Assert.Equal(JTokenType.String, data.Type);
+        Assert.Equal("myData", data.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanUpdatePropertiesAfterInstantiation()
     {
-        BluetoothManufacturerData properties = new(123, "myData");
-        properties.Key = 456;
-        properties.Data = "myUpdatedData";
+        BluetoothManufacturerData properties = new(123, "myData")
+        {
+            Key = 456,
+            Data = "myUpdatedData"
+        };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("key"));
-            Assert.That(serialized["key"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["key"]!.Value<uint>(), Is.EqualTo(456));
-            Assert.That(serialized, Contains.Key("data"));
-            Assert.That(serialized["data"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["data"]!.Value<string>(), Is.EqualTo("myUpdatedData"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("key"));
+        JToken? key = serialized["key"];
+        Assert.NotNull(key);
+        Assert.Equal(JTokenType.Integer, key.Type);
+        Assert.Equal(456u, key.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("data"));
+        JToken? data = serialized["data"];
+        Assert.NotNull(data);
+        Assert.Equal(JTokenType.String, data.Type);
+        Assert.Equal("myUpdatedData", data.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Bluetooth;
 
 using TestUtilities;
 
-[TestFixture]
 public class BluetoothModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestDisableSimulation()
     {
         TestWebSocketConnection connection = new();
@@ -22,17 +21,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<DisableSimulationCommandResult> task = module.DisableSimulationAsync(new DisableSimulationCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        DisableSimulationCommandResult result = task.Result;
+        Task<DisableSimulationCommandResult> task = module.DisableSimulationAsync(new DisableSimulationCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        DisableSimulationCommandResult result = await task;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestHandleRequestDevicePromptCommandAcceptingPrompt()
     {
         TestWebSocketConnection connection = new();
@@ -49,17 +47,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptAcceptCommandParameters("myContextId", "myPromptId", "myDeviceId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        EmptyResult result = task.Result;
+        Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptAcceptCommandParameters("myContextId", "myPromptId", "myDeviceId"), cancellationToken: TestContext.Current.CancellationToken);
+        HandleRequestDevicePromptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestHandleRequestDevicePromptCommandCancelingPrompt()
     {
         TestWebSocketConnection connection = new();
@@ -76,17 +73,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptCancelCommandParameters("myContextId", "myPromptId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        HandleRequestDevicePromptCommandResult result = task.Result;
+        Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptCancelCommandParameters("myContextId", "myPromptId"), cancellationToken: TestContext.Current.CancellationToken);
+        HandleRequestDevicePromptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateAdapterCommand()
     {
         TestWebSocketConnection connection = new();
@@ -103,16 +99,15 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateAdapterCommandResult> task = module.SimulateAdapterAsync(new SimulateAdapterCommandParameters("myContextId", AdapterState.PoweredOn));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateAdapterCommandResult result = task.Result;
-        Assert.That(result, Is.Not.Null);
+        Task<SimulateAdapterCommandResult> task = module.SimulateAdapterAsync(new SimulateAdapterCommandParameters("myContextId", AdapterState.PoweredOn), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateAdapterCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateAdvertisementCommand()
     {
         TestWebSocketConnection connection = new();
@@ -129,17 +124,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateAdvertisementCommandResult> task = module.SimulateAdvertisementAsync(new SimulateAdvertisementCommandParameters("myContextId", new SimulateAdvertisementScanEntry("08:08:08:08:08", -10, new ScanRecord())));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateAdvertisementCommandResult result = task.Result;
+        Task<SimulateAdvertisementCommandResult> task = module.SimulateAdvertisementAsync(new SimulateAdvertisementCommandParameters("myContextId", new SimulateAdvertisementScanEntry("08:08:08:08:08", -10, new ScanRecord())), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateAdvertisementCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateCharacteristic()
     {
         TestWebSocketConnection connection = new();
@@ -156,17 +150,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateCharacteristicCommandResult> task = module.SimulateCharacteristicAsync(new SimulateCharacteristicCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicType.Add));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateCharacteristicCommandResult result = task.Result;
+        Task<SimulateCharacteristicCommandResult> task = module.SimulateCharacteristicAsync(new SimulateCharacteristicCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicType.Add), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateCharacteristicCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateCharacteristicResponse()
     {
         TestWebSocketConnection connection = new();
@@ -183,17 +176,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateCharacteristicResponseCommandResult> task = module.SimulateCharacteristicResponseAsync(new SimulateCharacteristicResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicResponseType.Read, 0));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateCharacteristicResponseCommandResult result = task.Result;
+        Task<SimulateCharacteristicResponseCommandResult> task = module.SimulateCharacteristicResponseAsync(new SimulateCharacteristicResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicResponseType.Read, 0), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateCharacteristicResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateDescriptor()
     {
         TestWebSocketConnection connection = new();
@@ -210,17 +202,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateDescriptorCommandResult> task = module.SimulateDescriptorAsync(new SimulateDescriptorCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorType.Add));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateDescriptorCommandResult result = task.Result;
+        Task<SimulateDescriptorCommandResult> task = module.SimulateDescriptorAsync(new SimulateDescriptorCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorType.Add), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateDescriptorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateDescriptorResponse()
     {
         TestWebSocketConnection connection = new();
@@ -237,17 +228,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateDescriptorResponseCommandResult> task = module.SimulateDescriptorResponseAsync(new SimulateDescriptorResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorResponseType.Read, 0));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateDescriptorResponseCommandResult result = task.Result;
+        Task<SimulateDescriptorResponseCommandResult> task = module.SimulateDescriptorResponseAsync(new SimulateDescriptorResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorResponseType.Read, 0), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateDescriptorResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateGattConnectionResponse()
     {
         TestWebSocketConnection connection = new();
@@ -264,17 +254,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateGattConnectionResponseCommandResult> task = module.SimulateGattConnectionResponseAsync(new SimulateGattConnectionResponseCommandParameters("myContextId", "myAddress", 0));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateGattConnectionResponseCommandResult result = task.Result;
+        Task<SimulateGattConnectionResponseCommandResult> task = module.SimulateGattConnectionResponseAsync(new SimulateGattConnectionResponseCommandParameters("myContextId", "myAddress", 0), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateGattConnectionResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateGattDisconnection()
     {
         TestWebSocketConnection connection = new();
@@ -291,17 +280,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateGattDisconnectionCommandResult> task = module.SimulateGattDisconnectionAsync(new SimulateGattDisconnectionCommandParameters("myContextId", "myAddress"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateGattDisconnectionCommandResult result = task.Result;
+        Task<SimulateGattDisconnectionCommandResult> task = module.SimulateGattDisconnectionAsync(new SimulateGattDisconnectionCommandParameters("myContextId", "myAddress"), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateGattDisconnectionCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulatePreconnectedPeripheralCommand()
     {
         TestWebSocketConnection connection = new();
@@ -318,17 +306,16 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulatePreconnectedPeripheralCommandResult> task = module.SimulatePreconnectedPeripheralAsync(new SimulatePreconnectedPeripheralCommandParameters("myContextId", "08:08:08:08:08", "myDeviceName"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulatePreconnectedPeripheralCommandResult result = task.Result;
+        Task<SimulatePreconnectedPeripheralCommandResult> task = module.SimulatePreconnectedPeripheralAsync(new SimulatePreconnectedPeripheralCommandParameters("myContextId", "08:08:08:08:08", "myDeviceName"), cancellationToken: TestContext.Current.CancellationToken);
+        SimulatePreconnectedPeripheralCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSimulateService()
     {
         TestWebSocketConnection connection = new();
@@ -345,36 +332,33 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        Task<SimulateServiceCommandResult> task = module.SimulateServiceAsync(new SimulateServiceCommandParameters("myContextId", "myAddress", "my-service-uuid", SimulateServiceType.Add));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SimulateServiceCommandResult result = task.Result;
+        Task<SimulateServiceCommandResult> task = module.SimulateServiceAsync(new SimulateServiceCommandParameters("myContextId", "myAddress", "my-service-uuid", SimulateServiceType.Add), cancellationToken: TestContext.Current.CancellationToken);
+        SimulateServiceCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveCharacteristicEventGeneratedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         ManualResetEvent syncEvent = new(false);
         module.OnCharacteristicGeneratedEvent.AddObserver((CharacteristicEventGeneratedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Address, Is.EqualTo("myAddress"));
-                Assert.That(e.ServiceUuid, Is.EqualTo("my-service-uuid"));
-                Assert.That(e.CharacteristicUuid, Is.EqualTo("my-characteristic-uuid"));
-                Assert.That(e.Type, Is.EqualTo(CharacteristicEventGeneratedType.Read));
-                Assert.That(e.Data, Is.Null);
-            }
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myAddress", e.Address);
+            Assert.Equal("my-service-uuid", e.ServiceUuid);
+            Assert.Equal("my-characteristic-uuid", e.CharacteristicUuid);
+            Assert.Equal(CharacteristicEventGeneratedType.Read, e.Type);
+            Assert.Null(e.Data);
+
             syncEvent.Set();
         });
 
@@ -393,30 +377,28 @@ public class BluetoothModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveDescriptorEventGeneratedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         ManualResetEvent syncEvent = new(false);
         module.OnDescriptorGeneratedEvent.AddObserver((DescriptorEventGeneratedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Address, Is.EqualTo("myAddress"));
-                Assert.That(e.ServiceUuid, Is.EqualTo("my-service-uuid"));
-                Assert.That(e.CharacteristicUuid, Is.EqualTo("my-characteristic-uuid"));
-                Assert.That(e.DescriptorUuid, Is.EqualTo("my-descriptor-uuid"));
-                Assert.That(e.Type, Is.EqualTo(DescriptorEventGeneratedType.Read));
-                Assert.That(e.Data, Is.Null);
-            }
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myAddress", e.Address);
+            Assert.Equal("my-service-uuid", e.ServiceUuid);
+            Assert.Equal("my-characteristic-uuid", e.CharacteristicUuid);
+            Assert.Equal("my-descriptor-uuid", e.DescriptorUuid);
+            Assert.Equal(DescriptorEventGeneratedType.Read, e.Type);
+            Assert.Null(e.Data);
+
             syncEvent.Set();
         });
 
@@ -436,25 +418,23 @@ public class BluetoothModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestGattConnectionAttemptedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         ManualResetEvent syncEvent = new(false);
         module.OnGattConnectionAttempted.AddObserver((GattConnectionAttemptedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Address, Is.EqualTo("myAddress"));
-            }
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myAddress", e.Address);
+
             syncEvent.Set();
         });
 
@@ -470,28 +450,26 @@ public class BluetoothModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveRequestDevicePromptUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         ManualResetEvent syncEvent = new(false);
         module.OnRequestDevicePromptUpdated.AddObserver((RequestDevicePromptUpdatedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Prompt, Is.EqualTo("myPrompt"));
-                Assert.That(e.Devices, Has.Count.EqualTo(1));
-                Assert.That(e.Devices[0].DeviceId, Is.EqualTo("myDeviceId"));
-                Assert.That(e.Devices[0].DeviceName, Is.EqualTo("myDeviceName"));
-            }
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myPrompt", e.Prompt);
+            Assert.Single(e.Devices);
+            Assert.Equal("myDeviceId", e.Devices[0].DeviceId);
+            Assert.Equal("myDeviceName", e.Devices[0].DeviceName);
+
             syncEvent.Set();
         });
 
@@ -513,6 +491,6 @@ public class BluetoothModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
@@ -77,7 +77,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptCancelCommandParameters("myContextId", "myPromptId"), cancellationToken: TestContext.Current.CancellationToken);
-        HandleRequestDevicePromptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        HandleRequestDevicePromptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -103,7 +103,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateAdapterCommandResult> task = module.SimulateAdapterAsync(new SimulateAdapterCommandParameters("myContextId", AdapterState.PoweredOn), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateAdapterCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateAdapterCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
         Assert.NotNull(result);
     }
 
@@ -128,7 +128,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateAdvertisementCommandResult> task = module.SimulateAdvertisementAsync(new SimulateAdvertisementCommandParameters("myContextId", new SimulateAdvertisementScanEntry("08:08:08:08:08", -10, new ScanRecord())), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateAdvertisementCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateAdvertisementCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -154,7 +154,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateCharacteristicCommandResult> task = module.SimulateCharacteristicAsync(new SimulateCharacteristicCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicType.Add), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateCharacteristicCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateCharacteristicCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -180,7 +180,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateCharacteristicResponseCommandResult> task = module.SimulateCharacteristicResponseAsync(new SimulateCharacteristicResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicResponseType.Read, 0), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateCharacteristicResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateCharacteristicResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -206,7 +206,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateDescriptorCommandResult> task = module.SimulateDescriptorAsync(new SimulateDescriptorCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorType.Add), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateDescriptorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateDescriptorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -232,7 +232,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateDescriptorResponseCommandResult> task = module.SimulateDescriptorResponseAsync(new SimulateDescriptorResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorResponseType.Read, 0), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateDescriptorResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateDescriptorResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -258,7 +258,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateGattConnectionResponseCommandResult> task = module.SimulateGattConnectionResponseAsync(new SimulateGattConnectionResponseCommandParameters("myContextId", "myAddress", 0), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateGattConnectionResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateGattConnectionResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -284,7 +284,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateGattDisconnectionCommandResult> task = module.SimulateGattDisconnectionAsync(new SimulateGattDisconnectionCommandParameters("myContextId", "myAddress"), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateGattDisconnectionCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateGattDisconnectionCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -310,7 +310,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulatePreconnectedPeripheralCommandResult> task = module.SimulatePreconnectedPeripheralAsync(new SimulatePreconnectedPeripheralCommandParameters("myContextId", "08:08:08:08:08", "myDeviceName"), cancellationToken: TestContext.Current.CancellationToken);
-        SimulatePreconnectedPeripheralCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulatePreconnectedPeripheralCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -336,7 +336,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateServiceCommandResult> task = module.SimulateServiceAsync(new SimulateServiceCommandParameters("myContextId", "myAddress", "my-service-uuid", SimulateServiceType.Add), cancellationToken: TestContext.Current.CancellationToken);
-        SimulateServiceCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);;
+        SimulateServiceCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken); ;
 
         Assert.NotNull(result);
     }
@@ -350,7 +350,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnCharacteristicGeneratedEvent.AddObserver((CharacteristicEventGeneratedEventArgs e) =>
+        module.OnCharacteristicGeneratedEvent.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myAddress", e.Address);
@@ -388,7 +388,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnDescriptorGeneratedEvent.AddObserver((DescriptorEventGeneratedEventArgs e) =>
+        module.OnDescriptorGeneratedEvent.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myAddress", e.Address);
@@ -428,7 +428,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnGattConnectionAttempted.AddObserver((GattConnectionAttemptedEventArgs e) =>
+        module.OnGattConnectionAttempted.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myAddress", e.Address);
@@ -459,7 +459,7 @@ public class BluetoothModuleTests
         BluetoothModule module = driver.Bluetooth;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnRequestDevicePromptUpdated.AddObserver((RequestDevicePromptUpdatedEventArgs e) =>
+        module.OnRequestDevicePromptUpdated.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myPrompt", e.Prompt);

--- a/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
@@ -20,7 +20,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -46,7 +46,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -72,7 +72,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -98,7 +98,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -123,7 +123,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -149,7 +149,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -175,7 +175,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -201,7 +201,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -227,7 +227,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -253,7 +253,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -279,7 +279,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -305,7 +305,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -331,7 +331,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -345,7 +345,7 @@ public class BluetoothModuleTests
     public async Task TestCanReceiveCharacteristicEventGeneratedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -383,7 +383,7 @@ public class BluetoothModuleTests
     public async Task TestCanReceiveDescriptorEventGeneratedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -423,7 +423,7 @@ public class BluetoothModuleTests
     public async Task TestGattConnectionAttemptedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -454,7 +454,7 @@ public class BluetoothModuleTests
     public async Task TestCanReceiveRequestDevicePromptUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 

--- a/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
@@ -21,7 +21,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<DisableSimulationCommandResult> task = module.DisableSimulationAsync(new DisableSimulationCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -47,7 +47,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptAcceptCommandParameters("myContextId", "myPromptId", "myDeviceId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -73,7 +73,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<HandleRequestDevicePromptCommandResult> task = module.HandleRequestDevicePromptAsync(new HandleRequestDevicePromptCancelCommandParameters("myContextId", "myPromptId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -99,7 +99,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateAdapterCommandResult> task = module.SimulateAdapterAsync(new SimulateAdapterCommandParameters("myContextId", AdapterState.PoweredOn), cancellationToken: TestContext.Current.CancellationToken);
@@ -124,7 +124,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateAdvertisementCommandResult> task = module.SimulateAdvertisementAsync(new SimulateAdvertisementCommandParameters("myContextId", new SimulateAdvertisementScanEntry("08:08:08:08:08", -10, new ScanRecord())), cancellationToken: TestContext.Current.CancellationToken);
@@ -150,7 +150,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateCharacteristicCommandResult> task = module.SimulateCharacteristicAsync(new SimulateCharacteristicCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicType.Add), cancellationToken: TestContext.Current.CancellationToken);
@@ -176,7 +176,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateCharacteristicResponseCommandResult> task = module.SimulateCharacteristicResponseAsync(new SimulateCharacteristicResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", SimulateCharacteristicResponseType.Read, 0), cancellationToken: TestContext.Current.CancellationToken);
@@ -202,7 +202,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateDescriptorCommandResult> task = module.SimulateDescriptorAsync(new SimulateDescriptorCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorType.Add), cancellationToken: TestContext.Current.CancellationToken);
@@ -228,7 +228,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateDescriptorResponseCommandResult> task = module.SimulateDescriptorResponseAsync(new SimulateDescriptorResponseCommandParameters("myContextId", "myAddress", "my-service-uuid", "my-characteristic-uuid", "my-descriptor-uuid", SimulateDescriptorResponseType.Read, 0), cancellationToken: TestContext.Current.CancellationToken);
@@ -254,7 +254,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateGattConnectionResponseCommandResult> task = module.SimulateGattConnectionResponseAsync(new SimulateGattConnectionResponseCommandParameters("myContextId", "myAddress", 0), cancellationToken: TestContext.Current.CancellationToken);
@@ -280,7 +280,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateGattDisconnectionCommandResult> task = module.SimulateGattDisconnectionAsync(new SimulateGattDisconnectionCommandParameters("myContextId", "myAddress"), cancellationToken: TestContext.Current.CancellationToken);
@@ -306,7 +306,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulatePreconnectedPeripheralCommandResult> task = module.SimulatePreconnectedPeripheralAsync(new SimulatePreconnectedPeripheralCommandParameters("myContextId", "08:08:08:08:08", "myDeviceName"), cancellationToken: TestContext.Current.CancellationToken);
@@ -332,7 +332,7 @@ public class BluetoothModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
         Task<SimulateServiceCommandResult> task = module.SimulateServiceAsync(new SimulateServiceCommandParameters("myContextId", "myAddress", "my-service-uuid", SimulateServiceType.Add), cancellationToken: TestContext.Current.CancellationToken);
@@ -346,10 +346,10 @@ public class BluetoothModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnCharacteristicGeneratedEvent.AddObserver((CharacteristicEventGeneratedEventArgs e) =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
@@ -359,7 +359,7 @@ public class BluetoothModuleTests
             Assert.Equal(CharacteristicEventGeneratedType.Read, e.Type);
             Assert.Null(e.Data);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -376,8 +376,7 @@ public class BluetoothModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -385,10 +384,10 @@ public class BluetoothModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnDescriptorGeneratedEvent.AddObserver((DescriptorEventGeneratedEventArgs e) =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
@@ -399,7 +398,7 @@ public class BluetoothModuleTests
             Assert.Equal(DescriptorEventGeneratedType.Read, e.Type);
             Assert.Null(e.Data);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -417,8 +416,7 @@ public class BluetoothModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -426,16 +424,16 @@ public class BluetoothModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnGattConnectionAttempted.AddObserver((GattConnectionAttemptedEventArgs e) =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myAddress", e.Address);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -449,8 +447,7 @@ public class BluetoothModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -458,10 +455,10 @@ public class BluetoothModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnRequestDevicePromptUpdated.AddObserver((RequestDevicePromptUpdatedEventArgs e) =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
@@ -470,7 +467,7 @@ public class BluetoothModuleTests
             Assert.Equal("myDeviceId", e.Devices[0].DeviceId);
             Assert.Equal("myDeviceName", e.Devices[0].DeviceName);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -490,7 +487,6 @@ public class BluetoothModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/CharacteristicEventGeneratedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/CharacteristicEventGeneratedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CharacteristicEventGeneratedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithReadType()
     {
         string json = """
@@ -18,19 +17,17 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.Read));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.Read, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithWriteWithoutResponseType()
     {
         string json = """
@@ -43,19 +40,17 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.WriteWithoutResponse));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.WriteWithoutResponse, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithWriteWithResponseType()
     {
         string json = """
@@ -68,19 +63,17 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.WriteWithResponse));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.WriteWithResponse, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithSubscribeResponseType()
     {
         string json = """
@@ -93,19 +86,17 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.SubscribeToNotifications));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.SubscribeToNotifications, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUnsubscribeType()
     {
         string json = """
@@ -118,19 +109,17 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.UnsubscribeFromNotifications));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.UnsubscribeFromNotifications, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithEmptyData()
     {
         string json = """
@@ -144,20 +133,18 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.Read));
-            Assert.That(eventArgs.Data, Is.Not.Null);
-            Assert.That(eventArgs.Data, Is.Empty);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.Read, eventArgs.Type);
+        Assert.NotNull(eventArgs.Data);
+        Assert.Empty(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithData()
     {
         string json = """
@@ -171,22 +158,20 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(CharacteristicEventGeneratedType.Read));
-            Assert.That(eventArgs.Data, Is.Not.Null);
-            Assert.That(eventArgs.Data, Has.Count.EqualTo(2));
-            Assert.That(eventArgs.Data![0], Is.EqualTo(123));
-            Assert.That(eventArgs.Data![1], Is.EqualTo(456));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(CharacteristicEventGeneratedType.Read, eventArgs.Type);
+        Assert.NotNull(eventArgs.Data);
+        Assert.Equal(2, eventArgs.Data.Count);
+        Assert.Equal<uint>(123U, eventArgs.Data[0]);
+        Assert.Equal<uint>(456U, eventArgs.Data[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -199,12 +184,12 @@ public class CharacteristicEventGeneratedEventArgsTests
                       }
                       """;
         CharacteristicEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         CharacteristicEventGeneratedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = """
@@ -215,10 +200,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -230,10 +215,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingAddressThrows()
     {
         string json = """
@@ -244,10 +229,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidAddressTypeThrows()
     {
         string json = """
@@ -259,10 +244,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingServiceUuidThrows()
     {
         string json = """
@@ -273,10 +258,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidServiceUuidTypeThrows()
     {
         string json = """
@@ -288,10 +273,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingCharacteristicUuidThrows()
     {
         string json = """
@@ -302,10 +287,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                      """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidCharacteristicUuidTypeThrows()
     {
         string json = """
@@ -317,10 +302,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTypeThrows()
     {
         string json = """
@@ -331,10 +316,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "characteristicUuid": "myCharacteristicUuid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTypeDataTypeThrows()
     {
         string json = """
@@ -346,10 +331,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTypeValueThrows()
     {
         string json = """
@@ -361,10 +346,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "type": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInvalidDataType()
     {
         string json = """
@@ -377,10 +362,10 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "data": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInvalidDataElementsType()
     {
         string json = """
@@ -393,6 +378,6 @@ public class CharacteristicEventGeneratedEventArgsTests
                         "data": ["123", false]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/CharacteristicPropertiesTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/CharacteristicPropertiesTests.cs
@@ -3,19 +3,18 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CharacteristicPropertiesTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         CharacteristicProperties properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(0));
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAllValuesTrue()
     {
         CharacteristicProperties properties = new()
@@ -31,37 +30,58 @@ public class CharacteristicPropertiesTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(8));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("broadcast"));
-            Assert.That(serialized["broadcast"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["broadcast"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("read"));
-            Assert.That(serialized["read"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["read"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("writeWithoutResponse"));
-            Assert.That(serialized["writeWithoutResponse"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["writeWithoutResponse"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("write"));
-            Assert.That(serialized["write"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["write"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("notify"));
-            Assert.That(serialized["notify"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["notify"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("indicate"));
-            Assert.That(serialized["indicate"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["indicate"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("authenticatedSignedWrites"));
-            Assert.That(serialized["authenticatedSignedWrites"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["authenticatedSignedWrites"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("extendedProperties"));
-            Assert.That(serialized["extendedProperties"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["extendedProperties"]!.Value<bool>(), Is.True);
-        }
+        Assert.Equal(8, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("broadcast"));
+        JToken? broadcast = serialized["broadcast"];
+        Assert.NotNull(broadcast);
+        Assert.Equal(JTokenType.Boolean, broadcast.Type);
+        Assert.True(broadcast.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("read"));
+        JToken? read = serialized["read"];
+        Assert.NotNull(read);
+        Assert.Equal(JTokenType.Boolean, read.Type);
+        Assert.True(read.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("writeWithoutResponse"));
+        JToken? writeWithoutResponse = serialized["read"];
+        Assert.NotNull(writeWithoutResponse);
+        Assert.Equal(JTokenType.Boolean, writeWithoutResponse.Type);
+        Assert.True(writeWithoutResponse.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("write"));
+        JToken? write = serialized["write"];
+        Assert.NotNull(write);
+        Assert.Equal(JTokenType.Boolean, write.Type);
+        Assert.True(write.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("notify"));
+        JToken? notify = serialized["notify"];
+        Assert.NotNull(notify);
+        Assert.Equal(JTokenType.Boolean, notify.Type);
+        Assert.True(notify.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("indicate"));
+        JToken? indicate = serialized["indicate"];
+        Assert.NotNull(indicate);
+        Assert.Equal(JTokenType.Boolean, indicate.Type);
+        Assert.True(indicate.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("authenticatedSignedWrites"));
+        JToken? authenticatedSignedWrites = serialized["authenticatedSignedWrites"];
+        Assert.NotNull(authenticatedSignedWrites);
+        Assert.Equal(JTokenType.Boolean, authenticatedSignedWrites.Type);
+        Assert.True(authenticatedSignedWrites.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("extendedProperties"));
+        JToken? extendedProperties = serialized["extendedProperties"];
+        Assert.NotNull(extendedProperties);
+        Assert.Equal(JTokenType.Boolean, extendedProperties.Type);
+        Assert.True(extendedProperties.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAllValuesFalse()
     {
         CharacteristicProperties properties = new()
@@ -77,33 +97,54 @@ public class CharacteristicPropertiesTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(8));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("broadcast"));
-            Assert.That(serialized["broadcast"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["broadcast"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("read"));
-            Assert.That(serialized["read"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["read"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("writeWithoutResponse"));
-            Assert.That(serialized["writeWithoutResponse"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["writeWithoutResponse"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("write"));
-            Assert.That(serialized["write"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["write"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("notify"));
-            Assert.That(serialized["notify"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["notify"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("indicate"));
-            Assert.That(serialized["indicate"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["indicate"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("authenticatedSignedWrites"));
-            Assert.That(serialized["authenticatedSignedWrites"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["authenticatedSignedWrites"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("extendedProperties"));
-            Assert.That(serialized["extendedProperties"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["extendedProperties"]!.Value<bool>(), Is.False);
-        }
+        Assert.Equal(8, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("broadcast"));
+        JToken? broadcast = serialized["broadcast"];
+        Assert.NotNull(broadcast);
+        Assert.Equal(JTokenType.Boolean, broadcast.Type);
+        Assert.False(broadcast.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("read"));
+        JToken? read = serialized["read"];
+        Assert.NotNull(read);
+        Assert.Equal(JTokenType.Boolean, read.Type);
+        Assert.False(read.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("writeWithoutResponse"));
+        JToken? writeWithoutResponse = serialized["read"];
+        Assert.NotNull(writeWithoutResponse);
+        Assert.Equal(JTokenType.Boolean, writeWithoutResponse.Type);
+        Assert.False(writeWithoutResponse.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("write"));
+        JToken? write = serialized["write"];
+        Assert.NotNull(write);
+        Assert.Equal(JTokenType.Boolean, write.Type);
+        Assert.False(write.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("notify"));
+        JToken? notify = serialized["notify"];
+        Assert.NotNull(notify);
+        Assert.Equal(JTokenType.Boolean, notify.Type);
+        Assert.False(notify.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("indicate"));
+        JToken? indicate = serialized["indicate"];
+        Assert.NotNull(indicate);
+        Assert.Equal(JTokenType.Boolean, indicate.Type);
+        Assert.False(indicate.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("authenticatedSignedWrites"));
+        JToken? authenticatedSignedWrites = serialized["authenticatedSignedWrites"];
+        Assert.NotNull(authenticatedSignedWrites);
+        Assert.Equal(JTokenType.Boolean, authenticatedSignedWrites.Type);
+        Assert.False(authenticatedSignedWrites.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("extendedProperties"));
+        JToken? extendedProperties = serialized["extendedProperties"];
+        Assert.NotNull(extendedProperties);
+        Assert.Equal(JTokenType.Boolean, extendedProperties.Type);
+        Assert.False(extendedProperties.Value<bool>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/DescriptorEventGeneratedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/DescriptorEventGeneratedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DescriptorEventGeneratedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithReadType()
     {
         string json = """
@@ -19,19 +18,17 @@ public class DescriptorEventGeneratedEventArgsTests
                       }
                       """;
         DescriptorEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(DescriptorEventGeneratedType.Read));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(DescriptorEventGeneratedType.Read, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithWriteType()
     {
         string json = """
@@ -45,19 +42,17 @@ public class DescriptorEventGeneratedEventArgsTests
                       }
                       """;
         DescriptorEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(DescriptorEventGeneratedType.Write));
-            Assert.That(eventArgs.Data, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(DescriptorEventGeneratedType.Write, eventArgs.Type);
+        Assert.Null(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithEmptyData()
     {
         string json = """
@@ -72,20 +67,18 @@ public class DescriptorEventGeneratedEventArgsTests
                       }
                       """;
         DescriptorEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(DescriptorEventGeneratedType.Read));
-            Assert.That(eventArgs.Data, Is.Not.Null);
-            Assert.That(eventArgs.Data, Is.Empty);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(DescriptorEventGeneratedType.Read, eventArgs.Type);
+        Assert.NotNull(eventArgs.Data);
+        Assert.Empty(eventArgs.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithData()
     {
         string json = """
@@ -100,22 +93,20 @@ public class DescriptorEventGeneratedEventArgsTests
                       }
                       """;
         DescriptorEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-            Assert.That(eventArgs.ServiceUuid, Is.EqualTo("myServiceUuid"));
-            Assert.That(eventArgs.CharacteristicUuid, Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(eventArgs.Type, Is.EqualTo(DescriptorEventGeneratedType.Read));
-            Assert.That(eventArgs.Data, Is.Not.Null);
-            Assert.That(eventArgs.Data, Has.Count.EqualTo(2));
-            Assert.That(eventArgs.Data![0], Is.EqualTo(123));
-            Assert.That(eventArgs.Data![1], Is.EqualTo(456));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
+        Assert.Equal("myServiceUuid", eventArgs.ServiceUuid);
+        Assert.Equal("myCharacteristicUuid", eventArgs.CharacteristicUuid);
+        Assert.Equal(DescriptorEventGeneratedType.Read, eventArgs.Type);
+        Assert.NotNull(eventArgs.Data);
+        Assert.Equal(2, eventArgs.Data.Count);
+        Assert.Equal(123u, eventArgs.Data[0]);
+        Assert.Equal(456u, eventArgs.Data[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -129,12 +120,12 @@ public class DescriptorEventGeneratedEventArgsTests
                       }
                       """;
         DescriptorEventGeneratedEventArgs? eventArgs = JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         DescriptorEventGeneratedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = """
@@ -146,10 +137,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -162,10 +153,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingAddressThrows()
     {
         string json = """
@@ -177,10 +168,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidAddressTypeThrows()
     {
         string json = """
@@ -193,10 +184,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingServiceUuidThrows()
     {
         string json = """
@@ -208,10 +199,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidServiceUuidTypeThrows()
     {
         string json = """
@@ -224,10 +215,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingCharacteristicUuidThrows()
     {
         string json = """
@@ -239,10 +230,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                      """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidCharacteristicUuidTypeThrows()
     {
         string json = """
@@ -255,10 +246,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDescriptorUuidThrows()
     {
         string json = """
@@ -270,10 +261,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                      """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDescriptorUuidTypeThrows()
     {
         string json = """
@@ -286,10 +277,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "read"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTypeThrows()
     {
         string json = """
@@ -301,10 +292,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "descriptorUuid": "myDescriptorUuid",
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTypeDataTypeThrows()
     {
         string json = """
@@ -317,10 +308,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTypeValueThrows()
     {
         string json = """
@@ -333,10 +324,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "type": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DescriptorEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInvalidDataType()
     {
         string json = """
@@ -350,10 +341,10 @@ public class DescriptorEventGeneratedEventArgsTests
                         "data": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInvalidDataElementsType()
     {
         string json = """
@@ -367,6 +358,6 @@ public class DescriptorEventGeneratedEventArgsTests
                         "data": ["123", false]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CharacteristicEventGeneratedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/DiableSimulationCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/DiableSimulationCommandParametersTests.cs
@@ -4,28 +4,27 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class DisableSimulationCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         DisableSimulationCommandParameters properties = new("myContext");
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.disableSimulation"));
+        Assert.Equal("bluetooth.disableSimulation", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         DisableSimulationCommandParameters properties = new("myContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/DisableSimulationCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/DisableSimulationCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DisableSimulationCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DisableSimulationCommandResult? result = JsonSerializer.Deserialize<DisableSimulationCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DisableSimulationCommandResult? result = JsonSerializer.Deserialize<DisableSimulationCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         DisableSimulationCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/GattConnectionAttemptedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/GattConnectionAttemptedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class GattConnectionAttemptedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -15,15 +14,13 @@ public class GattConnectionAttemptedEventArgsTests
                       }
                       """;
         GattConnectionAttemptedEventArgs? eventArgs = JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Address, Is.EqualTo("myAddress"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myAddress", eventArgs.Address);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -33,12 +30,12 @@ public class GattConnectionAttemptedEventArgsTests
                       }
                       """;
         GattConnectionAttemptedEventArgs? eventArgs = JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         GattConnectionAttemptedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = """
@@ -46,10 +43,10 @@ public class GattConnectionAttemptedEventArgsTests
                         "address": "myAddress"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -58,10 +55,10 @@ public class GattConnectionAttemptedEventArgsTests
                         "address": "myAddress"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingAddressThrows()
     {
         string json = """
@@ -69,10 +66,10 @@ public class GattConnectionAttemptedEventArgsTests
                         "context": "myContextId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidAddressTypeThrows()
     {
         string json = """
@@ -81,6 +78,6 @@ public class GattConnectionAttemptedEventArgsTests
                         "address": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GattConnectionAttemptedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/HandleRequestDevicePromptCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/HandleRequestDevicePromptCommandParametersTests.cs
@@ -3,139 +3,172 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class HandleRequestDevicePromptCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         HandleRequestDevicePromptCommandParameters acceptParameters = new HandleRequestDevicePromptAcceptCommandParameters("myContext", "myPrompt", "myDevice");
-        Assert.That(acceptParameters.MethodName, Is.EqualTo("bluetooth.handleRequestDevicePrompt"));
+        Assert.Equal("bluetooth.handleRequestDevicePrompt", acceptParameters.MethodName);
         HandleRequestDevicePromptCommandParameters cancelParameters = new HandleRequestDevicePromptCancelCommandParameters("myContext", "myPrompt");
-        Assert.That(cancelParameters.MethodName, Is.EqualTo("bluetooth.handleRequestDevicePrompt"));
+        Assert.Equal("bluetooth.handleRequestDevicePrompt", cancelParameters.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAcceptParameters()
     {
         HandleRequestDevicePromptCommandParameters properties = new HandleRequestDevicePromptAcceptCommandParameters("myContext", "myPrompt", "myDevice");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("prompt"));
-            Assert.That(serialized["prompt"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["prompt"]!.Value<string>(), Is.EqualTo("myPrompt"));
-            Assert.That(serialized, Contains.Key("accept"));
-            Assert.That(serialized["accept"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["accept"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("device"));
-            Assert.That(serialized["device"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["device"]!.Value<string>(), Is.EqualTo("myDevice"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("prompt"));
+        JToken? prompt = serialized["prompt"];
+        Assert.NotNull(prompt);
+        Assert.Equal(JTokenType.String, prompt.Type);
+        Assert.Equal("myPrompt", prompt.Value<string>());
+
+        Assert.True(serialized.ContainsKey("accept"));
+        JToken? accept = serialized["accept"];
+        Assert.NotNull(accept);
+        Assert.Equal(JTokenType.Boolean, accept.Type);
+        Assert.True(accept.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("device"));
+        JToken? device = serialized["device"];
+        Assert.NotNull(device);
+        Assert.Equal(JTokenType.String, device.Type);
+        Assert.Equal("myDevice", device.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanModifyPropertiesInAcceptParameters()
     {
-        HandleRequestDevicePromptAcceptCommandParameters properties = new("myContext", "myPrompt", "myDevice");
-        properties.BrowsingContextId = "myOtherContext";
-        properties.PromptId = "myOtherPrompt";
-        properties.DeviceId = "myOtherDevice";
+        HandleRequestDevicePromptAcceptCommandParameters properties = new("myContext", "myPrompt", "myDevice")
+        {
+            BrowsingContextId = "myOtherContext",
+            PromptId = "myOtherPrompt",
+            DeviceId = "myOtherDevice"
+        };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myOtherContext"));
-            Assert.That(serialized, Contains.Key("prompt"));
-            Assert.That(serialized["prompt"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["prompt"]!.Value<string>(), Is.EqualTo("myOtherPrompt"));
-            Assert.That(serialized, Contains.Key("accept"));
-            Assert.That(serialized["accept"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["accept"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("device"));
-            Assert.That(serialized["device"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["device"]!.Value<string>(), Is.EqualTo("myOtherDevice"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myOtherContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("prompt"));
+        JToken? prompt = serialized["prompt"];
+        Assert.NotNull(prompt);
+        Assert.Equal(JTokenType.String, prompt.Type);
+        Assert.Equal("myOtherPrompt", prompt.Value<string>());
+
+        Assert.True(serialized.ContainsKey("accept"));
+        JToken? accept = serialized["accept"];
+        Assert.NotNull(accept);
+        Assert.Equal(JTokenType.Boolean, accept.Type);
+        Assert.True(accept.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("device"));
+        JToken? device = serialized["device"];
+        Assert.NotNull(device);
+        Assert.Equal(JTokenType.String, device.Type);
+        Assert.Equal("myOtherDevice", device.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCancelParameters()
     {
         HandleRequestDevicePromptCommandParameters properties = new HandleRequestDevicePromptCancelCommandParameters("myContext", "myPrompt");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("prompt"));
-            Assert.That(serialized["prompt"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["prompt"]!.Value<string>(), Is.EqualTo("myPrompt"));
-            Assert.That(serialized, Contains.Key("accept"));
-            Assert.That(serialized["accept"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["accept"]!.Value<bool>(), Is.False);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("prompt"));
+        JToken? prompt = serialized["prompt"];
+        Assert.NotNull(prompt);
+        Assert.Equal(JTokenType.String, prompt.Type);
+        Assert.Equal("myPrompt", prompt.Value<string>());
+
+        Assert.True(serialized.ContainsKey("accept"));
+        JToken? accept = serialized["accept"];
+        Assert.NotNull(accept);
+        Assert.Equal(JTokenType.Boolean, accept.Type);
+        Assert.False(accept.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanModifyPropertiesInCancelParameters()
     {
-        HandleRequestDevicePromptCancelCommandParameters properties = new("myContext", "myPrompt");
-        properties.BrowsingContextId = "myOtherContext";
-        properties.PromptId = "myOtherPrompt";
+        HandleRequestDevicePromptCancelCommandParameters properties = new("myContext", "myPrompt")
+        {
+            BrowsingContextId = "myOtherContext",
+            PromptId = "myOtherPrompt"
+        };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myOtherContext"));
-            Assert.That(serialized, Contains.Key("prompt"));
-            Assert.That(serialized["prompt"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["prompt"]!.Value<string>(), Is.EqualTo("myOtherPrompt"));
-            Assert.That(serialized, Contains.Key("accept"));
-            Assert.That(serialized["accept"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["accept"]!.Value<bool>(), Is.False);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myOtherContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("prompt"));
+        JToken? prompt = serialized["prompt"];
+        Assert.NotNull(prompt);
+        Assert.Equal(JTokenType.String, prompt.Type);
+        Assert.Equal("myOtherPrompt", prompt.Value<string>());
+
+        Assert.True(serialized.ContainsKey("accept"));
+        JToken? accept = serialized["accept"];
+        Assert.NotNull(accept);
+        Assert.Equal(JTokenType.Boolean, accept.Type);
+        Assert.False(accept.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestAcceptParametersDeviceIdGetterReturnsValue()
     {
         HandleRequestDevicePromptAcceptCommandParameters parameters = new("myContext", "myPrompt", "myDevice");
-        Assert.That(parameters.DeviceId, Is.EqualTo("myDevice"));
+        Assert.Equal("myDevice", parameters.DeviceId);
     }
 
-    [Test]
+    [Fact]
     public void TestAcceptParametersDeviceIdSetterSetsValue()
     {
         HandleRequestDevicePromptAcceptCommandParameters parameters = new("myContext", "myPrompt", "myDevice");
         parameters.DeviceId = "myNewDevice";
-        Assert.That(parameters.DeviceId, Is.EqualTo("myNewDevice"));
+        Assert.Equal("myNewDevice", parameters.DeviceId);
     }
 
-    [Test]
+    [Fact]
     public void TestAcceptParametersThrowsWhenGettingDeviceIdWhenNull()
     {
         HandleRequestDevicePromptAcceptCommandParameters parameters = new("myContext", "myPrompt", null!);
-        Assert.That(() => _ = parameters.DeviceId, Throws.InvalidOperationException.With.Message.EqualTo("DeviceId cannot be null"));
+        Assert.Equal("DeviceId cannot be null", Assert.ThrowsAny<InvalidOperationException>(() => _ = parameters.DeviceId).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestAcceptParametersThrowsWhenSettingDeviceIdToNull()
     {
         HandleRequestDevicePromptAcceptCommandParameters parameters = new("myContext", "myPrompt", "myDevice");
-        Assert.That(() => parameters.DeviceId = null!, Throws.ArgumentNullException);
+        Assert.Throws<ArgumentNullException>(() => parameters.DeviceId = null!);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/HandleRequestDevicePromptCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/HandleRequestDevicePromptCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class HandleRequestDevicePromptCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         HandleRequestDevicePromptCommandResult? result = JsonSerializer.Deserialize<HandleRequestDevicePromptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         HandleRequestDevicePromptCommandResult? result = JsonSerializer.Deserialize<HandleRequestDevicePromptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         HandleRequestDevicePromptCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/RequestDeviceInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/RequestDeviceInfoTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RequestDeviceInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -15,15 +14,13 @@ public class RequestDeviceInfoTests
                       }
                       """;
         RequestDeviceInfo? info = JsonSerializer.Deserialize<RequestDeviceInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.DeviceId, Is.EqualTo("myDeviceId"));
-            Assert.That(info.DeviceName, Is.EqualTo("myDeviceName"));
-        }
+        Assert.NotNull(info);
+
+        Assert.Equal("myDeviceId", info.DeviceId);
+        Assert.Equal("myDeviceName", info.DeviceName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullName()
     {
         string json = """
@@ -33,15 +30,13 @@ public class RequestDeviceInfoTests
                       }
                       """;
         RequestDeviceInfo? info = JsonSerializer.Deserialize<RequestDeviceInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.DeviceId, Is.EqualTo("myDeviceId"));
-            Assert.That(info.DeviceName, Is.Null);
-        }
+        Assert.NotNull(info);
+
+        Assert.Equal("myDeviceId", info.DeviceId);
+        Assert.Null(info.DeviceName);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -51,12 +46,12 @@ public class RequestDeviceInfoTests
                       }
                       """;
         RequestDeviceInfo? info = JsonSerializer.Deserialize<RequestDeviceInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         RequestDeviceInfo copy = info with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDeviceIdThrows()
     {
         string json = """
@@ -64,10 +59,10 @@ public class RequestDeviceInfoTests
                         "name": "myDeviceName"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDeviceIdTypeThrows()
     {
         string json = """
@@ -76,10 +71,10 @@ public class RequestDeviceInfoTests
                         "name": "myDeviceName"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDeviceNameThrows()
     {
         string json = """
@@ -87,10 +82,10 @@ public class RequestDeviceInfoTests
                         "id": "myDeviceId",
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDeviceNameTypeThrows()
     {
         string json = """
@@ -99,6 +94,6 @@ public class RequestDeviceInfoTests
                         "name": 123
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDeviceInfo>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/RequestDevicePromptUpdatedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/RequestDevicePromptUpdatedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RequestDevicePromptUpdatedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -16,16 +15,14 @@ public class RequestDevicePromptUpdatedEventArgsTests
                       }
                       """;
         RequestDevicePromptUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Prompt, Is.EqualTo("myPromptId"));
-            Assert.That(eventArgs.Devices, Has.Count.EqualTo(0));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myPromptId", eventArgs.Prompt);
+        Assert.Empty(eventArgs.Devices);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithDevices()
     {
         string json = """
@@ -41,18 +38,16 @@ public class RequestDevicePromptUpdatedEventArgsTests
                       }
                       """;
         RequestDevicePromptUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Prompt, Is.EqualTo("myPromptId"));
-            Assert.That(eventArgs.Devices, Has.Count.EqualTo(1));
-            Assert.That(eventArgs.Devices[0].DeviceId, Is.EqualTo("myDeviceId"));
-            Assert.That(eventArgs.Devices[0].DeviceName, Is.EqualTo("myDeviceName"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myPromptId", eventArgs.Prompt);
+        Assert.Single(eventArgs.Devices);
+        Assert.Equal("myDeviceId", eventArgs.Devices[0].DeviceId);
+        Assert.Equal("myDeviceName", eventArgs.Devices[0].DeviceName);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -63,12 +58,12 @@ public class RequestDevicePromptUpdatedEventArgsTests
                       }
                       """;
         RequestDevicePromptUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         RequestDevicePromptUpdatedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = """
@@ -77,10 +72,10 @@ public class RequestDevicePromptUpdatedEventArgsTests
                         "devices": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -90,10 +85,10 @@ public class RequestDevicePromptUpdatedEventArgsTests
                         "devices": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingPromptThrows()
     {
         string json = """
@@ -102,10 +97,10 @@ public class RequestDevicePromptUpdatedEventArgsTests
                         "devices": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidPromptTypeThrows()
     {
         string json = """
@@ -115,10 +110,10 @@ public class RequestDevicePromptUpdatedEventArgsTests
                         "devices": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDevicesThrows()
     {
         string json = """
@@ -127,10 +122,10 @@ public class RequestDevicePromptUpdatedEventArgsTests
                         "prompt": "myPromptId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDevicesTypeThrows()
     {
         string json = """
@@ -140,6 +135,6 @@ public class RequestDevicePromptUpdatedEventArgsTests
                         "devices": "someDevice"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestDevicePromptUpdatedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/ScanRecordTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/ScanRecordTests.cs
@@ -3,19 +3,18 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ScanRecordTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         ScanRecord properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(0));
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOptionalData()
     {
         ScanRecord properties = new()
@@ -27,26 +26,37 @@ public class ScanRecordTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            // BluetoothManufacturerData serialization is tested in its own set of tests,
-            // so its serialized structure need not be fully verified here.
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myName"));
-            Assert.That(serialized, Contains.Key("uuids"));
-            Assert.That(serialized["uuids"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["uuids"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["uuids"]![0]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["uuids"]![0]!.Value<string>(), Is.EqualTo("my-service-uuid"));
-            Assert.That(serialized, Contains.Key("appearance"));
-            Assert.That(serialized["appearance"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["appearance"]!.Value<uint>(), Is.EqualTo(123));
-            Assert.That(serialized, Contains.Key("manufacturerData"));
-            Assert.That(serialized["manufacturerData"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["manufacturerData"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["manufacturerData"]![0]!.Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        // BluetoothManufacturerData serialization is tested in its own set of tests,
+        // so its serialized structure need not be fully verified here.
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("uuids"));
+        JToken? uuids = serialized["uuids"];
+        Assert.NotNull(uuids);
+        Assert.Equal(JTokenType.Array, uuids.Type);
+        JToken uuid = Assert.Single(uuids);
+
+        Assert.NotNull(uuid);
+        Assert.Equal(JTokenType.String, uuid.Type);
+        Assert.Equal("my-service-uuid", uuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("appearance"));
+        JToken? appearance = serialized["appearance"];
+        Assert.NotNull(appearance);
+        Assert.Equal(JTokenType.Integer, appearance.Type);
+        Assert.Equal(123u, appearance.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("manufacturerData"));
+        JToken? manufacturerData = serialized["manufacturerData"];
+        Assert.NotNull(manufacturerData);
+        Assert.Equal(JTokenType.Array, manufacturerData.Type);
+        JToken manufacturerDataArray = Assert.Single(manufacturerData);
+        Assert.Equal(JTokenType.Object, manufacturerDataArray.Type);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdapterCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdapterCommandParametersTests.cs
@@ -3,67 +3,75 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateAdapterCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateAdapterCommandParameters properties = new("myContext", AdapterState.Absent);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateAdapter"));
+        Assert.Equal("bluetooth.simulateAdapter", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAbsentState()
     {
         SimulateAdapterCommandParameters properties = new("myContext", AdapterState.Absent);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("absent"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("absent", state.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPoweredOffState()
     {
         SimulateAdapterCommandParameters properties = new("myContext", AdapterState.PoweredOff);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("powered-off"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("powered-off", state.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPoweredOnState()
     {
         SimulateAdapterCommandParameters properties = new("myContext", AdapterState.PoweredOn);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("powered-on"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("powered-on", state.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdapterCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdapterCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateAdapterCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateAdapterCommandResult? result = JsonSerializer.Deserialize<SimulateAdapterCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateAdapterCommandResult? result = JsonSerializer.Deserialize<SimulateAdapterCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateAdapterCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementCommandParametersTests.cs
@@ -3,32 +3,34 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateAdvertisementCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateAdvertisementCommandParameters properties = new("myContext", new SimulateAdvertisementScanEntry("08:08:08:08:08", -10.1, new ScanRecord()));
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateAdvertisement"));
+        Assert.Equal("bluetooth.simulateAdvertisement", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SimulateAdvertisementCommandParameters properties = new("myContext", new SimulateAdvertisementScanEntry("08:08:08:08:08", -10.1, new ScanRecord()));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            // SimulateAdvertisementScanEntry serialization is tested in its own set of tests,
-            // so its serialized structure need not be fully verified here.
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("scanEntry"));
-            Assert.That(serialized["scanEntry"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        // SimulateAdvertisementScanEntry serialization is tested in its own set of tests,
+        // so its serialized structure need not be fully verified here.
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("scanEntry"));
+        JToken? scanEntry = serialized["scanEntry"];
+        Assert.NotNull(scanEntry);
+        Assert.Equal(JTokenType.Object, scanEntry.Type);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateAdvertisementCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateAdvertisementCommandResult? result = JsonSerializer.Deserialize<SimulateAdvertisementCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateAdvertisementCommandResult? result = JsonSerializer.Deserialize<SimulateAdvertisementCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateAdvertisementCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementScanEntryTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementScanEntryTests.cs
@@ -24,9 +24,9 @@ public class SimulateAdvertisementScanEntryTests
         Assert.True(serialized.ContainsKey("rssi"));
         JToken? rssi = serialized["rssi"];
         Assert.NotNull(rssi);
-        Assert.Equal(JTokenType.Float,rssi.Type);
+        Assert.Equal(JTokenType.Float, rssi.Type);
         Assert.Equal(-10.1, rssi.Value<double>());
-        
+
         Assert.True(serialized.ContainsKey("scanRecord"));
         JToken? scanRecord = serialized["scanRecord"];
         Assert.NotNull(scanRecord);

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementScanEntryTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateAdvertisementScanEntryTests.cs
@@ -3,28 +3,33 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateAdvertisementScanEntryTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         SimulateAdvertisementScanEntry properties = new("08:08:08:08:08", -10.1, new ScanRecord());
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            // ScanRecord serialization is tested in its own set of tests,
-            // so its serialized structure need not be fully verified here.
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("08:08:08:08:08"));
-            Assert.That(serialized, Contains.Key("rssi"));
-            Assert.That(serialized["rssi"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["rssi"]!.Value<double>(), Is.EqualTo(-10.1));
-            Assert.That(serialized, Contains.Key("scanRecord"));
-            Assert.That(serialized["scanRecord"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        // ScanRecord serialization is tested in its own set of tests,
+        // so its serialized structure need not be fully verified here.
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("08:08:08:08:08", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("rssi"));
+        JToken? rssi = serialized["rssi"];
+        Assert.NotNull(rssi);
+        Assert.Equal(JTokenType.Float,rssi.Type);
+        Assert.Equal(-10.1, rssi.Value<double>());
+        
+        Assert.True(serialized.ContainsKey("scanRecord"));
+        JToken? scanRecord = serialized["scanRecord"];
+        Assert.NotNull(scanRecord);
+        Assert.Equal(JTokenType.Object, scanRecord.Type);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicCommandParametersTests.cs
@@ -3,71 +3,94 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateCharacteristicCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateCharacteristicCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicType.Add);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateCharacteristic"));
+        Assert.Equal("bluetooth.simulateCharacteristic", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForAddingCharacteristic()
     {
         SimulateCharacteristicCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicType.Add);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("add"));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("add", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForRemovingCharacteristic()
     {
         SimulateCharacteristicCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicType.Remove);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("remove"));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("remove", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEmptyCharacteristicProperties()
     {
         SimulateCharacteristicCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicType.Add)
@@ -76,31 +99,49 @@ public class SimulateCharacteristicCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("characteristicProperties"));
-            Assert.That(serialized["characteristicProperties"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["characteristicProperties"]!.Value<JObject>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("add"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+        
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+        
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+        
+        Assert.True(serialized.ContainsKey("characteristicProperties"));
+        JToken? characteristicProperties = serialized["characteristicProperties"];
+        Assert.NotNull(characteristicProperties);
+        Assert.Equal(JTokenType.Object, characteristicProperties.Type);
+
+        JObject? characteristicPropertiesObject = characteristicProperties.Value<JObject>();
+        Assert.NotNull(characteristicPropertiesObject);
+        Assert.Empty(characteristicPropertiesObject);
+        
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("add", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCharacteristicProperties()
     {
         SimulateCharacteristicCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicType.Add)
@@ -112,31 +153,49 @@ public class SimulateCharacteristicCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("characteristicProperties"));
-            Assert.That(serialized["characteristicProperties"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? characteristicProperties = serialized["characteristicProperties"] as JObject;
-            Assert.That(characteristicProperties, Has.Count.EqualTo(1));
-            Assert.That(characteristicProperties, Contains.Key("read"));
-            Assert.That(characteristicProperties!["read"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(characteristicProperties!["read"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("add"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+        
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicProperties"));
+        JToken? characteristicProperties = serialized["characteristicProperties"];
+        Assert.NotNull(characteristicProperties);
+        Assert.Equal(JTokenType.Object, characteristicProperties.Type);
+
+        JObject? characteristicPropertiesObject = serialized["characteristicProperties"] as JObject;
+        Assert.NotNull(characteristicPropertiesObject);
+        Assert.True(characteristicPropertiesObject.ContainsKey("read"));
+        JToken? read = characteristicPropertiesObject["read"];
+        Assert.NotNull(read);
+        Assert.Equal(JTokenType.Boolean, read.Type);
+        Assert.True(read.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("add", type.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicCommandParametersTests.cs
@@ -112,19 +112,19 @@ public class SimulateCharacteristicCommandParametersTests
         Assert.NotNull(address);
         Assert.Equal(JTokenType.String, address.Type);
         Assert.Equal("myAddress", address.Value<string>());
-        
+
         Assert.True(serialized.ContainsKey("serviceUuid"));
         JToken? serviceUuid = serialized["serviceUuid"];
         Assert.NotNull(serviceUuid);
         Assert.Equal(JTokenType.String, serviceUuid.Type);
         Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
-        
+
         Assert.True(serialized.ContainsKey("characteristicUuid"));
         JToken? characteristicUuid = serialized["characteristicUuid"];
         Assert.NotNull(characteristicUuid);
         Assert.Equal(JTokenType.String, characteristicUuid.Type);
         Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
-        
+
         Assert.True(serialized.ContainsKey("characteristicProperties"));
         JToken? characteristicProperties = serialized["characteristicProperties"];
         Assert.NotNull(characteristicProperties);
@@ -133,7 +133,7 @@ public class SimulateCharacteristicCommandParametersTests
         JObject? characteristicPropertiesObject = characteristicProperties.Value<JObject>();
         Assert.NotNull(characteristicPropertiesObject);
         Assert.Empty(characteristicPropertiesObject);
-        
+
         Assert.True(serialized.ContainsKey("type"));
         JToken? type = serialized["type"];
         Assert.NotNull(type);
@@ -166,7 +166,7 @@ public class SimulateCharacteristicCommandParametersTests
         Assert.NotNull(address);
         Assert.Equal(JTokenType.String, address.Type);
         Assert.Equal("myAddress", address.Value<string>());
-        
+
         Assert.True(serialized.ContainsKey("serviceUuid"));
         JToken? serviceUuid = serialized["serviceUuid"];
         Assert.NotNull(serviceUuid);

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateCharacteristicCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateCharacteristicCommandResult? result = JsonSerializer.Deserialize<SimulateCharacteristicCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateCharacteristicCommandResult? result = JsonSerializer.Deserialize<SimulateCharacteristicCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateCharacteristicCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicResponseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicResponseCommandParametersTests.cs
@@ -3,137 +3,196 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateCharacteristicResponseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.Read, 0);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateCharacteristicResponse"));
+        Assert.Equal("bluetooth.simulateCharacteristicResponse", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicReadResponse()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.Read, 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("read"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("read", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicWriteResponse()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.Write, 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("write"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("write", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicSubscribeResponse()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.SubscribeToNotifications, 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("subscribe-to-notifications"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("subscribe-to-notifications", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicUnsubscribeResponse()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.UnsubscribeFromNotifications, 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("unsubscribe-from-notifications"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("unsubscribe-from-notifications", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicResponseWithEmptyData()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.Read, 0)
@@ -142,35 +201,55 @@ public class SimulateCharacteristicResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(7));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("read"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-            Assert.That(serialized, Contains.Key("data"));
-            Assert.That(serialized["data"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataArray = serialized["data"] as JArray;
-            Assert.That(dataArray, Is.Empty);
-        }
+        Assert.Equal(7, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("read", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0u, code.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("data"));
+        JToken? data = serialized["data"];
+        Assert.NotNull(data);
+        Assert.Equal(JTokenType.Array, data.Type);
+
+        JArray? dataArray = serialized["data"] as JArray;
+        Assert.NotNull(dataArray);
+        Assert.Empty(dataArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicResponseWithData()
     {
         SimulateCharacteristicResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", SimulateCharacteristicResponseType.Read, 0)
@@ -179,35 +258,55 @@ public class SimulateCharacteristicResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(7));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("read"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-            Assert.That(serialized, Contains.Key("data"));
-            Assert.That(serialized["data"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataArray = serialized["data"] as JArray;
-            Assert.That(dataArray, Has.Count.EqualTo(2));
-            Assert.That(dataArray![0].Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(dataArray[0].Value<uint>(), Is.EqualTo(123));
-            Assert.That(dataArray![1].Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(dataArray[1].Value<uint>(), Is.EqualTo(456));
-        }
+        Assert.Equal(7, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("read", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("data"));
+        JToken? data = serialized["data"];
+        Assert.NotNull(data);
+        Assert.Equal(JTokenType.Array, data.Type);
+
+        JArray? dataArray = serialized["data"] as JArray;
+        Assert.NotNull(dataArray);
+        Assert.Equal(2, dataArray.Count);
+        Assert.Equal(JTokenType.Integer, dataArray[0].Type);
+        Assert.Equal(123U, dataArray[0].Value<uint>());
+        Assert.Equal(JTokenType.Integer, dataArray[1].Type);
+        Assert.Equal(456U, dataArray[1].Value<uint>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicResponseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateCharacteristicResponseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateCharacteristicResponseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateCharacteristicResponseCommandResult? result = JsonSerializer.Deserialize<SimulateCharacteristicResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateCharacteristicResponseCommandResult? result = JsonSerializer.Deserialize<SimulateCharacteristicResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateCharacteristicResponseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorCommandParametersTests.cs
@@ -3,73 +3,102 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateDescriptorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateDescriptorCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorType.Add);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateDescriptor"));
+        Assert.Equal("bluetooth.simulateDescriptor", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForAddingDescriptor()
     {
         SimulateDescriptorCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorType.Add);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("descriptorUuid"));
-            Assert.That(serialized["descriptorUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["descriptorUuid"]!.Value<string>(), Is.EqualTo("myDescriptorUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("add"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("descriptorUuid"));
+        JToken? descriptorUuid = serialized["descriptorUuid"];
+        Assert.NotNull(descriptorUuid);
+        Assert.Equal(JTokenType.String, descriptorUuid.Type);
+        Assert.Equal("myDescriptorUuid", descriptorUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("add", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForRemovingDescriptor()
     {
         SimulateDescriptorCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorType.Remove);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("descriptorUuid"));
-            Assert.That(serialized["descriptorUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["descriptorUuid"]!.Value<string>(), Is.EqualTo("myDescriptorUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("remove"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("descriptorUuid"));
+        JToken? descriptorUuid = serialized["descriptorUuid"];
+        Assert.NotNull(descriptorUuid);
+        Assert.Equal(JTokenType.String, descriptorUuid.Type);
+        Assert.Equal("myDescriptorUuid", descriptorUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("remove", type.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateDescriptorCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateDescriptorCommandResult? result = JsonSerializer.Deserialize<SimulateDescriptorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateDescriptorCommandResult? result = JsonSerializer.Deserialize<SimulateDescriptorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateDescriptorCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorResponseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorResponseCommandParametersTests.cs
@@ -3,83 +3,118 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateDescriptorResponseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateDescriptorResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorResponseType.Read, 0);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateDescriptorResponse"));
+        Assert.Equal("bluetooth.simulateDescriptorResponse", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForDescriptorReadResponse()
     {
         SimulateDescriptorResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorResponseType.Read, 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(7));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("descriptorUuid"));
-            Assert.That(serialized["descriptorUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["descriptorUuid"]!.Value<string>(), Is.EqualTo("myDescriptorUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("read"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(7, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("descriptorUuid"));
+        JToken? descriptorUuid = serialized["descriptorUuid"];
+        Assert.NotNull(descriptorUuid);
+        Assert.Equal(JTokenType.String, descriptorUuid.Type);
+        Assert.Equal("myDescriptorUuid", descriptorUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("read", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForDescriptorWriteResponse()
     {
         SimulateDescriptorResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorResponseType.Write, 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(7));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("descriptorUuid"));
-            Assert.That(serialized["descriptorUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["descriptorUuid"]!.Value<string>(), Is.EqualTo("myDescriptorUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("write"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(7, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("descriptorUuid"));
+        JToken? descriptorUuid = serialized["descriptorUuid"];
+        Assert.NotNull(descriptorUuid);
+        Assert.Equal(JTokenType.String, descriptorUuid.Type);
+        Assert.Equal("myDescriptorUuid", descriptorUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("write", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicResponseWithEmptyData()
     {
         SimulateDescriptorResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorResponseType.Read, 0)
@@ -88,38 +123,61 @@ public class SimulateDescriptorResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(8));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("read"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized, Contains.Key("descriptorUuid"));
-            Assert.That(serialized["descriptorUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["descriptorUuid"]!.Value<string>(), Is.EqualTo("myDescriptorUuid"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-            Assert.That(serialized, Contains.Key("data"));
-            Assert.That(serialized["data"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataArray = serialized["data"] as JArray;
-            Assert.That(dataArray, Is.Empty);
-        }
+        Assert.Equal(8, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("descriptorUuid"));
+        JToken? descriptorUuid = serialized["descriptorUuid"];
+        Assert.NotNull(descriptorUuid);
+        Assert.Equal(JTokenType.String, descriptorUuid.Type);
+        Assert.Equal("myDescriptorUuid", descriptorUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("read", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("data"));
+        JToken? data = serialized["data"];
+        Assert.NotNull(data);
+        Assert.Equal(JTokenType.Array, data.Type);
+
+        JArray? dataArray = serialized["data"] as JArray;
+        Assert.NotNull(dataArray);
+        Assert.Empty(dataArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForCharacteristicResponseWithData()
     {
         SimulateDescriptorResponseCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", "myCharacteristicUuid", "myDescriptorUuid", SimulateDescriptorResponseType.Read, 0)
@@ -128,38 +186,61 @@ public class SimulateDescriptorResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(8));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("serviceUuid"));
-            Assert.That(serialized["serviceUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["serviceUuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("characteristicUuid"));
-            Assert.That(serialized["characteristicUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["characteristicUuid"]!.Value<string>(), Is.EqualTo("myCharacteristicUuid"));
-            Assert.That(serialized, Contains.Key("descriptorUuid"));
-            Assert.That(serialized["descriptorUuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["descriptorUuid"]!.Value<string>(), Is.EqualTo("myDescriptorUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("read"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-            Assert.That(serialized, Contains.Key("data"));
-            Assert.That(serialized["data"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataArray = serialized["data"] as JArray;
-            Assert.That(dataArray, Has.Count.EqualTo(2));
-            Assert.That(dataArray![0].Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(dataArray[0].Value<uint>(), Is.EqualTo(123));
-            Assert.That(dataArray![1].Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(dataArray[1].Value<uint>(), Is.EqualTo(456));
-        }
+        Assert.Equal(8, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serviceUuid"));
+        JToken? serviceUuid = serialized["serviceUuid"];
+        Assert.NotNull(serviceUuid);
+        Assert.Equal(JTokenType.String, serviceUuid.Type);
+        Assert.Equal("myServiceUuid", serviceUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("characteristicUuid"));
+        JToken? characteristicUuid = serialized["characteristicUuid"];
+        Assert.NotNull(characteristicUuid);
+        Assert.Equal(JTokenType.String, characteristicUuid.Type);
+        Assert.Equal("myCharacteristicUuid", characteristicUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("descriptorUuid"));
+        JToken? descriptorUuid = serialized["descriptorUuid"];
+        Assert.NotNull(descriptorUuid);
+        Assert.Equal(JTokenType.String, descriptorUuid.Type);
+        Assert.Equal("myDescriptorUuid", descriptorUuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("read", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
+
+        Assert.True(serialized.ContainsKey("data"));
+        JToken? data = serialized["data"];
+        Assert.NotNull(data);
+        Assert.Equal(JTokenType.Array, data.Type);
+
+        JArray? dataArray = serialized["data"] as JArray;
+        Assert.NotNull(dataArray);
+        Assert.Equal(2, dataArray.Count);
+        Assert.Equal(JTokenType.Integer, dataArray[0].Type);
+        Assert.Equal(123U, dataArray[0].Value<uint>());
+        Assert.Equal(JTokenType.Integer, dataArray[1].Type);
+        Assert.Equal(456U, dataArray[1].Value<uint>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorResponseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateDescriptorResponseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateDescriptorResponseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateDescriptorResponseCommandResult? result = JsonSerializer.Deserialize<SimulateDescriptorResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateDescriptorResponseCommandResult? result = JsonSerializer.Deserialize<SimulateDescriptorResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateDescriptorResponseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattConnectionResponseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattConnectionResponseCommandParametersTests.cs
@@ -3,34 +3,39 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateGattConnectionResponseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateGattConnectionResponseCommandParameters properties = new("myContext", "myAddress", 0);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateGattConnectionResponse"));
+        Assert.Equal("bluetooth.simulateGattConnectionResponse", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SimulateGattConnectionResponseCommandParameters properties = new("myContext", "myAddress", 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("code"));
-            Assert.That(serialized["code"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["code"]!.Value<uint>(), Is.Zero);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("code"));
+        JToken? code = serialized["code"];
+        Assert.NotNull(code);
+        Assert.Equal(JTokenType.Integer, code.Type);
+        Assert.Equal(0U, code.Value<uint>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattConnectionResponseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattConnectionResponseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateGattConnectionResponseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateGattConnectionResponseCommandResult? result = JsonSerializer.Deserialize<SimulateGattConnectionResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateGattConnectionResponseCommandResult? result = JsonSerializer.Deserialize<SimulateGattConnectionResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateGattConnectionResponseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattDisconnectionCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattDisconnectionCommandParametersTests.cs
@@ -3,31 +3,33 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateGattDisconnectionCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateGattDisconnectionCommandParameters properties = new("myContext", "myAddress");
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateGattDisconnection"));
+        Assert.Equal("bluetooth.simulateGattDisconnection", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SimulateGattDisconnectionCommandParameters properties = new("myContext", "myAddress");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattDisconnectionCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateGattDisconnectionCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateGattDisconnectionCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateGattDisconnectionCommandResult? result = JsonSerializer.Deserialize<SimulateGattDisconnectionCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateGattDisconnectionCommandResult? result = JsonSerializer.Deserialize<SimulateGattDisconnectionCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateGattDisconnectionCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulatePreconnectedPeripheralCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulatePreconnectedPeripheralCommandParametersTests.cs
@@ -3,44 +3,59 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulatePreconnectedPeripheralCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulatePreconnectedPeripheralCommandParameters properties = new("myContext", "AD:D2:E5:55", "myPeripheral");
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulatePreconnectedPeripheral"));
+        Assert.Equal("bluetooth.simulatePreconnectedPeripheral", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SimulatePreconnectedPeripheralCommandParameters properties = new("myContext", "AD:D2:E5:55", "myPeripheral");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("AD:D2:E5:55"));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myPeripheral"));
-            Assert.That(serialized, Contains.Key("manufacturerData"));
-            Assert.That(serialized["manufacturerData"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["manufacturerData"]!.Value<JArray>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("knownServiceUuids"));
-            Assert.That(serialized["knownServiceUuids"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["knownServiceUuids"]!.Value<JArray>(), Is.Empty);
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("AD:D2:E5:55", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myPeripheral", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("manufacturerData"));
+        JToken? manufacturerDataToken = serialized["manufacturerData"];
+        Assert.NotNull(manufacturerDataToken);
+        Assert.Equal(JTokenType.Array, manufacturerDataToken.Type);
+        JArray? manufacturerData = manufacturerDataToken.Value<JArray>();
+        Assert.NotNull(manufacturerData);
+        Assert.Empty(manufacturerData);
+
+        Assert.True(serialized.ContainsKey("knownServiceUuids"));
+        JToken? knownServiceUuidsToken = serialized["knownServiceUuids"];
+        Assert.NotNull(knownServiceUuidsToken);
+        Assert.Equal(JTokenType.Array, knownServiceUuidsToken.Type);
+        JArray? knownServiceUuids = knownServiceUuidsToken.Value<JArray>();
+        Assert.NotNull(knownServiceUuids);
+        Assert.Empty(knownServiceUuids);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithListData()
     {
         SimulatePreconnectedPeripheralCommandParameters properties = new("myContext", "AD:D2:E5:55", "myPeripheral");
@@ -48,29 +63,45 @@ public class SimulatePreconnectedPeripheralCommandParametersTests
         properties.KnownServiceUUIDs.Add("my-known-uuid");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            // BluetoothManufacturerData serialization is tested in its own set of tests,
-            // so its serialized structure need not be fully verified here.
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("AD:D2:E5:55"));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myPeripheral"));
-            Assert.That(serialized, Contains.Key("manufacturerData"));
-            Assert.That(serialized["manufacturerData"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["manufacturerData"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["manufacturerData"]![0]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("knownServiceUuids"));
-            Assert.That(serialized["knownServiceUuids"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["knownServiceUuids"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["knownServiceUuids"]![0]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["knownServiceUuids"]![0]!.Value<string>(), Is.EqualTo("my-known-uuid"));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        // BluetoothManufacturerData serialization is tested in its own set of tests,
+        // so its serialized structure need not be fully verified here.
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("AD:D2:E5:55", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myPeripheral", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("manufacturerData"));
+        JToken? manufacturerDataToken = serialized["manufacturerData"];
+        Assert.NotNull(manufacturerDataToken);
+        Assert.Equal(JTokenType.Array, manufacturerDataToken.Type);
+        JArray? manufacturerData = manufacturerDataToken.Value<JArray>();
+        Assert.NotNull(manufacturerData);
+        Assert.Single(manufacturerData);
+        Assert.Equal(JTokenType.Object, manufacturerData[0].Type);
+
+        Assert.True(serialized.ContainsKey("knownServiceUuids"));
+        JToken? knownServiceUuidsToken = serialized["knownServiceUuids"];
+        Assert.NotNull(knownServiceUuidsToken);
+        Assert.Equal(JTokenType.Array, knownServiceUuidsToken.Type);
+        JArray? knownServiceUuids = knownServiceUuidsToken.Value<JArray>();
+        Assert.NotNull(knownServiceUuids);
+        Assert.Single(knownServiceUuids);
+        Assert.Equal(JTokenType.String, knownServiceUuids[0].Type);
+        Assert.Equal("my-known-uuid", knownServiceUuids[0].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulatePreconnectedPeripheralCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulatePreconnectedPeripheralCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulatePreconnectedPeripheralCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulatePreconnectedPeripheralCommandResult? result = JsonSerializer.Deserialize<SimulatePreconnectedPeripheralCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulatePreconnectedPeripheralCommandResult? result = JsonSerializer.Deserialize<SimulatePreconnectedPeripheralCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulatePreconnectedPeripheralCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateServiceCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateServiceCommandParametersTests.cs
@@ -3,61 +3,78 @@ namespace WebDriverBiDi.Bluetooth;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SimulateServiceCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SimulateServiceCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", SimulateServiceType.Add);
-        Assert.That(properties.MethodName, Is.EqualTo("bluetooth.simulateService"));
+        Assert.Equal("bluetooth.simulateService", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForAddingService()
     {
         SimulateServiceCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", SimulateServiceType.Add);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("uuid"));
-            Assert.That(serialized["uuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["uuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("add"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("uuid"));
+        JToken? uuid = serialized["uuid"];
+        Assert.NotNull(uuid);
+        Assert.Equal(JTokenType.String, uuid.Type);
+        Assert.Equal("myServiceUuid", uuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("add", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForRemovingService()
     {
         SimulateServiceCommandParameters properties = new("myContext", "myAddress", "myServiceUuid", SimulateServiceType.Remove);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("address"));
-            Assert.That(serialized["address"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["address"]!.Value<string>(), Is.EqualTo("myAddress"));
-            Assert.That(serialized, Contains.Key("uuid"));
-            Assert.That(serialized["uuid"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["uuid"]!.Value<string>(), Is.EqualTo("myServiceUuid"));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("remove"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("address"));
+        JToken? address = serialized["address"];
+        Assert.NotNull(address);
+        Assert.Equal(JTokenType.String, address.Type);
+        Assert.Equal("myAddress", address.Value<string>());
+
+        Assert.True(serialized.ContainsKey("uuid"));
+        JToken? uuid = serialized["uuid"];
+        Assert.NotNull(uuid);
+        Assert.Equal(JTokenType.String, uuid.Type);
+        Assert.Equal("myServiceUuid", uuid.Value<string>());
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("remove", type.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Bluetooth/SimulateServiceCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/SimulateServiceCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Bluetooth;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SimulateServiceCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SimulateServiceCommandResult? result = JsonSerializer.Deserialize<SimulateServiceCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SimulateServiceCommandResult? result = JsonSerializer.Deserialize<SimulateServiceCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SimulateServiceCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using TestUtilities;
 
-[TestFixture]
 public class BrowserModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecuteCloseCommand()
     {
         TestWebSocketConnection connection = new();
@@ -22,17 +21,16 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<CloseCommandResult> task = module.CloseAsync(new CloseCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        CloseCommandResult result = task.Result;
+        Task<CloseCommandResult> task = module.CloseAsync(new CloseCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        CloseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCloseCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -49,17 +47,16 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<CloseCommandResult> task = module.CloseAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        CloseCommandResult result = task.Result;
+        Task<CloseCommandResult> task = module.CloseAsync(cancellationToken: TestContext.Current.CancellationToken);
+        CloseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCreateUserContextCommand()
     {
         TestWebSocketConnection connection = new();
@@ -78,18 +75,17 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<CreateUserContextCommandResult> task = module.CreateUserContextAsync(new CreateUserContextCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        CreateUserContextCommandResult result = task.Result;
+        Task<CreateUserContextCommandResult> task = module.CreateUserContextAsync(new CreateUserContextCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        CreateUserContextCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.UserContextId, Is.EqualTo("myUserContextId"));
+        Assert.NotNull(result);
+        Assert.Equal("myUserContextId", result.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCreateUserContextCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -108,18 +104,17 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<CreateUserContextCommandResult> task = module.CreateUserContextAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        CreateUserContextCommandResult result = task.Result;
+        Task<CreateUserContextCommandResult> task = module.CreateUserContextAsync(cancellationToken: TestContext.Current.CancellationToken);
+        CreateUserContextCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.UserContextId, Is.EqualTo("myUserContextId"));
+        Assert.NotNull(result);
+        Assert.Equal("myUserContextId", result.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetClientWindowsCommand()
     {
         TestWebSocketConnection connection = new();
@@ -157,35 +152,32 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<GetClientWindowsCommandResult> task = module.GetClientWindowsAsync(new GetClientWindowsCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetClientWindowsCommandResult result = task.Result;
+        Task<GetClientWindowsCommandResult> task = module.GetClientWindowsAsync(new GetClientWindowsCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        GetClientWindowsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindows, Has.Count.EqualTo(2));
-            Assert.That(result.ClientWindows[0].ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.ClientWindows[0].IsActive, Is.True);
-            Assert.That(result.ClientWindows[0].State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.ClientWindows[0].X, Is.EqualTo(100));
-            Assert.That(result.ClientWindows[0].Y, Is.EqualTo(200));
-            Assert.That(result.ClientWindows[0].Width, Is.EqualTo(640));
-            Assert.That(result.ClientWindows[0].Height, Is.EqualTo(480));
-            Assert.That(result.ClientWindows[1].ClientWindowId, Is.EqualTo("yourClientWindow"));
-            Assert.That(result.ClientWindows[1].IsActive, Is.False);
-            Assert.That(result.ClientWindows[1].State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.ClientWindows[1].X, Is.EqualTo(50));
-            Assert.That(result.ClientWindows[1].Y, Is.EqualTo(75));
-            Assert.That(result.ClientWindows[1].Width, Is.EqualTo(960));
-            Assert.That(result.ClientWindows[1].Height, Is.EqualTo(720));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal(2, result.ClientWindows.Count);
+        Assert.Equal("myClientWindow", result.ClientWindows[0].ClientWindowId);
+        Assert.True(result.ClientWindows[0].IsActive);
+        Assert.Equal(ClientWindowState.Normal, result.ClientWindows[0].State);
+        Assert.Equal(100u, result.ClientWindows[0].X);
+        Assert.Equal(200u, result.ClientWindows[0].Y);
+        Assert.Equal(640u, result.ClientWindows[0].Width);
+        Assert.Equal(480u, result.ClientWindows[0].Height);
+        Assert.Equal("yourClientWindow", result.ClientWindows[1].ClientWindowId);
+        Assert.False(result.ClientWindows[1].IsActive);
+        Assert.Equal(ClientWindowState.Normal, result.ClientWindows[1].State);
+        Assert.Equal(50u, result.ClientWindows[1].X);
+        Assert.Equal(75u, result.ClientWindows[1].Y);
+        Assert.Equal(960u, result.ClientWindows[1].Width);
+        Assert.Equal(720u, result.ClientWindows[1].Height);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetClientWindowsCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -223,35 +215,32 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<GetClientWindowsCommandResult> task = module.GetClientWindowsAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetClientWindowsCommandResult result = task.Result;
+        Task<GetClientWindowsCommandResult> task = module.GetClientWindowsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        GetClientWindowsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindows, Has.Count.EqualTo(2));
-            Assert.That(result.ClientWindows[0].ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.ClientWindows[0].IsActive, Is.True);
-            Assert.That(result.ClientWindows[0].State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.ClientWindows[0].X, Is.EqualTo(100));
-            Assert.That(result.ClientWindows[0].Y, Is.EqualTo(200));
-            Assert.That(result.ClientWindows[0].Width, Is.EqualTo(640));
-            Assert.That(result.ClientWindows[0].Height, Is.EqualTo(480));
-            Assert.That(result.ClientWindows[1].ClientWindowId, Is.EqualTo("yourClientWindow"));
-            Assert.That(result.ClientWindows[1].IsActive, Is.False);
-            Assert.That(result.ClientWindows[1].State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.ClientWindows[1].X, Is.EqualTo(50));
-            Assert.That(result.ClientWindows[1].Y, Is.EqualTo(75));
-            Assert.That(result.ClientWindows[1].Width, Is.EqualTo(960));
-            Assert.That(result.ClientWindows[1].Height, Is.EqualTo(720));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal(2, result.ClientWindows.Count);
+        Assert.Equal("myClientWindow", result.ClientWindows[0].ClientWindowId);
+        Assert.True(result.ClientWindows[0].IsActive);
+        Assert.Equal(ClientWindowState.Normal, result.ClientWindows[0].State);
+        Assert.Equal(100u, result.ClientWindows[0].X);
+        Assert.Equal(200u, result.ClientWindows[0].Y);
+        Assert.Equal(640u, result.ClientWindows[0].Width);
+        Assert.Equal(480u, result.ClientWindows[0].Height);
+        Assert.Equal("yourClientWindow", result.ClientWindows[1].ClientWindowId);
+        Assert.False(result.ClientWindows[1].IsActive);
+        Assert.Equal(ClientWindowState.Normal, result.ClientWindows[1].State);
+        Assert.Equal(50u, result.ClientWindows[1].X);
+        Assert.Equal(75u, result.ClientWindows[1].Y);
+        Assert.Equal(960u, result.ClientWindows[1].Width);
+        Assert.Equal(720u, result.ClientWindows[1].Height);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetUserContextsCommand()
     {
         TestWebSocketConnection connection = new();
@@ -277,24 +266,20 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<GetUserContextsCommandResult> task = module.GetUserContextsAsync(new GetUserContextsCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetUserContextsCommandResult result = task.Result;
+        Task<GetUserContextsCommandResult> task = module.GetUserContextsAsync(new GetUserContextsCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        GetUserContextsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContexts, Has.Count.EqualTo(2));
-            Assert.That(result.UserContexts[0].UserContextId, Is.EqualTo("default"));
-            Assert.That(result.UserContexts[1].UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(result);
 
+        Assert.Equal(2, result.UserContexts.Count);
+        Assert.Equal("default", result.UserContexts[0].UserContextId);
+        Assert.Equal("myUserContextId", result.UserContexts[1].UserContextId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetUserContextsCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -320,23 +305,20 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<GetUserContextsCommandResult> task = module.GetUserContextsAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetUserContextsCommandResult result = task.Result;
+        Task<GetUserContextsCommandResult> task = module.GetUserContextsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        GetUserContextsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContexts, Has.Count.EqualTo(2));
-            Assert.That(result.UserContexts[0].UserContextId, Is.EqualTo("default"));
-            Assert.That(result.UserContexts[1].UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal(2, result.UserContexts.Count);
+        Assert.Equal("default", result.UserContexts[0].UserContextId);
+        Assert.Equal("myUserContextId", result.UserContexts[1].UserContextId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteRemoveUserContextCommand()
     {
         TestWebSocketConnection connection = new();
@@ -353,17 +335,16 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<RemoveUserContextCommandResult> task = module.RemoveUserContextAsync(new RemoveUserContextCommandParameters("myUserContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        RemoveUserContextCommandResult result = task.Result;
+        Task<RemoveUserContextCommandResult> task = module.RemoveUserContextAsync(new RemoveUserContextCommandParameters("myUserContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        RemoveUserContextCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSetClientWindowStateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -388,7 +369,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<SetClientWindowStateCommandResult> task = module.SetClientWindowStateAsync(new SetClientWindowStateCommandParameters("myClientWindow")
@@ -398,24 +379,21 @@ public class BrowserModuleTests
             Y = 200,
             Width = 640,
             Height = 480
-        });
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetClientWindowStateCommandResult result = task.Result;
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        SetClientWindowStateCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.X, Is.EqualTo(100));
-            Assert.That(result.Y, Is.EqualTo(200));
-            Assert.That(result.Width, Is.EqualTo(640));
-            Assert.That(result.Height, Is.EqualTo(480));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.True(result.IsActive);
+        Assert.Equal(ClientWindowState.Normal, result.State);
+        Assert.Equal(100u, result.X);
+        Assert.Equal(200u, result.Y);
+        Assert.Equal(640u, result.Width);
+        Assert.Equal(480u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetDownloadBehaviorCommand()
     {
         TestWebSocketConnection connection = new();
@@ -432,13 +410,12 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
-        Task<SetDownloadBehaviorCommandResult> task = module.SetDownloadBehaviorAsync(new SetDownloadBehaviorCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetDownloadBehaviorCommandResult result = task.Result;
+        Task<SetDownloadBehaviorCommandResult> task = module.SetDownloadBehaviorAsync(new SetDownloadBehaviorCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetDownloadBehaviorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
@@ -20,7 +20,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -46,7 +46,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -74,7 +74,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -103,7 +103,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -151,7 +151,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -214,7 +214,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -265,7 +265,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -304,7 +304,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -334,7 +334,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -368,7 +368,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -409,7 +409,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 

--- a/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
@@ -21,7 +21,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<CloseCommandResult> task = module.CloseAsync(new CloseCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -47,7 +47,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<CloseCommandResult> task = module.CloseAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -75,7 +75,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<CreateUserContextCommandResult> task = module.CreateUserContextAsync(new CreateUserContextCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -104,7 +104,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<CreateUserContextCommandResult> task = module.CreateUserContextAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -152,7 +152,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<GetClientWindowsCommandResult> task = module.GetClientWindowsAsync(new GetClientWindowsCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -215,7 +215,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<GetClientWindowsCommandResult> task = module.GetClientWindowsAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -266,7 +266,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<GetUserContextsCommandResult> task = module.GetUserContextsAsync(new GetUserContextsCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -305,7 +305,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<GetUserContextsCommandResult> task = module.GetUserContextsAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -335,7 +335,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<RemoveUserContextCommandResult> task = module.RemoveUserContextAsync(new RemoveUserContextCommandParameters("myUserContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -369,7 +369,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<SetClientWindowStateCommandResult> task = module.SetClientWindowStateAsync(new SetClientWindowStateCommandParameters("myClientWindow")
@@ -410,7 +410,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
         Task<SetDownloadBehaviorCommandResult> task = module.SetDownloadBehaviorAsync(new SetDownloadBehaviorCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/Browser/ClientWindowInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/ClientWindowInfoTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ClientWindowsInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -20,20 +19,18 @@ public class ClientWindowsInfoTests
                       }
                       """;
         ClientWindowInfo? result = JsonSerializer.Deserialize<ClientWindowInfo>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(100));
-            Assert.That(result.Y, Is.EqualTo(200));
-            Assert.That(result.Width, Is.EqualTo(300));
-            Assert.That(result.Height, Is.EqualTo(400));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Normal, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(100u, result.X);
+        Assert.Equal(200u, result.Y);
+        Assert.Equal(300u, result.Width);
+        Assert.Equal(400u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -48,12 +45,12 @@ public class ClientWindowsInfoTests
                       }
                       """;
         ClientWindowInfo? result = JsonSerializer.Deserialize<ClientWindowInfo>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ClientWindowInfo? copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingWindowIdThrows()
     {
         string json = """
@@ -65,10 +62,10 @@ public class ClientWindowsInfoTests
                         "height": 400 
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWindowIdDataTypeThrows()
     {
         string json = """
@@ -82,10 +79,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMaximizedState()
     {
         string json = """
@@ -100,20 +97,18 @@ public class ClientWindowsInfoTests
                       }
                       """;
         ClientWindowInfo? result = JsonSerializer.Deserialize<ClientWindowInfo>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Maximized));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(0));
-            Assert.That(result.Y, Is.EqualTo(0));
-            Assert.That(result.Width, Is.EqualTo(1280));
-            Assert.That(result.Height, Is.EqualTo(1024));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Maximized, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(0u, result.X);
+        Assert.Equal(0u, result.Y);
+        Assert.Equal(1280u, result.Width);
+        Assert.Equal(1024u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMinimizedState()
     {
         string json = """
@@ -128,20 +123,18 @@ public class ClientWindowsInfoTests
                       }
                       """;
         ClientWindowInfo? result = JsonSerializer.Deserialize<ClientWindowInfo>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Minimized));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(0));
-            Assert.That(result.Y, Is.EqualTo(0));
-            Assert.That(result.Width, Is.EqualTo(0));
-            Assert.That(result.Height, Is.EqualTo(0));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Minimized, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(0u, result.X);
+        Assert.Equal(0u, result.Y);
+        Assert.Equal(0u, result.Width);
+        Assert.Equal(0u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithFullscreenState()
     {
         string json = """
@@ -156,20 +149,18 @@ public class ClientWindowsInfoTests
                       }
                       """;
         ClientWindowInfo? result = JsonSerializer.Deserialize<ClientWindowInfo>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Fullscreen));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(0));
-            Assert.That(result.Y, Is.EqualTo(0));
-            Assert.That(result.Width, Is.EqualTo(1280));
-            Assert.That(result.Height, Is.EqualTo(1024));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Fullscreen, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(0u, result.X);
+        Assert.Equal(0u, result.Y);
+        Assert.Equal(1280u, result.Width);
+        Assert.Equal(1024u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingStateThrows()
     {
         string json = """
@@ -182,10 +173,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidStateValueThrows()
     {
         string json = """
@@ -199,10 +190,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidStateDataTypeThrows()
     {
         string json = """
@@ -216,10 +207,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInactive()
     {
         string json = """
@@ -234,20 +225,18 @@ public class ClientWindowsInfoTests
                       }
                       """;
         ClientWindowInfo? result = JsonSerializer.Deserialize<ClientWindowInfo>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.IsActive, Is.False);
-            Assert.That(result.X, Is.EqualTo(100));
-            Assert.That(result.Y, Is.EqualTo(200));
-            Assert.That(result.Width, Is.EqualTo(300));
-            Assert.That(result.Height, Is.EqualTo(400));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Normal, result.State);
+        Assert.False(result.IsActive);
+        Assert.Equal(100u, result.X);
+        Assert.Equal(200u, result.Y);
+        Assert.Equal(300u, result.Width);
+        Assert.Equal(400u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingActiveThrows()
     {
         string json = """
@@ -260,10 +249,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidActiveValueThrows()
     {
         string json = """
@@ -277,10 +266,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingXThrows()
     {
         string json = """
@@ -293,10 +282,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidXValueThrows()
     {
         string json = """
@@ -310,10 +299,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidXDataTypeThrows()
     {
         string json = """
@@ -327,10 +316,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingYThrows()
     {
         string json = """
@@ -343,10 +332,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidYValueThrows()
     {
         string json = """
@@ -360,10 +349,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidYDataTypeThrows()
     {
         string json = """
@@ -377,10 +366,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingWidthThrows()
     {
         string json = """
@@ -393,10 +382,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWidthValueThrows()
     {
         string json = """
@@ -410,10 +399,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWidthDataTypeThrows()
     {
         string json = """
@@ -427,10 +416,10 @@ public class ClientWindowsInfoTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingHeightThrows()
     {
         string json = """
@@ -443,10 +432,10 @@ public class ClientWindowsInfoTests
                         "width": 300
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidHeightValueThrows()
     {
         string json = """
@@ -460,10 +449,10 @@ public class ClientWindowsInfoTests
                         "height": -1
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidHeightDataTypeThrows()
     {
         string json = """
@@ -477,6 +466,6 @@ public class ClientWindowsInfoTests
                         "height": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ClientWindowInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ClientWindowInfo>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/CloseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/CloseCommandParametersTests.cs
@@ -3,22 +3,21 @@ namespace WebDriverBiDi.Browser;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CloseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         CloseCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browser.close"));
+        Assert.Equal("browser.close", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         CloseCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/CloseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/CloseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CloseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         CloseCommandResult? result = JsonSerializer.Deserialize<CloseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         CloseCommandResult? result = JsonSerializer.Deserialize<CloseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CloseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/CreateUserContextCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/CreateUserContextCommandParametersTests.cs
@@ -4,26 +4,25 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Session;
 
-[TestFixture]
 public class CreateUserContextCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         CreateUserContextCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browser.createUserContext"));
+        Assert.Equal("browser.createUserContext", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         CreateUserContextCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptInsecureCertsTrue()
     {
         CreateUserContextCommandParameters properties = new()
@@ -32,16 +31,16 @@ public class CreateUserContextCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("acceptInsecureCerts"));
-            Assert.That(serialized["acceptInsecureCerts"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["acceptInsecureCerts"]!.Value<bool>(), Is.True);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("acceptInsecureCerts"));
+        JToken? acceptInsecureCerts = serialized["acceptInsecureCerts"];
+        Assert.NotNull(acceptInsecureCerts);
+        Assert.Equal(JTokenType.Boolean, acceptInsecureCerts.Type);
+        Assert.True(acceptInsecureCerts.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptInsecureCertsFalse()
     {
         CreateUserContextCommandParameters properties = new()
@@ -50,16 +49,16 @@ public class CreateUserContextCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("acceptInsecureCerts"));
-            Assert.That(serialized["acceptInsecureCerts"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["acceptInsecureCerts"]!.Value<bool>(), Is.False);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("acceptInsecureCerts"));
+        JToken? acceptInsecureCerts = serialized["acceptInsecureCerts"];
+        Assert.NotNull(acceptInsecureCerts);
+        Assert.Equal(JTokenType.Boolean, acceptInsecureCerts.Type);
+        Assert.False(acceptInsecureCerts.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithProxy()
     {
         CreateUserContextCommandParameters properties = new()
@@ -71,22 +70,28 @@ public class CreateUserContextCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxy"));
-            Assert.That(serialized["proxy"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? proxyObject = serialized["proxy"] as JObject;
-            Assert.That(proxyObject, Is.Not.Null);
-            Assert.That(proxyObject, Has.Count.EqualTo(2));
-            Assert.That(proxyObject, Contains.Key("proxyType"));
-            Assert.That(proxyObject!["proxyType"]!.Value<string>()!, Is.EqualTo("manual"));
-            Assert.That(proxyObject, Contains.Key("httpProxy"));
-            Assert.That(proxyObject!["httpProxy"]!.Value<string>(), Is.EqualTo("example-proxy.com"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("proxy"));
+        JToken? proxyToken = serialized["proxy"];
+        Assert.NotNull(proxyToken);
+        Assert.Equal(JTokenType.Object, proxyToken.Type);
+        JObject? proxyObject = proxyToken as JObject;
+        Assert.NotNull(proxyObject);
+        Assert.Equal(2, proxyObject.Count);
+
+        Assert.True(proxyObject.ContainsKey("proxyType"));
+        JToken? proxyType = proxyObject["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(proxyObject.ContainsKey("httpProxy"));
+        JToken? httpProxy = proxyObject["httpProxy"];
+        Assert.NotNull(httpProxy);
+        Assert.Equal("example-proxy.com", httpProxy.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUnhandledPromptBehavior()
     {
         CreateUserContextCommandParameters properties = new()
@@ -98,16 +103,19 @@ public class CreateUserContextCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("unhandledPromptBehavior"));
-            Assert.That(serialized["unhandledPromptBehavior"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? promptHandlerObject = serialized["unhandledPromptBehavior"] as JObject;
-            Assert.That(promptHandlerObject, Is.Not.Null);
-            Assert.That(promptHandlerObject, Has.Count.EqualTo(1));
-            Assert.That(promptHandlerObject, Contains.Key("default"));
-            Assert.That(promptHandlerObject!["default"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("unhandledPromptBehavior"));
+        JToken? promptHandlerToken = serialized["unhandledPromptBehavior"];
+        Assert.NotNull(promptHandlerToken);
+        Assert.Equal(JTokenType.Object, promptHandlerToken.Type);
+        JObject? promptHandlerObject = promptHandlerToken as JObject;
+        Assert.NotNull(promptHandlerObject);
+        Assert.Single(promptHandlerObject);
+
+        Assert.True(promptHandlerObject.ContainsKey("default"));
+        JToken? defaultHandler = promptHandlerObject["default"];
+        Assert.NotNull(defaultHandler);
+        Assert.Equal("accept", defaultHandler.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/CreateUserContextCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/CreateUserContextCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CreateUserContextCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class CreateUserContextCommandResultTests
                       }
                       """;
         CreateUserContextCommandResult? result = JsonSerializer.Deserialize<CreateUserContextCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.UserContextId, Is.EqualTo("myUserContext"));
+        Assert.NotNull(result);
+        Assert.Equal("myUserContext", result.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class CreateUserContextCommandResultTests
                       }
                       """;
         CreateUserContextCommandResult? result = JsonSerializer.Deserialize<CreateUserContextCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CreateUserContextCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class CreateUserContextCommandResultTests
                         "userContext": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/GetClientWindowsCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/GetClientWindowsCommandParametersTests.cs
@@ -3,22 +3,21 @@ namespace WebDriverBiDi.Browser;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GetClientWindowsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         GetClientWindowsCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browser.getClientWindows"));
+        Assert.Equal("browser.getClientWindows", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         GetClientWindowsCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/GetClientWindowsCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/GetClientWindowsCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class GetClientWindowsCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -24,21 +23,19 @@ public class GetClientWindowsCommandResultTests
                       }
                       """;
         GetClientWindowsCommandResult? result = JsonSerializer.Deserialize<GetClientWindowsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindows, Has.Count.EqualTo(1));
-            Assert.That(result.ClientWindows[0].ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.ClientWindows[0].State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.ClientWindows[0].IsActive, Is.True);
-            Assert.That(result.ClientWindows[0].X, Is.EqualTo(100));
-            Assert.That(result.ClientWindows[0].Y, Is.EqualTo(200));
-            Assert.That(result.ClientWindows[0].Width, Is.EqualTo(300));
-            Assert.That(result.ClientWindows[0].Height, Is.EqualTo(400));
-        }
+        Assert.NotNull(result);
+
+        Assert.Single(result.ClientWindows);
+        Assert.Equal("myClientWindow", result.ClientWindows[0].ClientWindowId);
+        Assert.Equal(ClientWindowState.Normal, result.ClientWindows[0].State);
+        Assert.True(result.ClientWindows[0].IsActive);
+        Assert.Equal(100u, result.ClientWindows[0].X);
+        Assert.Equal(200u, result.ClientWindows[0].Y);
+        Assert.Equal(300u, result.ClientWindows[0].Width);
+        Assert.Equal(400u, result.ClientWindows[0].Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -57,12 +54,12 @@ public class GetClientWindowsCommandResultTests
                       }
                       """;
         GetClientWindowsCommandResult? result = JsonSerializer.Deserialize<GetClientWindowsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         GetClientWindowsCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithEmptyList()
     {
         string json = """
@@ -71,7 +68,7 @@ public class GetClientWindowsCommandResultTests
                       }
                       """;
         GetClientWindowsCommandResult? result = JsonSerializer.Deserialize<GetClientWindowsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ClientWindows, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.ClientWindows);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/GetUserContextsCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/GetUserContextsCommandParametersTests.cs
@@ -3,22 +3,21 @@ namespace WebDriverBiDi.Browser;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GetUserContextsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         GetUserContextsCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browser.getUserContexts"));
+        Assert.Equal("browser.getUserContexts", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         CloseCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/GetUserContextsCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/GetUserContextsCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class GetUserContextsCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -21,16 +20,14 @@ public class GetUserContextsCommandResultTests
                       }
                       """;
         GetUserContextsCommandResult? result = JsonSerializer.Deserialize<GetUserContextsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContexts, Has.Count.EqualTo(2));
-            Assert.That(result.UserContexts[0].UserContextId, Is.EqualTo("default"));
-            Assert.That(result.UserContexts[1].UserContextId, Is.EqualTo("myUserContext"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal(2, result.UserContexts.Count);
+        Assert.Equal("default", result.UserContexts[0].UserContextId);
+        Assert.Equal("myUserContext", result.UserContexts[1].UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -46,19 +43,19 @@ public class GetUserContextsCommandResultTests
                       }
                       """;
         GetUserContextsCommandResult? result = JsonSerializer.Deserialize<GetUserContextsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         GetUserContextsCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -66,6 +63,6 @@ public class GetUserContextsCommandResultTests
                         "userContexts": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CreateUserContextCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/RemoveUserContextCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/RemoveUserContextCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.Browser;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class RemoveUserContextCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         RemoveUserContextCommandParameters properties = new("myUserContext");
-        Assert.That(properties.MethodName, Is.EqualTo("browser.removeUserContext"));
+        Assert.Equal("browser.removeUserContext", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         RemoveUserContextCommandParameters properties = new("myUserContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("userContext"));
-            Assert.That(serialized["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("userContext"));
+        JToken? userContext = serialized["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/RemoveUserContextCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/RemoveUserContextCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RemoveUserContextCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         RemoveUserContextCommandResult? result = JsonSerializer.Deserialize<RemoveUserContextCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         RemoveUserContextCommandResult? result = JsonSerializer.Deserialize<RemoveUserContextCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoveUserContextCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/SetClientWindowStateCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/SetClientWindowStateCommandParametersTests.cs
@@ -3,35 +3,37 @@ namespace WebDriverBiDi.Browser;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetClientWindowStateCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetClientWindowStateCommandParameters properties = new("myWindowId");
-        Assert.That(properties.MethodName, Is.EqualTo("browser.setClientWindowState"));
+        Assert.Equal("browser.setClientWindowState", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetClientWindowStateCommandParameters properties = new("myWindowId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientWindow"));
-            Assert.That(serialized["clientWindow"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["clientWindow"]!.Value<string>(), Is.EqualTo("myWindowId"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("normal"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientWindow"));
+        JToken? clientWindow = serialized["clientWindow"];
+        Assert.NotNull(clientWindow);
+        Assert.Equal(JTokenType.String, clientWindow.Type);
+        Assert.Equal("myWindowId", clientWindow.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("normal", state.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithSpecifiedSizeAndLocation()
     {
         SetClientWindowStateCommandParameters properties = new("myWindowId")
@@ -43,31 +45,46 @@ public class SetClientWindowStateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientWindow"));
-            Assert.That(serialized["clientWindow"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["clientWindow"]!.Value<string>(), Is.EqualTo("myWindowId"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("normal"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<ulong>(), Is.EqualTo(100));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<ulong>(), Is.EqualTo(200));
-            Assert.That(serialized, Contains.Key("width"));
-            Assert.That(serialized["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["width"]!.Value<ulong>(), Is.EqualTo(300));
-            Assert.That(serialized, Contains.Key("height"));
-            Assert.That(serialized["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["height"]!.Value<ulong>(), Is.EqualTo(400));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientWindow"));
+        JToken? clientWindow = serialized["clientWindow"];
+        Assert.NotNull(clientWindow);
+        Assert.Equal(JTokenType.String, clientWindow.Type);
+        Assert.Equal("myWindowId", clientWindow.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("normal", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(100UL, x.Value<ulong>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(200UL, y.Value<ulong>());
+
+        Assert.True(serialized.ContainsKey("width"));
+        JToken? width = serialized["width"];
+        Assert.NotNull(width);
+        Assert.Equal(JTokenType.Integer, width.Type);
+        Assert.Equal(300UL, width.Value<ulong>());
+
+        Assert.True(serialized.ContainsKey("height"));
+        JToken? height = serialized["height"];
+        Assert.NotNull(height);
+        Assert.Equal(JTokenType.Integer, height.Type);
+        Assert.Equal(400UL, height.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithMaximizedState()
     {
         SetClientWindowStateCommandParameters properties = new("myWindowId")
@@ -80,19 +97,22 @@ public class SetClientWindowStateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientWindow"));
-            Assert.That(serialized["clientWindow"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["clientWindow"]!.Value<string>(), Is.EqualTo("myWindowId"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("maximized"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientWindow"));
+        JToken? clientWindow = serialized["clientWindow"];
+        Assert.NotNull(clientWindow);
+        Assert.Equal(JTokenType.String, clientWindow.Type);
+        Assert.Equal("myWindowId", clientWindow.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("maximized", state.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithMinimizedState()
     {
         SetClientWindowStateCommandParameters properties = new("myWindowId")
@@ -105,19 +125,22 @@ public class SetClientWindowStateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientWindow"));
-            Assert.That(serialized["clientWindow"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["clientWindow"]!.Value<string>(), Is.EqualTo("myWindowId"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("minimized"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientWindow"));
+        JToken? clientWindow = serialized["clientWindow"];
+        Assert.NotNull(clientWindow);
+        Assert.Equal(JTokenType.String, clientWindow.Type);
+        Assert.Equal("myWindowId", clientWindow.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("minimized", state.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithFullscreenState()
     {
         SetClientWindowStateCommandParameters properties = new("myWindowId")
@@ -130,15 +153,18 @@ public class SetClientWindowStateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientWindow"));
-            Assert.That(serialized["clientWindow"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["clientWindow"]!.Value<string>(), Is.EqualTo("myWindowId"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("fullscreen"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientWindow"));
+        JToken? clientWindow = serialized["clientWindow"];
+        Assert.NotNull(clientWindow);
+        Assert.Equal(JTokenType.String, clientWindow.Type);
+        Assert.Equal("myWindowId", clientWindow.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("fullscreen", state.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/SetClientWindowStateCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/SetClientWindowStateCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetClientWindowStateCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -20,20 +19,18 @@ public class SetClientWindowStateCommandResultTests
                       }
                       """;
         SetClientWindowStateCommandResult? result = JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(100));
-            Assert.That(result.Y, Is.EqualTo(200));
-            Assert.That(result.Width, Is.EqualTo(300));
-            Assert.That(result.Height, Is.EqualTo(400));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Normal, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(100u, result.X);
+        Assert.Equal(200u, result.Y);
+        Assert.Equal(300u, result.Width);
+        Assert.Equal(400u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -48,12 +45,12 @@ public class SetClientWindowStateCommandResultTests
                       }
                       """;
         SetClientWindowStateCommandResult? result = JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetClientWindowStateCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingWindowIdThrows()
     {
         string json = """
@@ -66,10 +63,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWindowIdDataTypeThrows()
     {
         string json = """
@@ -83,10 +80,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMaximizedState()
     {
         string json = """
@@ -101,20 +98,18 @@ public class SetClientWindowStateCommandResultTests
                       }
                       """;
         SetClientWindowStateCommandResult? result = JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Maximized));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(0));
-            Assert.That(result.Y, Is.EqualTo(0));
-            Assert.That(result.Width, Is.EqualTo(1280));
-            Assert.That(result.Height, Is.EqualTo(1024));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Maximized, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(0u, result.X);
+        Assert.Equal(0u, result.Y);
+        Assert.Equal(1280u, result.Width);
+        Assert.Equal(1024u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMinimizedState()
     {
         string json = """
@@ -129,20 +124,18 @@ public class SetClientWindowStateCommandResultTests
                       }
                       """;
         SetClientWindowStateCommandResult? result = JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Minimized));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(0));
-            Assert.That(result.Y, Is.EqualTo(0));
-            Assert.That(result.Width, Is.EqualTo(0));
-            Assert.That(result.Height, Is.EqualTo(0));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Minimized, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(0u, result.X);
+        Assert.Equal(0u, result.Y);
+        Assert.Equal(0u, result.Width);
+        Assert.Equal(0u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithFullscreenState()
     {
         string json = """
@@ -157,20 +150,18 @@ public class SetClientWindowStateCommandResultTests
                       }
                       """;
         SetClientWindowStateCommandResult? result = JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Fullscreen));
-            Assert.That(result.IsActive, Is.True);
-            Assert.That(result.X, Is.EqualTo(0));
-            Assert.That(result.Y, Is.EqualTo(0));
-            Assert.That(result.Width, Is.EqualTo(1280));
-            Assert.That(result.Height, Is.EqualTo(1024));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Fullscreen, result.State);
+        Assert.True(result.IsActive);
+        Assert.Equal(0u, result.X);
+        Assert.Equal(0u, result.Y);
+        Assert.Equal(1280u, result.Width);
+        Assert.Equal(1024u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingStateThrows()
     {
         string json = """
@@ -183,10 +174,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidStateValueThrows()
     {
         string json = """
@@ -200,10 +191,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidStateDataTypeThrows()
     {
         string json = """
@@ -217,10 +208,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInactive()
     {
         string json = """
@@ -235,20 +226,18 @@ public class SetClientWindowStateCommandResultTests
                       }
                       """;
         SetClientWindowStateCommandResult? result = JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ClientWindowId, Is.EqualTo("myClientWindow"));
-            Assert.That(result.State, Is.EqualTo(ClientWindowState.Normal));
-            Assert.That(result.IsActive, Is.False);
-            Assert.That(result.X, Is.EqualTo(100));
-            Assert.That(result.Y, Is.EqualTo(200));
-            Assert.That(result.Width, Is.EqualTo(300));
-            Assert.That(result.Height, Is.EqualTo(400));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myClientWindow", result.ClientWindowId);
+        Assert.Equal(ClientWindowState.Normal, result.State);
+        Assert.False(result.IsActive);
+        Assert.Equal(100u, result.X);
+        Assert.Equal(200u, result.Y);
+        Assert.Equal(300u, result.Width);
+        Assert.Equal(400u, result.Height);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingActiveThrows()
     {
         string json = """
@@ -261,10 +250,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidActiveValueThrows()
     {
         string json = """
@@ -278,10 +267,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingXThrows()
     {
         string json = """
@@ -294,10 +283,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidXValueThrows()
     {
         string json = """
@@ -311,10 +300,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidXDataTypeThrows()
     {
         string json = """
@@ -328,10 +317,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingYThrows()
     {
         string json = """
@@ -344,10 +333,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidYValueThrows()
     {
         string json = """
@@ -361,10 +350,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidYDataTypeThrows()
     {
         string json = """
@@ -378,10 +367,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingWidthThrows()
     {
         string json = """
@@ -394,10 +383,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWidthValueThrows()
     {
         string json = """
@@ -411,10 +400,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWidthDataTypeThrows()
     {
         string json = """
@@ -428,10 +417,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": 400
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingHeightThrows()
     {
         string json = """
@@ -444,10 +433,10 @@ public class SetClientWindowStateCommandResultTests
                         "width": 300,
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidHeightValueThrows()
     {
         string json = """
@@ -461,10 +450,10 @@ public class SetClientWindowStateCommandResultTests
                         "height": -1
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidHeightDataTypeThrows()
     {
         string json = """
@@ -478,6 +467,6 @@ public class SetClientWindowStateCommandResultTests
                         "height": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetClientWindowStateCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/SetDownloadBehaviorCommandParameterTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/SetDownloadBehaviorCommandParameterTests.cs
@@ -47,7 +47,7 @@ public class SetDownloadBehaviorCommandParametersTests
         Assert.NotNull(userContexts);
         Assert.Equal(JTokenType.Array, userContexts.Type);
         JArray? contextsArray = serialized["userContexts"] as JArray;
-        
+
         Assert.NotNull(contextsArray);
         Assert.Single(contextsArray);
         Assert.Equal(JTokenType.String, contextsArray[0].Type);

--- a/test/WebDriverBiDi.Tests/Browser/SetDownloadBehaviorCommandParameterTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/SetDownloadBehaviorCommandParameterTests.cs
@@ -3,31 +3,30 @@ namespace WebDriverBiDi.Browser;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetDownloadBehaviorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetDownloadBehaviorCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browser.setDownloadBehavior"));
+        Assert.Equal("browser.setDownloadBehavior", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetDownloadBehaviorCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("downloadBehavior"));
-            Assert.That(serialized["downloadBehavior"]!.Type, Is.EqualTo(JTokenType.Null));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("downloadBehavior"));
+        JToken? downloadBehavior = serialized["downloadBehavior"];
+        Assert.NotNull(downloadBehavior);
+        Assert.Equal(JTokenType.Null, downloadBehavior.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithContexts()
     {
         SetDownloadBehaviorCommandParameters properties = new()
@@ -36,22 +35,26 @@ public class SetDownloadBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("downloadBehavior"));
-            Assert.That(serialized["downloadBehavior"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["userContexts"] as JArray;
-            Assert.That(contextsArray, Is.Not.Null);
-            Assert.That(contextsArray, Has.Count.EqualTo(1));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("myUserContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("downloadBehavior"));
+        JToken? downloadBehavior = serialized["downloadBehavior"];
+        Assert.NotNull(downloadBehavior);
+        Assert.Equal(JTokenType.Null, downloadBehavior.Type);
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContexts = serialized["userContexts"];
+        Assert.NotNull(userContexts);
+        Assert.Equal(JTokenType.Array, userContexts.Type);
+        JArray? contextsArray = serialized["userContexts"] as JArray;
+        
+        Assert.NotNull(contextsArray);
+        Assert.Single(contextsArray);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("myUserContext", contextsArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAllowingDownloads()
     {
         SetDownloadBehaviorCommandParameters properties = new()
@@ -60,23 +63,31 @@ public class SetDownloadBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("downloadBehavior"));
-            Assert.That(serialized["downloadBehavior"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
-            Assert.That(behaviorObject, Has.Count.EqualTo(2));
-            Assert.That(behaviorObject, Contains.Key("type"));
-            Assert.That(behaviorObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(behaviorObject!["type"]!.Value<string>, Is.EqualTo("allowed"));
-            Assert.That(behaviorObject, Contains.Key("destinationFolder"));
-            Assert.That(behaviorObject!["destinationFolder"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(behaviorObject!["destinationFolder"]!.Value<string>, Is.EqualTo("my/destination/folder"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("downloadBehavior"));
+        JToken? downloadBehavior = serialized["downloadBehavior"];
+        Assert.NotNull(downloadBehavior);
+        Assert.Equal(JTokenType.Object, downloadBehavior.Type);
+
+        JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
+        Assert.NotNull(behaviorObject);
+        Assert.Equal(2, behaviorObject.Count);
+
+        Assert.True(behaviorObject.ContainsKey("type"));
+        JToken? type = behaviorObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("allowed", type.Value<string>());
+
+        Assert.True(behaviorObject.ContainsKey("destinationFolder"));
+        JToken? destinationFolder = behaviorObject["destinationFolder"];
+        Assert.NotNull(destinationFolder);
+        Assert.Equal(JTokenType.String, destinationFolder.Type);
+        Assert.Equal("my/destination/folder", destinationFolder.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAllowingDownloadsWithUserContexts()
     {
         SetDownloadBehaviorCommandParameters properties = new()
@@ -86,30 +97,42 @@ public class SetDownloadBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("downloadBehavior"));
-            Assert.That(serialized["downloadBehavior"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
-            Assert.That(behaviorObject, Has.Count.EqualTo(2));
-            Assert.That(behaviorObject, Contains.Key("type"));
-            Assert.That(behaviorObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(behaviorObject!["type"]!.Value<string>, Is.EqualTo("allowed"));
-            Assert.That(behaviorObject, Contains.Key("destinationFolder"));
-            Assert.That(behaviorObject!["destinationFolder"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(behaviorObject!["destinationFolder"]!.Value<string>, Is.EqualTo("my/destination/folder"));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["userContexts"] as JArray;
-            Assert.That(contextsArray, Is.Not.Null);
-            Assert.That(contextsArray, Has.Count.EqualTo(1));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("myUserContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("downloadBehavior"));
+        JToken? downloadBehavior = serialized["downloadBehavior"];
+        Assert.NotNull(downloadBehavior);
+        Assert.Equal(JTokenType.Object, downloadBehavior.Type);
+
+        JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
+        Assert.NotNull(behaviorObject);
+        Assert.Equal(2, behaviorObject.Count);
+
+        Assert.True(behaviorObject.ContainsKey("type"));
+        JToken? type = behaviorObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("allowed", type.Value<string>());
+
+        Assert.True(behaviorObject.ContainsKey("destinationFolder"));
+        JToken? destinationFolder = behaviorObject["destinationFolder"];
+        Assert.NotNull(destinationFolder);
+        Assert.Equal(JTokenType.String, destinationFolder.Type);
+        Assert.Equal("my/destination/folder", destinationFolder.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContexts = serialized["userContexts"];
+        Assert.NotNull(userContexts);
+        Assert.Equal(JTokenType.Array, userContexts.Type);
+
+        JArray? contextsArray = userContexts as JArray;
+        Assert.NotNull(contextsArray);
+        Assert.Single(contextsArray);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("myUserContext", contextsArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDenyingDownloads()
     {
         SetDownloadBehaviorCommandParameters properties = new()
@@ -118,20 +141,25 @@ public class SetDownloadBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("downloadBehavior"));
-            Assert.That(serialized["downloadBehavior"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
-            Assert.That(behaviorObject, Has.Count.EqualTo(1));
-            Assert.That(behaviorObject, Contains.Key("type"));
-            Assert.That(behaviorObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(behaviorObject!["type"]!.Value<string>, Is.EqualTo("denied"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("downloadBehavior"));
+        JToken? downloadBehavior = serialized["downloadBehavior"];
+        Assert.NotNull(downloadBehavior);
+        Assert.Equal(JTokenType.Object, downloadBehavior.Type);
+
+        JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
+        Assert.NotNull(behaviorObject);
+        Assert.Single(behaviorObject);
+
+        Assert.True(behaviorObject.ContainsKey("type"));
+        JToken? type = behaviorObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("denied", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDenyingDownloadsWithUserContexts()
     {
         SetDownloadBehaviorCommandParameters properties = new()
@@ -141,43 +169,50 @@ public class SetDownloadBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("downloadBehavior"));
-            Assert.That(serialized["downloadBehavior"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
-            Assert.That(behaviorObject, Has.Count.EqualTo(1));
-            Assert.That(behaviorObject, Contains.Key("type"));
-            Assert.That(behaviorObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(behaviorObject!["type"]!.Value<string>, Is.EqualTo("denied"));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["userContexts"] as JArray;
-            Assert.That(contextsArray, Is.Not.Null);
-            Assert.That(contextsArray, Has.Count.EqualTo(1));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("myUserContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("downloadBehavior"));
+        JToken? downloadBehavior = serialized["downloadBehavior"];
+        Assert.NotNull(downloadBehavior);
+        Assert.Equal(JTokenType.Object, downloadBehavior.Type);
+
+        JObject? behaviorObject = serialized["downloadBehavior"] as JObject;
+        Assert.NotNull(behaviorObject);
+        Assert.Single(behaviorObject);
+
+        Assert.True(behaviorObject.ContainsKey("type"));
+        JToken? type = behaviorObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("denied", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContexts = serialized["userContexts"];
+        Assert.NotNull(userContexts);
+        Assert.Equal(JTokenType.Array, userContexts.Type);
+
+        JArray? contextsArray = userContexts as JArray;
+        Assert.NotNull(contextsArray);
+        Assert.Single(contextsArray);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("myUserContext", contextsArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetDownloadBehaviorCommandParameters properties = SetDownloadBehaviorCommandParameters.ResetDownloadBehavior;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.DownloadBehavior, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.DownloadBehavior);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetDownloadBehaviorCommandParameters firstInstance = SetDownloadBehaviorCommandParameters.ResetDownloadBehavior;
         SetDownloadBehaviorCommandParameters secondInstance = SetDownloadBehaviorCommandParameters.ResetDownloadBehavior;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/SetDownloadBehaviorCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/SetDownloadBehaviorCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetDownloadBehaviorCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetDownloadBehaviorCommandResult? result = JsonSerializer.Deserialize<SetDownloadBehaviorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetDownloadBehaviorCommandResult? result = JsonSerializer.Deserialize<SetDownloadBehaviorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetDownloadBehaviorCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Browser/UserContextInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/UserContextInfoTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Browser;
 
 using System.Text.Json;
 
-[TestFixture]
 public class UserContextInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class UserContextInfoTests
                       }
                       """;
         UserContextInfo? result = JsonSerializer.Deserialize<UserContextInfo>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.UserContextId, Is.EqualTo("default"));
+        Assert.NotNull(result);
+        Assert.Equal("default", result.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,22 +26,22 @@ public class UserContextInfoTests
                       }
                       """;
         UserContextInfo? result = JsonSerializer.Deserialize<UserContextInfo>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UserContextInfo copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingUserContextThrows()
     {
         string json = """
                       {
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithIncorrectUserContextTypeThrows()
     {
         string json = """
@@ -50,6 +49,6 @@ public class UserContextInfoTests
                         "userContext": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserContextInfo>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/ActivateCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/ActivateCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ActivateCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ActivateCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.activate"));
+        Assert.Equal("browsingContext.activate", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ActivateCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/ActivateCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/ActivateCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ActivateCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         ActivateCommandResult? result = JsonSerializer.Deserialize<ActivateCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ActivateCommandResult? result = JsonSerializer.Deserialize<ActivateCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ActivateCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class BrowsingContextEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -19,23 +18,21 @@ public class BrowsingContextEventArgsTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
         BrowsingContextEventArgs eventArgs = new(info);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-            Assert.That(eventArgs.OriginalOpener, Is.EqualTo("openerContext"));
-            Assert.That(eventArgs.Children, Is.Not.Null);
-            Assert.That(eventArgs.Children, Is.Empty);
-            Assert.That(eventArgs.Parent, Is.Null);
-        }
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal("myClientWindowId", eventArgs.ClientWindowId);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
+        Assert.Equal("openerContext", eventArgs.OriginalOpener);
+        Assert.NotNull(eventArgs.Children);
+        Assert.Empty(eventArgs.Children);
+        Assert.Null(eventArgs.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithChildren()
     {
         string json = """
@@ -58,22 +55,20 @@ public class BrowsingContextEventArgsTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
         BrowsingContextEventArgs eventArgs = new(info);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(eventArgs.OriginalOpener, Is.EqualTo("openerContext"));
-            Assert.That(eventArgs.Children, Is.Not.Null);
-            Assert.That(eventArgs.Children, Has.Count.EqualTo(1));
-            Assert.That(eventArgs.Parent, Is.Null);
-        }
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal("myClientWindowId", eventArgs.ClientWindowId);
+        Assert.Equal("openerContext", eventArgs.OriginalOpener);
+        Assert.NotNull(eventArgs.Children);
+        Assert.Single(eventArgs.Children);
+        Assert.Null(eventArgs.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalParent()
     {
         string json = """
@@ -88,23 +83,21 @@ public class BrowsingContextEventArgsTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
         BrowsingContextEventArgs eventArgs = new(info);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(eventArgs.OriginalOpener, Is.EqualTo("openerContext"));
-            Assert.That(eventArgs.Children, Is.Not.Null);
-            Assert.That(eventArgs.Children, Has.Count.EqualTo(0));
-            Assert.That(eventArgs.Parent, Is.Not.Null);
-            Assert.That(eventArgs.Parent, Is.EqualTo("parentContextId"));
-        }
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal("myClientWindowId", eventArgs.ClientWindowId);
+        Assert.Equal("openerContext", eventArgs.OriginalOpener);
+        Assert.NotNull(eventArgs.Children);
+        Assert.Empty(eventArgs.Children);
+        Assert.NotNull(eventArgs.Parent);
+        Assert.Equal("parentContextId", eventArgs.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullOriginalOpener()
     {
         string json = """
@@ -118,23 +111,21 @@ public class BrowsingContextEventArgsTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
         BrowsingContextEventArgs eventArgs = new(info);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-            Assert.That(eventArgs.OriginalOpener, Is.Null);
-            Assert.That(eventArgs.Children, Is.Not.Null);
-            Assert.That(eventArgs.Children, Is.Empty);
-            Assert.That(eventArgs.Parent, Is.Null);
-        }
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal("myClientWindowId", eventArgs.ClientWindowId);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
+        Assert.Null(eventArgs.OriginalOpener);
+        Assert.NotNull(eventArgs.Children);
+        Assert.Empty(eventArgs.Children);
+        Assert.Null(eventArgs.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -148,9 +139,9 @@ public class BrowsingContextEventArgsTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         BrowsingContextEventArgs eventArgs = new(info);
         BrowsingContextEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextInfoTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class BrowsingContextInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -19,22 +18,20 @@ public class BrowsingContextInfoTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(info.Url, Is.EqualTo("http://example.com"));
-            Assert.That(info.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(info.UserContextId, Is.EqualTo("myUserContextId"));
-            Assert.That(info.OriginalOpener, Is.EqualTo("openerContext"));
-            Assert.That(info.Children, Is.Not.Null);
-            Assert.That(info.Children, Is.Empty);
-            Assert.That(info.Parent, Is.Null);
-        }
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
+
+        Assert.Equal("myContextId", info.BrowsingContextId);
+        Assert.Equal("http://example.com", info.Url);
+        Assert.Equal("myClientWindowId", info.ClientWindowId);
+        Assert.Equal("myUserContextId", info.UserContextId);
+        Assert.Equal("openerContext", info.OriginalOpener);
+        Assert.NotNull(info.Children);
+        Assert.Empty(info.Children);
+        Assert.Null(info.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithChildren()
     {
         string json = """
@@ -57,21 +54,19 @@ public class BrowsingContextInfoTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(info.Url, Is.EqualTo("http://example.com"));
-            Assert.That(info.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(info.OriginalOpener, Is.EqualTo("openerContext"));
-            Assert.That(info.Children, Is.Not.Null);
-            Assert.That(info.Children, Has.Count.EqualTo(1));
-            Assert.That(info.Parent, Is.Null);
-        }
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
+
+        Assert.Equal("myContextId", info.BrowsingContextId);
+        Assert.Equal("http://example.com", info.Url);
+        Assert.Equal("myClientWindowId", info.ClientWindowId);
+        Assert.Equal("openerContext", info.OriginalOpener);
+        Assert.NotNull(info.Children);
+        Assert.Single(info.Children);
+        Assert.Null(info.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalParent()
     {
         string json = """
@@ -86,22 +81,20 @@ public class BrowsingContextInfoTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(info.Url, Is.EqualTo("http://example.com"));
-            Assert.That(info.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(info.OriginalOpener, Is.EqualTo("openerContext"));
-            Assert.That(info.Children, Is.Not.Null);
-            Assert.That(info.Children, Has.Count.EqualTo(0));
-            Assert.That(info.Parent, Is.Not.Null);
-            Assert.That(info.Parent, Is.EqualTo("parentContextId"));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
+
+        Assert.Equal("myContextId", info.BrowsingContextId);
+        Assert.Equal("http://example.com", info.Url);
+        Assert.Equal("myClientWindowId", info.ClientWindowId);
+        Assert.Equal("openerContext", info.OriginalOpener);
+        Assert.NotNull(info.Children);
+        Assert.Empty(info.Children);
+        Assert.NotNull(info.Parent);
+        Assert.Equal("parentContextId", info.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullOriginalOpener()
     {
         string json = """
@@ -115,22 +108,20 @@ public class BrowsingContextInfoTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<BrowsingContextInfo>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(info.Url, Is.EqualTo("http://example.com"));
-            Assert.That(info.ClientWindowId, Is.EqualTo("myClientWindowId"));
-            Assert.That(info.UserContextId, Is.EqualTo("myUserContextId"));
-            Assert.That(info.OriginalOpener, Is.Null);
-            Assert.That(info.Children, Is.Not.Null);
-            Assert.That(info.Children, Is.Empty);
-            Assert.That(info.Parent, Is.Null);
-        }
+        Assert.NotNull(info);
+        Assert.IsType<BrowsingContextInfo>(info);
+
+        Assert.Equal("myContextId", info.BrowsingContextId);
+        Assert.Equal("http://example.com", info.Url);
+        Assert.Equal("myClientWindowId", info.ClientWindowId);
+        Assert.Equal("myUserContextId", info.UserContextId);
+        Assert.Null(info.OriginalOpener);
+        Assert.NotNull(info.Children);
+        Assert.Empty(info.Children);
+        Assert.Null(info.Parent);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -144,12 +135,12 @@ public class BrowsingContextInfoTests
                       }
                       """;
         BrowsingContextInfo? info = JsonSerializer.Deserialize<BrowsingContextInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         BrowsingContextInfo copy = info with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithMissingContextThrows()
     {
         string json = """
@@ -161,10 +152,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithMissingClientWindowIdThrows()
     {
         string json = """
@@ -176,10 +167,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithMissingUrlThrows()
     {
         string json = """
@@ -191,10 +182,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithMissingOriginalOpenerThrows()
     {
         string json = """
@@ -206,10 +197,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithMissingChildrenThrows()
     {
         string json = """
@@ -221,10 +212,10 @@ public class BrowsingContextInfoTests
                         "userContext": "myUserContextId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithMissingUserContextThrows()
     {
         string json = """
@@ -236,10 +227,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidContextTypeThrows()
     {
         string json = """
@@ -252,10 +243,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidClientWindowThrows()
     {
         string json = """
@@ -268,10 +259,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidUrlTypeThrows()
     {
         string json = """
@@ -284,10 +275,10 @@ public class BrowsingContextInfoTests
                         "children": [] 
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidOriginalOpenerTypeThrows()
     {
         string json = """
@@ -300,10 +291,10 @@ public class BrowsingContextInfoTests
                         "children": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidUserContextTypeThrows()
     {
         string json = """
@@ -316,10 +307,10 @@ public class BrowsingContextInfoTests
                         "children": [] 
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidChildrenTypeThrows()
     {
         string json = """
@@ -331,10 +322,10 @@ public class BrowsingContextInfoTests
                         "children": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBrowsingContextInfoWithInvalidParentTypeThrows()
     {
         string json = """
@@ -347,6 +338,6 @@ public class BrowsingContextInfoTests
                         "parent": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BrowsingContextInfo>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
@@ -20,7 +20,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -48,7 +48,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -75,7 +75,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -103,7 +103,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -141,7 +141,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -174,7 +174,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -201,7 +201,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -239,7 +239,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -268,7 +268,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -299,7 +299,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -329,7 +329,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -358,7 +358,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -384,7 +384,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -410,7 +410,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -424,7 +424,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveContextCreatedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -463,7 +463,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveContextDestroyedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -500,7 +500,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveDomContentLoadedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -537,7 +537,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveDownloadWillBeginEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -578,7 +578,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveDownloadEndEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -621,7 +621,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveFragmentNavigatedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -658,7 +658,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveLoadEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -695,7 +695,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationAbortedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -732,7 +732,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationCommittedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -769,7 +769,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationFailedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -806,7 +806,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationStartedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -843,7 +843,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveHistoryUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -875,7 +875,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveUserPromptClosedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -908,7 +908,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveUserPromptOpenedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using TestUtilities;
 
-[TestFixture]
 public class BrowsingContextModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecuteActivateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -22,17 +21,16 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<ActivateCommandResult> task = module.ActivateAsync(new ActivateCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        ActivateCommandResult result = task.Result;
+        Task<ActivateCommandResult> task = module.ActivateAsync(new ActivateCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        ActivateCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCaptureScreenshotCommand()
     {
         TestWebSocketConnection connection = new();
@@ -51,18 +49,17 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<CaptureScreenshotCommandResult> task = module.CaptureScreenshotAsync(new CaptureScreenshotCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        CaptureScreenshotCommandResult result = task.Result;
+        Task<CaptureScreenshotCommandResult> task = module.CaptureScreenshotAsync(new CaptureScreenshotCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        CaptureScreenshotCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Data, Is.EqualTo("encodedScreenshotData"));
+        Assert.NotNull(result);
+        Assert.Equal("encodedScreenshotData", result.Data);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCloseCommand()
     {
         TestWebSocketConnection connection = new();
@@ -79,17 +76,16 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<CloseCommandResult> task = module.CloseAsync(new CloseCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        CloseCommandResult result = task.Result;
+        Task<CloseCommandResult> task = module.CloseAsync(new CloseCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        CloseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCreateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -108,18 +104,17 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<CreateCommandResult> task = module.CreateAsync(new CreateCommandParameters(CreateType.Tab));
-        task.Wait(TimeSpan.FromSeconds(1));
-        CreateCommandResult result = task.Result;
+        Task<CreateCommandResult> task = module.CreateAsync(new CreateCommandParameters(CreateType.Tab), cancellationToken: TestContext.Current.CancellationToken);
+        CreateCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.BrowsingContextId, Is.EqualTo("myContext"));
+        Assert.NotNull(result);
+        Assert.Equal("myContext", result.BrowsingContextId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetTreeCommand()
     {
         TestWebSocketConnection connection = new();
@@ -147,24 +142,21 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<GetTreeCommandResult> task = module.GetTreeAsync(new GetTreeCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetTreeCommandResult result = task.Result;
+        Task<GetTreeCommandResult> task = module.GetTreeAsync(new GetTreeCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        GetTreeCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ContextTree, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.ContextTree[0].BrowsingContextId, Is.EqualTo("myContext"));
-            Assert.That(result.ContextTree[0].Url, Is.EqualTo("https://example.com"));
-            Assert.That(result.ContextTree[0].Children, Has.Count.EqualTo(0));
-        }
+        Assert.NotNull(result);
+        Assert.Single(result.ContextTree);
+
+        Assert.Equal("myContext", result.ContextTree[0].BrowsingContextId);
+        Assert.Equal("https://example.com", result.ContextTree[0].Url);
+        Assert.Empty(result.ContextTree[0].Children);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetTreeCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -183,18 +175,17 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<GetTreeCommandResult> task = module.GetTreeAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetTreeCommandResult result = task.Result;
+        Task<GetTreeCommandResult> task = module.GetTreeAsync(cancellationToken: TestContext.Current.CancellationToken);
+        GetTreeCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ContextTree, Has.Count.EqualTo(0));
+        Assert.NotNull(result);
+        Assert.Empty(result.ContextTree);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteHandleUserPromptCommand()
     {
         TestWebSocketConnection connection = new();
@@ -211,17 +202,16 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<HandleUserPromptCommandResult> task = module.HandleUserPromptAsync(new HandleUserPromptCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        HandleUserPromptCommandResult result = task.Result;
+        Task<HandleUserPromptCommandResult> task = module.HandleUserPromptAsync(new HandleUserPromptCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        HandleUserPromptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteLocateNodesCommand()
     {
         TestWebSocketConnection connection = new();
@@ -250,17 +240,16 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<LocateNodesCommandResult> task = module.LocateNodesAsync(new LocateNodesCommandParameters("myContextId", new CssLocator(".selector")));
-        task.Wait(TimeSpan.FromSeconds(1));
-        LocateNodesCommandResult result = task.Result;
+        Task<LocateNodesCommandResult> task = module.LocateNodesAsync(new LocateNodesCommandParameters("myContextId", new CssLocator(".selector")), cancellationToken: TestContext.Current.CancellationToken);
+        LocateNodesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteNavigateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -280,22 +269,19 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<NavigateCommandResult> task = module.NavigateAsync(new NavigateCommandParameters("myContext", "https://example.com") { Wait = ReadinessState.Complete });
-        task.Wait(TimeSpan.FromSeconds(1));
-        NavigateCommandResult result = task.Result;
+        Task<NavigateCommandResult> task = module.NavigateAsync(new NavigateCommandParameters("myContext", "https://example.com") { Wait = ReadinessState.Complete }, cancellationToken: TestContext.Current.CancellationToken);
+        NavigateCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(result.Url, Is.EqualTo("https://example.com"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myNavigationId", result.NavigationId);
+        Assert.Equal("https://example.com", result.Url);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecutePrintCommand()
     {
         TestWebSocketConnection connection = new();
@@ -314,18 +300,17 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<PrintCommandResult> task = module.PrintAsync(new PrintCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        PrintCommandResult result = task.Result;
+        Task<PrintCommandResult> task = module.PrintAsync(new PrintCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        PrintCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Data, Is.EqualTo("encodedPdf"));
+        Assert.NotNull(result);
+        Assert.Equal("encodedPdf", result.Data);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteReloadCommand()
     {
         TestWebSocketConnection connection = new();
@@ -345,22 +330,19 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<ReloadCommandResult> task = module.ReloadAsync(new ReloadCommandParameters("myContext"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        ReloadCommandResult result = task.Result;
+        Task<ReloadCommandResult> task = module.ReloadAsync(new ReloadCommandParameters("myContext"), cancellationToken: TestContext.Current.CancellationToken);
+        ReloadCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(result.Url, Is.EqualTo("https://example.com"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myNavigationId", result.NavigationId);
+        Assert.Equal("https://example.com", result.Url);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSetBypassCSPCommand()
     {
         TestWebSocketConnection connection = new();
@@ -377,17 +359,16 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<SetBypassCSPCommandResult> task = module.SetBypassCSPAsync(new SetBypassCSPCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetBypassCSPCommandResult result = task.Result;
+        Task<SetBypassCSPCommandResult> task = module.SetBypassCSPAsync(new SetBypassCSPCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetBypassCSPCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSetViewportCommand()
     {
         TestWebSocketConnection connection = new();
@@ -404,17 +385,16 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<SetViewportCommandResult> task = module.SetViewportAsync(new SetViewportCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetViewportCommandResult result = task.Result;
+        Task<SetViewportCommandResult> task = module.SetViewportAsync(new SetViewportCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetViewportCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteTraverseHistoryCommand()
     {
         TestWebSocketConnection connection = new();
@@ -431,36 +411,34 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        Task<TraverseHistoryCommandResult> task = module.TraverseHistoryAsync(new TraverseHistoryCommandParameters("myContextId", -3));
-        task.Wait(TimeSpan.FromSeconds(1));
-        TraverseHistoryCommandResult result = task.Result;
+        Task<TraverseHistoryCommandResult> task = module.TraverseHistoryAsync(new TraverseHistoryCommandParameters("myContextId", -3), cancellationToken: TestContext.Current.CancellationToken);
+        TraverseHistoryCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveContextCreatedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         module.OnContextCreated.AddObserver((BrowsingContextEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.UserContextId, Is.EqualTo("default"));
-                Assert.That(e.OriginalOpener, Is.EqualTo("openerContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Children, Has.Count.EqualTo(0));
-                Assert.That(e.Parent, Is.Null);
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("default", e.UserContextId);
+            Assert.Equal("openerContext", e.OriginalOpener);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Empty(e.Children);
+            Assert.Null(e.Parent);
+
             syncEvent.Set();
         });
 
@@ -480,27 +458,26 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveContextDestroyedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         module.OnContextDestroyed.AddObserver((BrowsingContextEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Children, Has.Count.EqualTo(0));
-                Assert.That(e.Parent, Is.Null);
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Empty(e.Children);
+            Assert.Null(e.Parent);
+
             syncEvent.Set();
         });
 
@@ -520,29 +497,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveDomContentLoadedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnDomContentLoaded.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -560,31 +536,30 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(12500));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveDownloadWillBeginEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnDownloadWillBegin.AddObserver((DownloadWillBeginEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-                Assert.That(e.DownloadId, Is.EqualTo("myDownloadId"));
-                Assert.That(e.SuggestedFileName, Is.EqualTo("myFile.file"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+            Assert.Equal("myDownloadId", e.DownloadId);
+            Assert.Equal("myFile.file", e.SuggestedFileName);
+
             syncEvent.Set();
         });
 
@@ -604,32 +579,31 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveDownloadEndEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnDownloadEnd.AddObserver((DownloadEndEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-                Assert.That(e.Status, Is.EqualTo(DownloadEndStatus.Complete));
-                Assert.That(e.DownloadId, Is.EqualTo("myDownloadId"));
-                Assert.That(e.FilePath, Is.EqualTo("myFile.file"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+            Assert.Equal(DownloadEndStatus.Complete, e.Status);
+            Assert.Equal("myDownloadId", e.DownloadId);
+            Assert.Equal("myFile.file", e.FilePath);
+
             syncEvent.Set();
         });
 
@@ -650,29 +624,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveFragmentNavigatedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnFragmentNavigated.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -690,29 +663,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveLoadEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnLoad.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -730,29 +702,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveNavigationAbortedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationAborted.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -770,29 +741,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveNavigationCommittedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationCommitted.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -810,29 +780,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveNavigationFailedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationFailed.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -850,29 +819,28 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveNavigationStartedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationStarted.AddObserver((NavigationEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(epochTimestamp));
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+
             syncEvent.Set();
         });
 
@@ -890,25 +858,24 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveHistoryUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         module.OnHistoryUpdated.AddObserver((HistoryUpdatedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com", e.Url);
+
             syncEvent.Set();
         });
 
@@ -925,26 +892,25 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveUserPromptClosedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         module.OnUserPromptClosed.AddObserver((UserPromptClosedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.IsAccepted, Is.EqualTo(true));
-                Assert.That(e.UserText, Is.EqualTo("my prompt text"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.True(e.IsAccepted);
+            Assert.Equal("my prompt text", e.UserText);
+
             syncEvent.Set();
         });
 
@@ -961,26 +927,25 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveUserPromptOpenedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         ManualResetEvent syncEvent = new(false);
         module.OnUserPromptOpened.AddObserver((UserPromptOpenedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.PromptType, Is.EqualTo(UserPromptType.Confirm));
-                Assert.That(e.Message, Is.EqualTo("my message text"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal(UserPromptType.Confirm, e.PromptType);
+            Assert.Equal("my message text", e.Message);
+
             syncEvent.Set();
         });
 
@@ -998,6 +963,6 @@ public class BrowsingContextModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
@@ -21,7 +21,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<ActivateCommandResult> task = module.ActivateAsync(new ActivateCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -49,7 +49,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<CaptureScreenshotCommandResult> task = module.CaptureScreenshotAsync(new CaptureScreenshotCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -76,7 +76,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<CloseCommandResult> task = module.CloseAsync(new CloseCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -104,7 +104,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<CreateCommandResult> task = module.CreateAsync(new CreateCommandParameters(CreateType.Tab), cancellationToken: TestContext.Current.CancellationToken);
@@ -142,7 +142,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<GetTreeCommandResult> task = module.GetTreeAsync(new GetTreeCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -175,7 +175,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<GetTreeCommandResult> task = module.GetTreeAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -202,7 +202,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<HandleUserPromptCommandResult> task = module.HandleUserPromptAsync(new HandleUserPromptCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -240,7 +240,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<LocateNodesCommandResult> task = module.LocateNodesAsync(new LocateNodesCommandParameters("myContextId", new CssLocator(".selector")), cancellationToken: TestContext.Current.CancellationToken);
@@ -269,7 +269,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<NavigateCommandResult> task = module.NavigateAsync(new NavigateCommandParameters("myContext", "https://example.com") { Wait = ReadinessState.Complete }, cancellationToken: TestContext.Current.CancellationToken);
@@ -300,7 +300,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<PrintCommandResult> task = module.PrintAsync(new PrintCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -330,7 +330,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<ReloadCommandResult> task = module.ReloadAsync(new ReloadCommandParameters("myContext"), cancellationToken: TestContext.Current.CancellationToken);
@@ -359,7 +359,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<SetBypassCSPCommandResult> task = module.SetBypassCSPAsync(new SetBypassCSPCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -385,7 +385,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<SetViewportCommandResult> task = module.SetViewportAsync(new SetViewportCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -411,7 +411,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
         Task<TraverseHistoryCommandResult> task = module.TraverseHistoryAsync(new TraverseHistoryCommandParameters("myContextId", -3), cancellationToken: TestContext.Current.CancellationToken);
@@ -425,13 +425,12 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnContextCreated.AddObserver((BrowsingContextEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("default", e.UserContextId);
             Assert.Equal("openerContext", e.OriginalOpener);
@@ -439,7 +438,7 @@ public class BrowsingContextModuleTests
             Assert.Empty(e.Children);
             Assert.Null(e.Parent);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -457,8 +456,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -466,19 +464,18 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnContextDestroyed.AddObserver((BrowsingContextEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Empty(e.Children);
             Assert.Null(e.Parent);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -496,8 +493,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -505,21 +501,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnDomContentLoaded.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -535,8 +530,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(12500));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -544,14 +538,13 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnDownloadWillBegin.AddObserver((DownloadWillBeginEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
@@ -560,7 +553,7 @@ public class BrowsingContextModuleTests
             Assert.Equal("myDownloadId", e.DownloadId);
             Assert.Equal("myFile.file", e.SuggestedFileName);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -578,8 +571,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -587,14 +579,13 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnDownloadEnd.AddObserver((DownloadEndEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
@@ -604,7 +595,7 @@ public class BrowsingContextModuleTests
             Assert.Equal("myDownloadId", e.DownloadId);
             Assert.Equal("myFile.file", e.FilePath);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -623,8 +614,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -632,21 +622,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnFragmentNavigated.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -662,8 +651,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -671,21 +659,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnLoad.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -701,8 +688,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -710,21 +696,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationAborted.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -740,8 +725,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -749,21 +733,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationCommitted.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -779,8 +762,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -788,21 +770,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationFailed.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -818,8 +799,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -827,21 +807,20 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnNavigationStarted.AddObserver((NavigationEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal((ulong)((ulong)(epochTimestamp)), e.EpochTimestamp);
             Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -857,8 +836,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -866,17 +844,16 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnHistoryUpdated.AddObserver((HistoryUpdatedEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -891,8 +868,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -900,18 +876,17 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnUserPromptClosed.AddObserver((UserPromptClosedEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.True(e.IsAccepted);
             Assert.Equal("my prompt text", e.UserText);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -926,8 +901,7 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -935,18 +909,17 @@ public class BrowsingContextModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnUserPromptOpened.AddObserver((UserPromptOpenedEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal(UserPromptType.Confirm, e.PromptType);
             Assert.Equal("my message text", e.Message);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -962,7 +935,6 @@ public class BrowsingContextModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
@@ -429,7 +429,7 @@ public class BrowsingContextModuleTests
         BrowsingContextModule module = driver.BrowsingContext;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnContextCreated.AddObserver((BrowsingContextEventArgs e) =>
+        module.OnContextCreated.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("default", e.UserContextId);
@@ -468,7 +468,7 @@ public class BrowsingContextModuleTests
         BrowsingContextModule module = driver.BrowsingContext;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnContextDestroyed.AddObserver((BrowsingContextEventArgs e) =>
+        module.OnContextDestroyed.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -506,7 +506,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnDomContentLoaded.AddObserver((NavigationEventArgs e) =>
+        module.OnDomContentLoaded.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -543,7 +543,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnDownloadWillBegin.AddObserver((DownloadWillBeginEventArgs e) =>
+        module.OnDownloadWillBegin.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -584,7 +584,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnDownloadEnd.AddObserver((DownloadEndEventArgs e) =>
+        module.OnDownloadEnd.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -627,7 +627,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnFragmentNavigated.AddObserver((NavigationEventArgs e) =>
+        module.OnFragmentNavigated.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -664,7 +664,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnLoad.AddObserver((NavigationEventArgs e) =>
+        module.OnLoad.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -701,7 +701,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnNavigationAborted.AddObserver((NavigationEventArgs e) =>
+        module.OnNavigationAborted.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -738,7 +738,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnNavigationCommitted.AddObserver((NavigationEventArgs e) =>
+        module.OnNavigationCommitted.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -775,7 +775,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnNavigationFailed.AddObserver((NavigationEventArgs e) =>
+        module.OnNavigationFailed.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -812,7 +812,7 @@ public class BrowsingContextModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnNavigationStarted.AddObserver((NavigationEventArgs e) =>
+        module.OnNavigationStarted.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -848,7 +848,7 @@ public class BrowsingContextModuleTests
         BrowsingContextModule module = driver.BrowsingContext;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnHistoryUpdated.AddObserver((HistoryUpdatedEventArgs e) =>
+        module.OnHistoryUpdated.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com", e.Url);
@@ -880,7 +880,7 @@ public class BrowsingContextModuleTests
         BrowsingContextModule module = driver.BrowsingContext;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnUserPromptClosed.AddObserver((UserPromptClosedEventArgs e) =>
+        module.OnUserPromptClosed.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.True(e.IsAccepted);
@@ -913,7 +913,7 @@ public class BrowsingContextModuleTests
         BrowsingContextModule module = driver.BrowsingContext;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnUserPromptOpened.AddObserver((UserPromptOpenedEventArgs e) =>
+        module.OnUserPromptOpened.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal(UserPromptType.Confirm, e.PromptType);

--- a/test/WebDriverBiDi.Tests/BrowsingContext/CaptureScreenshotCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/CaptureScreenshotCommandParametersTests.cs
@@ -4,32 +4,31 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class CaptureScreenshotCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.captureScreenshot"));
+        Assert.Equal("browsingContext.captureScreenshot", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDefaultBoxClipRectangle()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -38,35 +37,54 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("clip"));
-            Assert.That(serialized["clip"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? clipObject = serialized["clip"]!.Value<JObject>();
-            Assert.That(clipObject, Has.Count.EqualTo(5));
-            Assert.That(clipObject, Contains.Key("type"));
-            Assert.That(clipObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(clipObject["type"]!.Value<string>(), Is.EqualTo("box"));
-            Assert.That(clipObject, Contains.Key("x"));
-            Assert.That(clipObject!["x"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["x"]!.Value<double>(), Is.EqualTo(0.0));
-            Assert.That(clipObject, Contains.Key("y"));
-            Assert.That(clipObject!["y"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["y"]!.Value<double>(), Is.EqualTo(0.0));
-            Assert.That(clipObject, Contains.Key("width"));
-            Assert.That(clipObject!["width"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["width"]!.Value<double>(), Is.EqualTo(0.0));
-            Assert.That(clipObject, Contains.Key("height"));
-            Assert.That(clipObject!["height"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["height"]!.Value<double>(), Is.EqualTo(0.0));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("clip"));
+        JToken? clipToken = serialized["clip"];
+        Assert.NotNull(clipToken);
+        Assert.Equal(JTokenType.Object, clipToken.Type);
+        JObject? clipObject = clipToken.Value<JObject>();
+        Assert.NotNull(clipObject);
+        Assert.Equal(5, clipObject.Count);
+
+        Assert.True(clipObject.ContainsKey("type"));
+        JToken? clipType = clipObject["type"];
+        Assert.NotNull(clipType);
+        Assert.Equal(JTokenType.String, clipType.Type);
+        Assert.Equal("box", clipType.Value<string>());
+
+        Assert.True(clipObject.ContainsKey("x"));
+        JToken? clipX = clipObject["x"];
+        Assert.NotNull(clipX);
+        Assert.Equal(JTokenType.Float, clipX.Type);
+        Assert.Equal(0.0, clipX.Value<double>());
+
+        Assert.True(clipObject.ContainsKey("y"));
+        JToken? clipY = clipObject["y"];
+        Assert.NotNull(clipY);
+        Assert.Equal(JTokenType.Float, clipY.Type);
+        Assert.Equal(0.0, clipY.Value<double>());
+
+        Assert.True(clipObject.ContainsKey("width"));
+        JToken? clipWidth = clipObject["width"];
+        Assert.NotNull(clipWidth);
+        Assert.Equal(JTokenType.Float, clipWidth.Type);
+        Assert.Equal(0.0, clipWidth.Value<double>());
+
+        Assert.True(clipObject.ContainsKey("height"));
+        JToken? clipHeight = clipObject["height"];
+        Assert.NotNull(clipHeight);
+        Assert.Equal(JTokenType.Float, clipHeight.Type);
+        Assert.Equal(0.0, clipHeight.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNonDefaultBoxClipRectangle()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -81,35 +99,54 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("clip"));
-            Assert.That(serialized["clip"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? clipObject = serialized["clip"]!.Value<JObject>();
-            Assert.That(clipObject, Has.Count.EqualTo(5));
-            Assert.That(clipObject, Contains.Key("type"));
-            Assert.That(clipObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(clipObject["type"]!.Value<string>(), Is.EqualTo("box"));
-            Assert.That(clipObject, Contains.Key("x"));
-            Assert.That(clipObject!["x"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["x"]!.Value<double>(), Is.EqualTo(10.0));
-            Assert.That(clipObject, Contains.Key("y"));
-            Assert.That(clipObject!["y"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["y"]!.Value<double>(), Is.EqualTo(20.0));
-            Assert.That(clipObject, Contains.Key("width"));
-            Assert.That(clipObject!["width"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["width"]!.Value<double>(), Is.EqualTo(200.0));
-            Assert.That(clipObject, Contains.Key("height"));
-            Assert.That(clipObject!["height"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(clipObject["height"]!.Value<double>(), Is.EqualTo(100.0));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("clip"));
+        JToken? clipToken = serialized["clip"];
+        Assert.NotNull(clipToken);
+        Assert.Equal(JTokenType.Object, clipToken.Type);
+        JObject? clipObject = clipToken.Value<JObject>();
+        Assert.NotNull(clipObject);
+        Assert.Equal(5, clipObject.Count);
+
+        Assert.True(clipObject.ContainsKey("type"));
+        JToken? clipType = clipObject["type"];
+        Assert.NotNull(clipType);
+        Assert.Equal(JTokenType.String, clipType.Type);
+        Assert.Equal("box", clipType.Value<string>());
+
+        Assert.True(clipObject.ContainsKey("x"));
+        JToken? clipX = clipObject["x"];
+        Assert.NotNull(clipX);
+        Assert.Equal(JTokenType.Float, clipX.Type);
+        Assert.Equal(10.0, clipX.Value<double>());
+
+        Assert.True(clipObject.ContainsKey("y"));
+        JToken? clipY = clipObject["y"];
+        Assert.NotNull(clipY);
+        Assert.Equal(JTokenType.Float, clipY.Type);
+        Assert.Equal(20.0, clipY.Value<double>());
+
+        Assert.True(clipObject.ContainsKey("width"));
+        JToken? clipWidth = clipObject["width"];
+        Assert.NotNull(clipWidth);
+        Assert.Equal(JTokenType.Float, clipWidth.Type);
+        Assert.Equal(200.0, clipWidth.Value<double>());
+
+        Assert.True(clipObject.ContainsKey("height"));
+        JToken? clipHeight = clipObject["height"];
+        Assert.NotNull(clipHeight);
+        Assert.Equal(JTokenType.Float, clipHeight.Type);
+        Assert.Equal(100.0, clipHeight.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDefaultElementClipRectangle()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -118,28 +155,41 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("clip"));
-            Assert.That(serialized["clip"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? clipObject = serialized["clip"]!.Value<JObject>();
-            Assert.That(clipObject, Has.Count.EqualTo(2));
-            Assert.That(clipObject, Contains.Key("type"));
-            Assert.That(clipObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(clipObject["type"]!.Value<string>(), Is.EqualTo("element"));
-            Assert.That(clipObject, Contains.Key("element"));
-            Assert.That(clipObject!["element"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? sharedReferenceObject = clipObject["element"]!.Value<JObject>();
-            Assert.That(sharedReferenceObject, Contains.Key("sharedId"));
-            Assert.That(sharedReferenceObject!["sharedId"]!.Value<string>(), Is.EqualTo("myElementSharedId"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("clip"));
+        JToken? clipToken = serialized["clip"];
+        Assert.NotNull(clipToken);
+        Assert.Equal(JTokenType.Object, clipToken.Type);
+        JObject? clipObject = clipToken.Value<JObject>();
+        Assert.NotNull(clipObject);
+        Assert.Equal(2, clipObject.Count);
+
+        Assert.True(clipObject.ContainsKey("type"));
+        JToken? clipType = clipObject["type"];
+        Assert.NotNull(clipType);
+        Assert.Equal(JTokenType.String, clipType.Type);
+        Assert.Equal("element", clipType.Value<string>());
+
+        Assert.True(clipObject.ContainsKey("element"));
+        JToken? clipElement = clipObject["element"];
+        Assert.NotNull(clipElement);
+        Assert.Equal(JTokenType.Object, clipElement.Type);
+        JObject? sharedReferenceObject = clipElement.Value<JObject>();
+        Assert.NotNull(sharedReferenceObject);
+        Assert.True(sharedReferenceObject.ContainsKey("sharedId"));
+        JToken? sharedId = sharedReferenceObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal("myElementSharedId", sharedId.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithDefaultFormatParameter()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -148,23 +198,30 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("format"));
-            Assert.That(serialized["format"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? formatObject = serialized["format"]!.Value<JObject>();
-            Assert.That(formatObject, Has.Count.EqualTo(1));
-            Assert.That(formatObject, Contains.Key("type"));
-            Assert.That(formatObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(formatObject["type"]!.Value<string>(), Is.EqualTo("image/png"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("format"));
+        JToken? formatToken = serialized["format"];
+        Assert.NotNull(formatToken);
+        Assert.Equal(JTokenType.Object, formatToken.Type);
+        JObject? formatObject = formatToken.Value<JObject>();
+        Assert.NotNull(formatObject);
+        Assert.Single(formatObject);
+
+        Assert.True(formatObject.ContainsKey("type"));
+        JToken? formatType = formatObject["type"];
+        Assert.NotNull(formatType);
+        Assert.Equal(JTokenType.String, formatType.Type);
+        Assert.Equal("image/png", formatType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithNonDefaultFormatParameter()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -176,23 +233,30 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("format"));
-            Assert.That(serialized["format"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? formatObject = serialized["format"]!.Value<JObject>();
-            Assert.That(formatObject, Has.Count.EqualTo(1));
-            Assert.That(formatObject, Contains.Key("type"));
-            Assert.That(formatObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(formatObject["type"]!.Value<string>(), Is.EqualTo("image/jpeg"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("format"));
+        JToken? formatToken = serialized["format"];
+        Assert.NotNull(formatToken);
+        Assert.Equal(JTokenType.Object, formatToken.Type);
+        JObject? formatObject = formatToken.Value<JObject>();
+        Assert.NotNull(formatObject);
+        Assert.Single(formatObject);
+
+        Assert.True(formatObject.ContainsKey("type"));
+        JToken? formatType = formatObject["type"];
+        Assert.NotNull(formatType);
+        Assert.Equal(JTokenType.String, formatType.Type);
+        Assert.Equal("image/jpeg", formatType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithNonDefaultFormatParameterIncludingQuality()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -205,26 +269,36 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("format"));
-            Assert.That(serialized["format"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? formatObject = serialized["format"]!.Value<JObject>();
-            Assert.That(formatObject, Has.Count.EqualTo(2));
-            Assert.That(formatObject, Contains.Key("type"));
-            Assert.That(formatObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(formatObject["type"]!.Value<string>(), Is.EqualTo("image/jpeg"));
-            Assert.That(formatObject, Contains.Key("quality"));
-            Assert.That(formatObject!["quality"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(formatObject["quality"]!.Value<double>(), Is.EqualTo(0.5));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("format"));
+        JToken? formatToken = serialized["format"];
+        Assert.NotNull(formatToken);
+        Assert.Equal(JTokenType.Object, formatToken.Type);
+        JObject? formatObject = formatToken.Value<JObject>();
+        Assert.NotNull(formatObject);
+        Assert.Equal(2, formatObject.Count);
+
+        Assert.True(formatObject.ContainsKey("type"));
+        JToken? formatType = formatObject["type"];
+        Assert.NotNull(formatType);
+        Assert.Equal(JTokenType.String, formatType.Type);
+        Assert.Equal("image/jpeg", formatType.Value<string>());
+
+        Assert.True(formatObject.ContainsKey("quality"));
+        JToken? formatQuality = formatObject["quality"];
+        Assert.NotNull(formatQuality);
+        Assert.Equal(JTokenType.Float, formatQuality.Type);
+        Assert.Equal(0.5, formatQuality.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithViewportOrigin()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -233,19 +307,22 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("viewport"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("viewport", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDocumentOrigin()
     {
         CaptureScreenshotCommandParameters properties = new("myContextId")
@@ -254,26 +331,29 @@ public class CaptureScreenshotCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("document"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("document", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestImageFormatQualityParameterOutsideValidRangeThrows()
     {
         ImageFormat format = new();
 
         // Also test that Quality property can be explicitly set to null.
         format.Quality = null;
-        Assert.That(() => format.Quality = -.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Quality must be between 0 and 1 inclusive."));
-        Assert.That(() => format.Quality = 1.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Quality must be between 0 and 1 inclusive."));
+        Assert.Contains("Quality must be between 0 and 1 inclusive.", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => format.Quality = -.01).Message);
+        Assert.Contains("Quality must be between 0 and 1 inclusive.", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => format.Quality = 1.01).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/CaptureScreenshotCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/CaptureScreenshotCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CaptureScreenshotCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class CaptureScreenshotCommandResultTests
                       }
                       """;
         CaptureScreenshotCommandResult? result = JsonSerializer.Deserialize<CaptureScreenshotCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result!.Data, Is.EqualTo("some screenshot data"));
+        Assert.NotNull(result);
+        Assert.Equal("some screenshot data", result.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class CaptureScreenshotCommandResultTests
                       }
                       """;
         CaptureScreenshotCommandResult? result = JsonSerializer.Deserialize<CaptureScreenshotCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CaptureScreenshotCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<CaptureScreenshotCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CaptureScreenshotCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class CaptureScreenshotCommandResultTests
                         "data": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CaptureScreenshotCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CaptureScreenshotCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/CloseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/CloseCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CloseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         CloseCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.close"));
+        Assert.Equal("browsingContext.close", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         CloseCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPromptUnloadTrue()
     {
         CloseCommandParameters properties = new("myContextId")
@@ -37,19 +36,22 @@ public class CloseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("promptUnload"));
-            Assert.That(serialized["promptUnload"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["promptUnload"]!.Value<bool>(), Is.True);
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("promptUnload"));
+        JToken? promptUnload = serialized["promptUnload"];
+        Assert.NotNull(promptUnload);
+        Assert.Equal(JTokenType.Boolean, promptUnload.Type);
+        Assert.True(promptUnload.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPromptUnloadFalse()
     {
         CloseCommandParameters properties = new("myContextId")
@@ -58,15 +60,18 @@ public class CloseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("promptUnload"));
-            Assert.That(serialized["promptUnload"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["promptUnload"]!.Value<bool>(), Is.False);
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("promptUnload"));
+        JToken? promptUnload = serialized["promptUnload"];
+        Assert.NotNull(promptUnload);
+        Assert.Equal(JTokenType.Boolean, promptUnload.Type);
+        Assert.False(promptUnload.Value<bool>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/CloseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/CloseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CloseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         CloseCommandResult? result = JsonSerializer.Deserialize<CloseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         CloseCommandResult? result = JsonSerializer.Deserialize<CloseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CloseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/CreateCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/CreateCommandParametersTests.cs
@@ -3,47 +3,46 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CreateCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         CreateCommandParameters properties = new(CreateType.Tab);
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.create"));
+        Assert.Equal("browsingContext.create", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForTab()
     {
         CreateCommandParameters properties = new(CreateType.Tab);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("tab"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("tab", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForWindow()
     {
         CreateCommandParameters properties = new(CreateType.Window);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("window"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("window", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithReferenceContext()
     {
         CreateCommandParameters properties = new(CreateType.Tab)
@@ -52,19 +51,22 @@ public class CreateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("tab"));
-            Assert.That(serialized, Contains.Key("referenceContext"));
-            Assert.That(serialized["referenceContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["referenceContext"]!.Value<string>(), Is.EqualTo("myReferenceContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("tab", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("referenceContext"));
+        JToken? referenceContext = serialized["referenceContext"];
+        Assert.NotNull(referenceContext);
+        Assert.Equal(JTokenType.String, referenceContext.Type);
+        Assert.Equal("myReferenceContext", referenceContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUserContext()
     {
         CreateCommandParameters properties = new(CreateType.Tab)
@@ -73,19 +75,22 @@ public class CreateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("tab"));
-            Assert.That(serialized, Contains.Key("userContext"));
-            Assert.That(serialized["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("tab", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContext"));
+        JToken? userContext = serialized["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBackgroundTrue()
     {
         CreateCommandParameters properties = new(CreateType.Tab)
@@ -94,19 +99,22 @@ public class CreateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("tab"));
-            Assert.That(serialized, Contains.Key("background"));
-            Assert.That(serialized["background"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["background"]!.Value<bool>(), Is.EqualTo(true));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("tab", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("background"));
+        JToken? background = serialized["background"];
+        Assert.NotNull(background);
+        Assert.Equal(JTokenType.Boolean, background.Type);
+        Assert.True(background.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBackgroundFalse()
     {
         CreateCommandParameters properties = new(CreateType.Tab)
@@ -115,19 +123,22 @@ public class CreateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("tab"));
-            Assert.That(serialized, Contains.Key("background"));
-            Assert.That(serialized["background"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["background"]!.Value<bool>(), Is.EqualTo(false));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("tab", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("background"));
+        JToken? background = serialized["background"];
+        Assert.NotNull(background);
+        Assert.Equal(JTokenType.Boolean, background.Type);
+        Assert.False(background.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSetCreateTypeProperty()
     {
         CreateCommandParameters properties = new(CreateType.Tab)
@@ -136,12 +147,12 @@ public class CreateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("window"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("window", type.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/CreateCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/CreateCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CreateCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class CreateCommandResultTests
                       }
                       """;
         CreateCommandResult? result = JsonSerializer.Deserialize<CreateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.BrowsingContextId, Is.EqualTo("myContextId"));
+        Assert.NotNull(result);
+        Assert.Equal("myContextId", result.BrowsingContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserContext()
     {
         string json = """
@@ -28,12 +27,12 @@ public class CreateCommandResultTests
                       }
                       """;
         CreateCommandResult? result = JsonSerializer.Deserialize<CreateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.BrowsingContextId, Is.EqualTo("myContextId"));
-        Assert.That(result.UserContextId, Is.EqualTo("myUserContextId"));
+        Assert.NotNull(result);
+        Assert.Equal("myContextId", result.BrowsingContextId);
+        Assert.Equal("myUserContextId", result.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -42,19 +41,19 @@ public class CreateCommandResultTests
                       }
                       """;
         CreateCommandResult? result = JsonSerializer.Deserialize<CreateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CreateCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<CreateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CreateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -62,6 +61,6 @@ public class CreateCommandResultTests
                         "context": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CreateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CreateCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/DownloadEndEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/DownloadEndEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DownloadEndEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeComplete()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -21,21 +20,19 @@ public class DownloadEndEventArgsTests
                       }
                       """;
         DownloadEndEventArgs? eventArgs = JsonSerializer.Deserialize<DownloadEndEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.DownloadId, Is.EqualTo("myDownloadId"));
-            Assert.That(eventArgs.Status, Is.EqualTo(DownloadEndStatus.Complete));
-            Assert.That(eventArgs.FilePath, Is.EqualTo("myFile.file"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(epochTimestamp)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal("myDownloadId", eventArgs.DownloadId);
+        Assert.Equal(DownloadEndStatus.Complete, eventArgs.Status);
+        Assert.Equal("myFile.file", eventArgs.FilePath);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCompleteWithNullFilePath()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -51,21 +48,19 @@ public class DownloadEndEventArgsTests
                       }
                       """;
         DownloadEndEventArgs? eventArgs = JsonSerializer.Deserialize<DownloadEndEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.DownloadId, Is.EqualTo("myDownloadId"));
-            Assert.That(eventArgs.Status, Is.EqualTo(DownloadEndStatus.Complete));
-            Assert.That(eventArgs.FilePath, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(epochTimestamp)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal("myDownloadId", eventArgs.DownloadId);
+        Assert.Equal(DownloadEndStatus.Complete, eventArgs.Status);
+        Assert.Null(eventArgs.FilePath);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCanceled()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -80,21 +75,19 @@ public class DownloadEndEventArgsTests
                       }
                       """;
         DownloadEndEventArgs? eventArgs = JsonSerializer.Deserialize<DownloadEndEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.DownloadId, Is.EqualTo("myDownloadId"));
-            Assert.That(eventArgs.Status, Is.EqualTo(DownloadEndStatus.Canceled));
-            Assert.That(eventArgs.FilePath, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(epochTimestamp)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal("myDownloadId", eventArgs.DownloadId);
+        Assert.Equal(DownloadEndStatus.Canceled, eventArgs.Status);
+        Assert.Null(eventArgs.FilePath);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -110,12 +103,12 @@ public class DownloadEndEventArgsTests
                       }
                       """;
         DownloadEndEventArgs? eventArgs = JsonSerializer.Deserialize<DownloadEndEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         DownloadEndEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingStatusValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -128,10 +121,10 @@ public class DownloadEndEventArgsTests
                         "download": "myDownloadId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidStatusValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -145,10 +138,10 @@ public class DownloadEndEventArgsTests
                         "status": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingDownloadIdValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -161,10 +154,10 @@ public class DownloadEndEventArgsTests
                         "status": "complete"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidDownloadIdTypeThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -178,10 +171,10 @@ public class DownloadEndEventArgsTests
                         "status": "complete"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidStatusTypeThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -195,10 +188,10 @@ public class DownloadEndEventArgsTests
                         "download": "myDownloadId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidFilePathValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -213,6 +206,6 @@ public class DownloadEndEventArgsTests
                         "filepath": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/DownloadWillBeginEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/DownloadWillBeginEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DownloadWillBeginEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -20,20 +19,18 @@ public class DownloadWillBeginEventArgsTests
                       }
                       """;
         DownloadWillBeginEventArgs? eventArgs = JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.DownloadId, Is.EqualTo("myDownloadId"));
-            Assert.That(eventArgs.SuggestedFileName, Is.EqualTo("myFile.file"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(epochTimestamp)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal("myDownloadId", eventArgs.DownloadId);
+        Assert.Equal("myFile.file", eventArgs.SuggestedFileName);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -48,12 +45,12 @@ public class DownloadWillBeginEventArgsTests
                       }
                       """;
         DownloadWillBeginEventArgs? eventArgs = JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         DownloadWillBeginEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingSuggestedFileNameValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -66,10 +63,10 @@ public class DownloadWillBeginEventArgsTests
                         "navigation": "myNavigationId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidSuggestedFileNameValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -83,10 +80,10 @@ public class DownloadWillBeginEventArgsTests
                         "suggestedFileName": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingDownloadIdValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -99,10 +96,10 @@ public class DownloadWillBeginEventArgsTests
                         "suggestedFileName": "myFile.file"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidDownloadIdThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -116,6 +113,6 @@ public class DownloadWillBeginEventArgsTests
                         "suggestedFileName": "myFile.file"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DownloadWillBeginEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/GetTreeCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/GetTreeCommandParametersTests.cs
@@ -3,26 +3,25 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GetTreeCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         GetTreeCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.getTree"));
+        Assert.Equal("browsingContext.getTree", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         GetTreeCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithMaxDepth()
     {
         GetTreeCommandParameters properties = new()
@@ -31,17 +30,16 @@ public class GetTreeCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("maxDepth"));
-            Assert.That(serialized["maxDepth"], Is.Not.Null);
-            Assert.That(serialized["maxDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxDepth"]!.Value<long>(), Is.EqualTo(2));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("maxDepth"));
+        JToken? maxDepth = serialized["maxDepth"];
+        Assert.NotNull(maxDepth);
+        Assert.Equal(JTokenType.Integer, maxDepth.Type);
+        Assert.Equal(2L, maxDepth.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithRoot()
     {
         GetTreeCommandParameters properties = new()
@@ -50,13 +48,12 @@ public class GetTreeCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("root"));
-            Assert.That(serialized["root"], Is.Not.Null);
-            Assert.That(serialized["root"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["root"]!.Value<string>(), Is.EqualTo("rootBrowsingContext"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("root"));
+        JToken? root = serialized["root"];
+        Assert.NotNull(root);
+        Assert.Equal(JTokenType.String, root.Type);
+        Assert.Equal("rootBrowsingContext", root.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/GetTreeCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/GetTreeCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class GetTreeCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -23,11 +22,11 @@ public class GetTreeCommandResultTests
                       }
                       """;
         GetTreeCommandResult? result = JsonSerializer.Deserialize<GetTreeCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ContextTree, Has.Count.EqualTo(1));
+        Assert.NotNull(result);
+        Assert.Single(result.ContextTree);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNoContexts()
     {
         string json = """
@@ -36,11 +35,11 @@ public class GetTreeCommandResultTests
                       }
                       """;
         GetTreeCommandResult? result = JsonSerializer.Deserialize<GetTreeCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ContextTree, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.ContextTree);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -58,19 +57,19 @@ public class GetTreeCommandResultTests
                       }
                       """;
         GetTreeCommandResult? result = JsonSerializer.Deserialize<GetTreeCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         GetTreeCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextsThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<GetTreeCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetTreeCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextsTypeThrows()
     {
         string json = """
@@ -78,10 +77,10 @@ public class GetTreeCommandResultTests
                         "contexts": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetTreeCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetTreeCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextValueTypeThrows()
     {
         string json = """
@@ -89,6 +88,6 @@ public class GetTreeCommandResultTests
                         "contexts": [ "invalid" ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetTreeCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetTreeCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/HandleUserPromptCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/HandleUserPromptCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class HandleUserPromptCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         HandleUserPromptCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.handleUserPrompt"));
+        Assert.Equal("browsingContext.handleUserPrompt", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         HandleUserPromptCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptTrue()
     {
         HandleUserPromptCommandParameters properties = new("myContextId")
@@ -37,19 +36,22 @@ public class HandleUserPromptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("accept"));
-            Assert.That(serialized["accept"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["accept"]!.Value<bool>(), Is.EqualTo(true));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("accept"));
+        JToken? accept = serialized["accept"];
+        Assert.NotNull(accept);
+        Assert.Equal(JTokenType.Boolean, accept.Type);
+        Assert.True(accept.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptFalse()
     {
         HandleUserPromptCommandParameters properties = new("myContextId")
@@ -58,19 +60,22 @@ public class HandleUserPromptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("accept"));
-            Assert.That(serialized["accept"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["accept"]!.Value<bool>(), Is.EqualTo(false));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("accept"));
+        JToken? accept = serialized["accept"];
+        Assert.NotNull(accept);
+        Assert.Equal(JTokenType.Boolean, accept.Type);
+        Assert.False(accept.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUserText()
     {
         HandleUserPromptCommandParameters properties = new("myContextId")
@@ -79,15 +84,18 @@ public class HandleUserPromptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("userText"));
-            Assert.That(serialized["userText"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userText"]!.Value<string>(), Is.EqualTo("myUserText"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userText"));
+        JToken? userText = serialized["userText"];
+        Assert.NotNull(userText);
+        Assert.Equal(JTokenType.String, userText.Type);
+        Assert.Equal("myUserText", userText.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/HandleUserPromptCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/HandleUserPromptCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class HandleUserPromptCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         HandleUserPromptCommandResult? result = JsonSerializer.Deserialize<HandleUserPromptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         HandleUserPromptCommandResult? result = JsonSerializer.Deserialize<HandleUserPromptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         HandleUserPromptCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/HistoryUpdatedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/HistoryUpdatedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class HistoryUpdatedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -19,17 +18,15 @@ public class HistoryUpdatedEventArgsTests
                       }
                       """;
         HistoryUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserContext()
     {
         DateTime now = DateTime.UtcNow;
@@ -44,18 +41,16 @@ public class HistoryUpdatedEventArgsTests
                       }
                       """;
         HistoryUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -69,12 +64,12 @@ public class HistoryUpdatedEventArgsTests
                       }
                       """;
         HistoryUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         HistoryUpdatedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingContextValueThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -86,10 +81,10 @@ public class HistoryUpdatedEventArgsTests
                         "timestamp": {{milliseconds}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidContextValueThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -102,10 +97,10 @@ public class HistoryUpdatedEventArgsTests
                         "timestamp": {{milliseconds}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingUrlValueThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -117,10 +112,10 @@ public class HistoryUpdatedEventArgsTests
                         "timestamp": {{milliseconds}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidUrlValueThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -133,10 +128,10 @@ public class HistoryUpdatedEventArgsTests
                           "timestamp": {{milliseconds}}
                         }
                         """;
-        Assert.That(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingTimestampValueThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -148,10 +143,10 @@ public class HistoryUpdatedEventArgsTests
                         "url": "http://example.com"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidTimestampValueThrows()
     {
         string json = """
@@ -161,7 +156,6 @@ public class HistoryUpdatedEventArgsTests
                         "timestamp": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<HistoryUpdatedEventArgs>(json));
     }
-
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/LocateNodesCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/LocateNodesCommandParametersTests.cs
@@ -4,40 +4,50 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class LocateNodesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         LocateNodesCommandParameters properties = new("myContextId", new CssLocator(".selector"));
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.locateNodes"));
+        Assert.Equal("browsingContext.locateNodes", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         LocateNodesCommandParameters properties = new("myContextId", new CssLocator(".selector"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("locator"));
-            Assert.That(serialized["locator"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["locator"]!, Contains.Key("type"));
-            Assert.That(serialized["locator"]!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["type"]!.Value<string>, Is.EqualTo("css"));
-            Assert.That(serialized["locator"]!, Contains.Key("value"));
-            Assert.That(serialized["locator"]!["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["value"]!.Value<string>, Is.EqualTo(".selector"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("locator"));
+        JToken? locatorToken = serialized["locator"];
+        Assert.NotNull(locatorToken);
+        Assert.Equal(JTokenType.Object, locatorToken.Type);
+        JObject? locator = locatorToken.Value<JObject>();
+        Assert.NotNull(locator);
+
+        Assert.True(locator.ContainsKey("type"));
+        JToken? locatorType = locator["type"];
+        Assert.NotNull(locatorType);
+        Assert.Equal(JTokenType.String, locatorType.Type);
+        Assert.Equal("css", locatorType.Value<string>());
+
+        Assert.True(locator.ContainsKey("value"));
+        JToken? locatorValue = locator["value"];
+        Assert.NotNull(locatorValue);
+        Assert.Equal(JTokenType.String, locatorValue.Type);
+        Assert.Equal(".selector", locatorValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithMaxNodeCount()
     {
         LocateNodesCommandParameters properties = new("myContextId", new CssLocator(".selector"))
@@ -46,27 +56,41 @@ public class LocateNodesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("locator"));
-            Assert.That(serialized["locator"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["locator"]!, Contains.Key("type"));
-            Assert.That(serialized["locator"]!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["type"]!.Value<string>, Is.EqualTo("css"));
-            Assert.That(serialized["locator"]!, Contains.Key("value"));
-            Assert.That(serialized["locator"]!["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["value"]!.Value<string>, Is.EqualTo(".selector"));
-            Assert.That(serialized, Contains.Key("maxNodeCount"));
-            Assert.That(serialized["maxNodeCount"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxNodeCount"]!.Value<ulong>(), Is.EqualTo(10));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("locator"));
+        JToken? locatorToken = serialized["locator"];
+        Assert.NotNull(locatorToken);
+        Assert.Equal(JTokenType.Object, locatorToken.Type);
+        JObject? locator = locatorToken.Value<JObject>();
+        Assert.NotNull(locator);
+
+        Assert.True(locator.ContainsKey("type"));
+        JToken? locatorType = locator["type"];
+        Assert.NotNull(locatorType);
+        Assert.Equal(JTokenType.String, locatorType.Type);
+        Assert.Equal("css", locatorType.Value<string>());
+
+        Assert.True(locator.ContainsKey("value"));
+        JToken? locatorValue = locator["value"];
+        Assert.NotNull(locatorValue);
+        Assert.Equal(JTokenType.String, locatorValue.Type);
+        Assert.Equal(".selector", locatorValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxNodeCount"));
+        JToken? maxNodeCount = serialized["maxNodeCount"];
+        Assert.NotNull(maxNodeCount);
+        Assert.Equal(JTokenType.Integer, maxNodeCount.Type);
+        Assert.Equal(10UL, maxNodeCount.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithSerializationOptions()
     {
         LocateNodesCommandParameters properties = new("myContextId", new CssLocator(".selector"))
@@ -80,63 +104,106 @@ public class LocateNodesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("locator"));
-            Assert.That(serialized["locator"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["locator"]!, Contains.Key("type"));
-            Assert.That(serialized["locator"]!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["type"]!.Value<string>, Is.EqualTo("css"));
-            Assert.That(serialized["locator"]!, Contains.Key("value"));
-            Assert.That(serialized["locator"]!["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["value"]!.Value<string>, Is.EqualTo(".selector"));
-            Assert.That(serialized, Contains.Key("serializationOptions"));
-            Assert.That(serialized["serializationOptions"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject serializationOptions = (serialized["serializationOptions"]! as JObject)!;
-            Assert.That(serializationOptions, Has.Count.EqualTo(3));
-            Assert.That(serializationOptions, Contains.Key("includeShadowTree"));
-            Assert.That(serializationOptions["includeShadowTree"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serializationOptions["includeShadowTree"]!.Value<string>, Is.EqualTo("all"));
-            Assert.That(serializationOptions, Contains.Key("maxDomDepth"));
-            Assert.That(serializationOptions["maxDomDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serializationOptions["maxDomDepth"]!.Value<ulong>, Is.EqualTo(10));
-            Assert.That(serializationOptions, Contains.Key("maxObjectDepth"));
-            Assert.That(serializationOptions["maxObjectDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serializationOptions["maxObjectDepth"]!.Value<ulong>, Is.EqualTo(0));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("locator"));
+        JToken? locatorToken = serialized["locator"];
+        Assert.NotNull(locatorToken);
+        Assert.Equal(JTokenType.Object, locatorToken.Type);
+        JObject? locator = locatorToken.Value<JObject>();
+        Assert.NotNull(locator);
+
+        Assert.True(locator.ContainsKey("type"));
+        JToken? locatorType = locator["type"];
+        Assert.NotNull(locatorType);
+        Assert.Equal(JTokenType.String, locatorType.Type);
+        Assert.Equal("css", locatorType.Value<string>());
+
+        Assert.True(locator.ContainsKey("value"));
+        JToken? locatorValue = locator["value"];
+        Assert.NotNull(locatorValue);
+        Assert.Equal(JTokenType.String, locatorValue.Type);
+        Assert.Equal(".selector", locatorValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("serializationOptions"));
+        JToken? serializationOptionsToken = serialized["serializationOptions"];
+        Assert.NotNull(serializationOptionsToken);
+        Assert.Equal(JTokenType.Object, serializationOptionsToken.Type);
+        JObject? serializationOptions = serializationOptionsToken.Value<JObject>();
+        Assert.NotNull(serializationOptions);
+        Assert.Equal(3, serializationOptions.Count);
+
+        Assert.True(serializationOptions.ContainsKey("includeShadowTree"));
+        JToken? includeShadowTree = serializationOptions["includeShadowTree"];
+        Assert.NotNull(includeShadowTree);
+        Assert.Equal(JTokenType.String, includeShadowTree.Type);
+        Assert.Equal("all", includeShadowTree.Value<string>());
+
+        Assert.True(serializationOptions.ContainsKey("maxDomDepth"));
+        JToken? maxDomDepth = serializationOptions["maxDomDepth"];
+        Assert.NotNull(maxDomDepth);
+        Assert.Equal(JTokenType.Integer, maxDomDepth.Type);
+        Assert.Equal(10UL, maxDomDepth.Value<ulong>());
+
+        Assert.True(serializationOptions.ContainsKey("maxObjectDepth"));
+        JToken? maxObjectDepth = serializationOptions["maxObjectDepth"];
+        Assert.NotNull(maxObjectDepth);
+        Assert.Equal(JTokenType.Integer, maxObjectDepth.Type);
+        Assert.Equal(0UL, maxObjectDepth.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithStartNode()
     {
         string nodeJson = @"{ ""type"": ""node"", ""sharedId"": ""mySharedId"", ""value"": { ""nodeType"": 1, ""nodeValue"": """", ""childNodeCount"": 0 } }";
-        RemoteValue nodeValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson)!;
+        RemoteValue? nodeValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson);
+        Assert.NotNull(nodeValue);
+        NodeRemoteValue? nodeRemoteValue = nodeValue as NodeRemoteValue;
+        Assert.NotNull(nodeRemoteValue);
         LocateNodesCommandParameters properties = new("myContextId", new CssLocator(".selector"));
-        properties.StartNodes.Add(((NodeRemoteValue)nodeValue).ToSharedReference());
+        properties.StartNodes.Add(nodeRemoteValue.ToSharedReference());
 
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("locator"));
-            Assert.That(serialized["locator"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["locator"]!, Contains.Key("type"));
-            Assert.That(serialized["locator"]!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["type"]!.Value<string>, Is.EqualTo("css"));
-            Assert.That(serialized["locator"]!, Contains.Key("value"));
-            Assert.That(serialized["locator"]!["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locator"]!["value"]!.Value<string>, Is.EqualTo(".selector"));
-            Assert.That(serialized, Contains.Key("startNodes"));
-            Assert.That(serialized["startNodes"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["startNodes"]! as JArray, Has.Count.EqualTo(1));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("locator"));
+        JToken? locatorToken = serialized["locator"];
+        Assert.NotNull(locatorToken);
+        Assert.Equal(JTokenType.Object, locatorToken.Type);
+        JObject? locator = locatorToken.Value<JObject>();
+        Assert.NotNull(locator);
+
+        Assert.True(locator.ContainsKey("type"));
+        JToken? locatorType = locator["type"];
+        Assert.NotNull(locatorType);
+        Assert.Equal(JTokenType.String, locatorType.Type);
+        Assert.Equal("css", locatorType.Value<string>());
+
+        Assert.True(locator.ContainsKey("value"));
+        JToken? locatorValue = locator["value"];
+        Assert.NotNull(locatorValue);
+        Assert.Equal(JTokenType.String, locatorValue.Type);
+        Assert.Equal(".selector", locatorValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("startNodes"));
+        JToken? startNodesToken = serialized["startNodes"];
+        Assert.NotNull(startNodesToken);
+        Assert.Equal(JTokenType.Array, startNodesToken.Type);
+        JArray? startNodes = startNodesToken as JArray;
+        Assert.NotNull(startNodes);
+        Assert.Single(startNodes);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/LocateNodesCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/LocateNodesCommandResultTests.cs
@@ -1,12 +1,10 @@
 namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
-using WebDriverBiDi.Script;
 
-[TestFixture]
 public class LocateNodesCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -25,12 +23,12 @@ public class LocateNodesCommandResultTests
                       }
                       """;
         LocateNodesCommandResult? result = JsonSerializer.Deserialize<LocateNodesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Nodes, Has.Count.EqualTo(1));
-        Assert.That(result.Nodes[0].SharedId, Is.EqualTo("mySharedId"));
+        Assert.NotNull(result);
+        Assert.Single(result.Nodes);
+        Assert.Equal("mySharedId", result.Nodes[0].SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithEmptyResult()
     {
         string json = """
@@ -39,11 +37,11 @@ public class LocateNodesCommandResultTests
                       }
                       """;
         LocateNodesCommandResult? result = JsonSerializer.Deserialize<LocateNodesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Nodes, Has.Count.EqualTo(0));
+        Assert.NotNull(result);
+        Assert.Empty(result.Nodes);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -62,19 +60,19 @@ public class LocateNodesCommandResultTests
                       }
                       """;
         LocateNodesCommandResult? result = JsonSerializer.Deserialize<LocateNodesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocateNodesCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<LocateNodesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LocateNodesCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -82,6 +80,6 @@ public class LocateNodesCommandResultTests
                         "nodes": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LocateNodesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LocateNodesCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/LocatorTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/LocatorTests.cs
@@ -3,79 +3,87 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class LocatorTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeUsingBaseType()
     {
         Locator locator = new CssLocator("locator");
-        Assert.That(JsonSerializer.Serialize(locator), Is.Not.Empty);
+        Assert.NotEmpty(JsonSerializer.Serialize(locator));
         locator = new XPathLocator("//locator");
-        Assert.That(JsonSerializer.Serialize(locator), Is.Not.Empty);
+        Assert.NotEmpty(JsonSerializer.Serialize(locator));
         locator = new InnerTextLocator("locator text");
-        Assert.That(JsonSerializer.Serialize(locator), Is.Not.Empty);
+        Assert.NotEmpty(JsonSerializer.Serialize(locator));
         locator = new AccessibilityLocator();
-        Assert.That(JsonSerializer.Serialize(locator), Is.Not.Empty);
+        Assert.NotEmpty(JsonSerializer.Serialize(locator));
         locator = new ContextLocator("myContext");
-        Assert.That(JsonSerializer.Serialize(locator), Is.Not.Empty);
+        Assert.NotEmpty(JsonSerializer.Serialize(locator));
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCssLocator()
     {
         CssLocator value = new(".selector");
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("css"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo(".selector"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("css", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal(".selector", valueProperty.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeXPathLocator()
     {
         XPathLocator value = new("//selector");
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("xpath"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("//selector"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("xpath", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("//selector", valueProperty.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocator()
     {
         InnerTextLocator value = new("text to locate");
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocatorWithMaxDepthZero()
     {
         InnerTextLocator value = new("text to locate")
@@ -84,22 +92,28 @@ public class LocatorTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(3));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-            Assert.That(parsed, Contains.Key("maxDepth"));
-            Assert.That(parsed["maxDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(parsed["maxDepth"]!.Value<ulong>(), Is.EqualTo(0));
-        }
+
+        Assert.Equal(3, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("maxDepth"));
+        JToken? maxDepthProperty = parsed["maxDepth"];
+        Assert.NotNull(maxDepthProperty);
+        Assert.Equal(JTokenType.Integer, maxDepthProperty.Type);
+        Assert.Equal(0UL, maxDepthProperty.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocatorWithMaxDepthNonZero()
     {
         InnerTextLocator value = new("text to locate")
@@ -108,22 +122,28 @@ public class LocatorTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(3));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-            Assert.That(parsed, Contains.Key("maxDepth"));
-            Assert.That(parsed["maxDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(parsed["maxDepth"]!.Value<ulong>(), Is.EqualTo(10));
-        }
+
+        Assert.Equal(3, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("maxDepth"));
+        JToken? maxDepthProperty = parsed["maxDepth"];
+        Assert.NotNull(maxDepthProperty);
+        Assert.Equal(JTokenType.Integer, maxDepthProperty.Type);
+        Assert.Equal(10UL, maxDepthProperty.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocatorWithIgnoreCaseTrue()
     {
         InnerTextLocator value = new("text to locate")
@@ -132,22 +152,28 @@ public class LocatorTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(3));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-            Assert.That(parsed, Contains.Key("ignoreCase"));
-            Assert.That(parsed["ignoreCase"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(parsed["ignoreCase"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Equal(3, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("ignoreCase"));
+        JToken? ignoreCaseProperty = parsed["ignoreCase"];
+        Assert.NotNull(ignoreCaseProperty);
+        Assert.Equal(JTokenType.Boolean, ignoreCaseProperty.Type);
+        Assert.True(ignoreCaseProperty.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocatorWithIgnoreCaseFalse()
     {
         InnerTextLocator value = new("text to locate")
@@ -156,22 +182,28 @@ public class LocatorTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(3));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-            Assert.That(parsed, Contains.Key("ignoreCase"));
-            Assert.That(parsed["ignoreCase"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(parsed["ignoreCase"]!.Value<bool>(), Is.False);
-        }
+
+        Assert.Equal(3, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("ignoreCase"));
+        JToken? ignoreCaseProperty = parsed["ignoreCase"];
+        Assert.NotNull(ignoreCaseProperty);
+        Assert.Equal(JTokenType.Boolean, ignoreCaseProperty.Type);
+        Assert.False(ignoreCaseProperty.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocatorWithMatchTypeFull()
     {
         InnerTextLocator value = new("text to locate")
@@ -180,22 +212,28 @@ public class LocatorTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(3));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-            Assert.That(parsed, Contains.Key("matchType"));
-            Assert.That(parsed["matchType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["matchType"]!.Value<string>(), Is.EqualTo("full"));
-        }
+
+        Assert.Equal(3, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("matchType"));
+        JToken? matchTypeProperty = parsed["matchType"];
+        Assert.NotNull(matchTypeProperty);
+        Assert.Equal(JTokenType.String, matchTypeProperty.Type);
+        Assert.Equal("full", matchTypeProperty.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInnerTextLocatorWithMatchTypePartial()
     {
         InnerTextLocator value = new("text to locate")
@@ -204,47 +242,56 @@ public class LocatorTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(3));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("innerText"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("text to locate"));
-            Assert.That(parsed, Contains.Key("matchType"));
-            Assert.That(parsed["matchType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["matchType"]!.Value<string>(), Is.EqualTo("partial"));
-        }
+
+        Assert.Equal(3, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("innerText", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.String, valueProperty.Type);
+        Assert.Equal("text to locate", valueProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("matchType"));
+        JToken? matchTypeProperty = parsed["matchType"];
+        Assert.NotNull(matchTypeProperty);
+        Assert.Equal(JTokenType.String, matchTypeProperty.Type);
+        Assert.Equal("partial", matchTypeProperty.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityLocator()
     {
         AccessibilityLocator value = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(value.Name, Is.Null);
-            Assert.That(value.Role, Is.Null);
-        }
+
+        Assert.Null(value.Name);
+        Assert.Null(value.Role);
 
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue!, Is.Empty);
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Empty(accessibilityValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityWithNameAndRole()
     {
         AccessibilityLocator value = new()
@@ -252,99 +299,117 @@ public class LocatorTests
             Name = "accessibleName",
             Role = "accessibleRole"
         };
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(value.Name, Is.EqualTo("accessibleName"));
-            Assert.That(value.Role, Is.EqualTo("accessibleRole"));
-        }
+
+        Assert.Equal("accessibleName", value.Name);
+        Assert.Equal("accessibleRole", value.Role);
 
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue, Is.Not.Null);
-            Assert.That(accessibilityValue!, Has.Count.EqualTo(2));
-            Assert.That(accessibilityValue, Contains.Key("name"));
-            Assert.That(accessibilityValue!["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(accessibilityValue!["name"]!.Value<string>(), Is.EqualTo("accessibleName"));
-            Assert.That(accessibilityValue, Contains.Key("role"));
-            Assert.That(accessibilityValue!["role"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(accessibilityValue!["role"]!.Value<string>(), Is.EqualTo("accessibleRole"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Equal(2, accessibilityValue.Count);
+
+        Assert.True(accessibilityValue.ContainsKey("name"));
+        JToken? accessibilityName = accessibilityValue["name"];
+        Assert.NotNull(accessibilityName);
+        Assert.Equal(JTokenType.String, accessibilityName.Type);
+        Assert.Equal("accessibleName", accessibilityName.Value<string>());
+
+        Assert.True(accessibilityValue.ContainsKey("role"));
+        JToken? accessibilityRole = accessibilityValue["role"];
+        Assert.NotNull(accessibilityRole);
+        Assert.Equal(JTokenType.String, accessibilityRole.Type);
+        Assert.Equal("accessibleRole", accessibilityRole.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityWithName()
     {
         AccessibilityLocator value = new()
         {
             Name = "accessibleName"
         };
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(value.Name, Is.EqualTo("accessibleName"));
-            Assert.That(value.Role, Is.Null);
-        }
+
+        Assert.Equal("accessibleName", value.Name);
+        Assert.Null(value.Role);
 
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue, Is.Not.Null);
-            Assert.That(accessibilityValue!, Has.Count.EqualTo(1));
-            Assert.That(accessibilityValue, Contains.Key("name"));
-            Assert.That(accessibilityValue!["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(accessibilityValue!["name"]!.Value<string>(), Is.EqualTo("accessibleName"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Single(accessibilityValue);
+
+        Assert.True(accessibilityValue.ContainsKey("name"));
+        JToken? accessibilityName = accessibilityValue["name"];
+        Assert.NotNull(accessibilityName);
+        Assert.Equal(JTokenType.String, accessibilityName.Type);
+        Assert.Equal("accessibleName", accessibilityName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityWithRole()
     {
         AccessibilityLocator value = new()
         {
             Role = "accessibleRole"
         };
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(value.Name, Is.Null);
-            Assert.That(value.Role, Is.EqualTo("accessibleRole"));
-        }
+
+        Assert.Null(value.Name);
+        Assert.Equal("accessibleRole", value.Role);
 
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue, Is.Not.Null);
-            Assert.That(accessibilityValue!, Has.Count.EqualTo(1));
-            Assert.That(accessibilityValue, Contains.Key("role"));
-            Assert.That(accessibilityValue!["role"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(accessibilityValue!["role"]!.Value<string>(), Is.EqualTo("accessibleRole"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Single(accessibilityValue);
+
+        Assert.True(accessibilityValue.ContainsKey("role"));
+        JToken? accessibilityRole = accessibilityValue["role"];
+        Assert.NotNull(accessibilityRole);
+        Assert.Equal(JTokenType.String, accessibilityRole.Type);
+        Assert.Equal("accessibleRole", accessibilityRole.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityWithRemovingName()
     {
         AccessibilityLocator value = new()
@@ -355,24 +420,31 @@ public class LocatorTests
         value.Name = null;
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue, Is.Not.Null);
-            Assert.That(accessibilityValue!, Has.Count.EqualTo(1));
-            Assert.That(accessibilityValue, Contains.Key("role"));
-            Assert.That(accessibilityValue!["role"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(accessibilityValue!["role"]!.Value<string>(), Is.EqualTo("accessibleRole"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Single(accessibilityValue);
+
+        Assert.True(accessibilityValue.ContainsKey("role"));
+        JToken? accessibilityRole = accessibilityValue["role"];
+        Assert.NotNull(accessibilityRole);
+        Assert.Equal(JTokenType.String, accessibilityRole.Type);
+        Assert.Equal("accessibleRole", accessibilityRole.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityWithRemovingRole()
     {
         AccessibilityLocator value = new()
@@ -383,24 +455,31 @@ public class LocatorTests
         value.Role = null;
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue, Is.Not.Null);
-            Assert.That(accessibilityValue!, Has.Count.EqualTo(1));
-            Assert.That(accessibilityValue, Contains.Key("name"));
-            Assert.That(accessibilityValue!["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(accessibilityValue!["name"]!.Value<string>(), Is.EqualTo("accessibleName"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Single(accessibilityValue);
+
+        Assert.True(accessibilityValue.ContainsKey("name"));
+        JToken? accessibilityName = accessibilityValue["name"];
+        Assert.NotNull(accessibilityName);
+        Assert.Equal(JTokenType.String, accessibilityName.Type);
+        Assert.Equal("accessibleName", accessibilityName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeAccessibilityWithRemovingNameAndRole()
     {
         AccessibilityLocator value = new()
@@ -412,41 +491,52 @@ public class LocatorTests
         value.Role = null;
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("accessibility"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? accessibilityValue = parsed["value"] as JObject;
-            Assert.That(accessibilityValue, Is.Empty);
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("accessibility", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+        Assert.Equal(JTokenType.Object, valueProperty.Type);
+
+        JObject? accessibilityValue = valueProperty as JObject;
+        Assert.NotNull(accessibilityValue);
+        Assert.Empty(accessibilityValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeContextLocator()
     {
         ContextLocator value = new("myContext");
-        Assert.That(value.BrowsingContextId, Is.EqualTo("myContext"));
+        Assert.Equal("myContext", value.BrowsingContextId);
 
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? contextValue = parsed["value"] as JObject;
-            Assert.That(contextValue, Is.Not.Null);
-            Assert.That(contextValue, Has.Count.EqualTo(1));
-            Assert.That(contextValue, Contains.Key("context"));
-            Assert.That(contextValue!["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextValue!["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? typeProperty = parsed["type"];
+        Assert.NotNull(typeProperty);
+        Assert.Equal(JTokenType.String, typeProperty.Type);
+        Assert.Equal("context", typeProperty.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueProperty = parsed["value"];
+        Assert.NotNull(valueProperty);
+ 
+        JObject? contextValue = valueProperty as JObject;
+        Assert.NotNull(contextValue);
+        Assert.Single(contextValue);
+        Assert.True(contextValue.ContainsKey("context"));
+
+        JToken? context = contextValue["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/LocatorTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/LocatorTests.cs
@@ -528,7 +528,7 @@ public class LocatorTests
         Assert.True(parsed.ContainsKey("value"));
         JToken? valueProperty = parsed["value"];
         Assert.NotNull(valueProperty);
- 
+
         JObject? contextValue = valueProperty as JObject;
         Assert.NotNull(contextValue);
         Assert.Single(contextValue);

--- a/test/WebDriverBiDi.Tests/BrowsingContext/NavigateCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/NavigateCommandParametersTests.cs
@@ -3,35 +3,37 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class NavigateCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         NavigateCommandParameters properties = new("myContextId", "http://example.com");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.navigate"));
+        Assert.Equal("browsingContext.navigate", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         NavigateCommandParameters properties = new("myContextId", "http://example.com");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("url"));
-            Assert.That(serialized["url"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["url"]!.Value<string>(), Is.EqualTo("http://example.com"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("url"));
+        JToken? url = serialized["url"];
+        Assert.NotNull(url);
+        Assert.Equal(JTokenType.String, url.Type);
+        Assert.Equal("http://example.com", url.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptWaitNone()
     {
         NavigateCommandParameters properties = new("myContextId", "http://example.com")
@@ -40,22 +42,28 @@ public class NavigateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("url"));
-            Assert.That(serialized["url"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["url"]!.Value<string>(), Is.EqualTo("http://example.com"));
-            Assert.That(serialized, Contains.Key("wait"));
-            Assert.That(serialized["wait"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["wait"]!.Value<string>(), Is.EqualTo("none"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("url"));
+        JToken? url = serialized["url"];
+        Assert.NotNull(url);
+        Assert.Equal(JTokenType.String, url.Type);
+        Assert.Equal("http://example.com", url.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wait"));
+        JToken? wait = serialized["wait"];
+        Assert.NotNull(wait);
+        Assert.Equal(JTokenType.String, wait.Type);
+        Assert.Equal("none", wait.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptWaitInteractive()
     {
         NavigateCommandParameters properties = new("myContextId", "http://example.com")
@@ -64,22 +72,28 @@ public class NavigateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("url"));
-            Assert.That(serialized["url"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["url"]!.Value<string>(), Is.EqualTo("http://example.com"));
-            Assert.That(serialized, Contains.Key("wait"));
-            Assert.That(serialized["wait"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["wait"]!.Value<string>(), Is.EqualTo("interactive"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("url"));
+        JToken? url = serialized["url"];
+        Assert.NotNull(url);
+        Assert.Equal(JTokenType.String, url.Type);
+        Assert.Equal("http://example.com", url.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wait"));
+        JToken? wait = serialized["wait"];
+        Assert.NotNull(wait);
+        Assert.Equal(JTokenType.String, wait.Type);
+        Assert.Equal("interactive", wait.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptWaitComplete()
     {
         NavigateCommandParameters properties = new("myContextId", "http://example.com")
@@ -88,18 +102,24 @@ public class NavigateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("url"));
-            Assert.That(serialized["url"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["url"]!.Value<string>(), Is.EqualTo("http://example.com"));
-            Assert.That(serialized, Contains.Key("wait"));
-            Assert.That(serialized["wait"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["wait"]!.Value<string>(), Is.EqualTo("complete"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("url"));
+        JToken? url = serialized["url"];
+        Assert.NotNull(url);
+        Assert.Equal(JTokenType.String, url.Type);
+        Assert.Equal("http://example.com", url.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wait"));
+        JToken? wait = serialized["wait"];
+        Assert.NotNull(wait);
+        Assert.Equal(JTokenType.String, wait.Type);
+        Assert.Equal("complete", wait.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/NavigateCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/NavigateCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NavigationResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,15 +13,13 @@ public class NavigationResultTests
                       }
                       """;
         NavigateCommandResult? result = JsonSerializer.Deserialize<NavigateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Url, Is.EqualTo("http://example.com"));
-            Assert.That(result.NavigationId, Is.Null);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("http://example.com", result.Url);
+        Assert.Null(result.NavigationId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNavigationId()
     {
         string json = """
@@ -32,15 +29,13 @@ public class NavigationResultTests
                       }
                       """;
         NavigateCommandResult? result = JsonSerializer.Deserialize<NavigateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Url, Is.EqualTo("http://example.com"));
-            Assert.That(result.NavigationId, Is.EqualTo("myNavigationId"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("http://example.com", result.Url);
+        Assert.Equal("myNavigationId", result.NavigationId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -49,19 +44,19 @@ public class NavigationResultTests
                       }
                       """;
         NavigateCommandResult? result = JsonSerializer.Deserialize<NavigateCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         NavigateCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingUrlThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<NavigateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidUrlTypeThrows()
     {
         string json = """
@@ -69,10 +64,10 @@ public class NavigationResultTests
                         "url": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigateCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidNavigationIdTypeThrows()
     {
         string json = """
@@ -81,6 +76,6 @@ public class NavigationResultTests
                         "navigation": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigateCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigateCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/NavigationEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/NavigationEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NavigationEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -18,18 +17,16 @@ public class NavigationEventArgsTests
                       }
                       """;
         NavigationEventArgs? eventArgs = JsonSerializer.Deserialize<NavigationEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.NavigationId, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal((ulong)((ulong)(epochTimestamp)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Null(eventArgs.NavigationId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNavigationId()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -42,16 +39,14 @@ public class NavigationEventArgsTests
                       }
                       """;
         NavigationEventArgs? eventArgs = JsonSerializer.Deserialize<NavigationEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserContext()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -65,17 +60,15 @@ public class NavigationEventArgsTests
                       }
                       """;
         NavigationEventArgs? eventArgs = JsonSerializer.Deserialize<NavigationEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("http://example.com"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("http://example.com", eventArgs.Url);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -88,13 +81,12 @@ public class NavigationEventArgsTests
                       }
                       """;
         NavigationEventArgs? eventArgs = JsonSerializer.Deserialize<NavigationEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         NavigationEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingContextValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -105,10 +97,10 @@ public class NavigationEventArgsTests
                         "navigation": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidContextValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -120,10 +112,10 @@ public class NavigationEventArgsTests
                         "navigation": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingUrlValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -134,10 +126,10 @@ public class NavigationEventArgsTests
                         "navigation": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidUrlValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -149,10 +141,10 @@ public class NavigationEventArgsTests
                         "navigation": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingTimestampValueThrows()
     {
         string json = $$"""
@@ -162,10 +154,10 @@ public class NavigationEventArgsTests
                         "navigation": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidTimestampValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -177,10 +169,10 @@ public class NavigationEventArgsTests
                         "navigation": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingNavigationValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -191,10 +183,10 @@ public class NavigationEventArgsTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidNavigationValueThrows()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -206,6 +198,6 @@ public class NavigationEventArgsTests
                         "navigation": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NavigationEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NavigationEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/PrintCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/PrintCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PrintCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         PrintCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.print"));
+        Assert.Equal("browsingContext.print", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PrintCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithMargins()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -43,36 +42,49 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("margin"));
-            Assert.That(serialized["margin"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? margins = serialized["margin"] as JObject;
-        Assert.That(margins, Is.Not.Null);
-        Assert.That(margins, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(margins!, Contains.Key("right"));
-            Assert.That(margins!["right"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(margins["right"]!.Value<double>(), Is.EqualTo(2.54));
-            Assert.That(margins, Contains.Key("left"));
-            Assert.That(margins["left"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(margins["left"]!.Value<double>(), Is.EqualTo(2.54));
-            Assert.That(margins, Contains.Key("top"));
-            Assert.That(margins["top"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(margins["top"]!.Value<double>(), Is.EqualTo(2.54));
-            Assert.That(margins, Contains.Key("bottom"));
-            Assert.That(margins["bottom"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(margins["bottom"]!.Value<double>(), Is.EqualTo(2.54));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("margin"));
+        JToken? marginToken = serialized["margin"];
+        Assert.NotNull(marginToken);
+        Assert.Equal(JTokenType.Object, marginToken.Type);
+
+        JObject? margins = marginToken.Value<JObject>();
+        Assert.NotNull(margins);
+        Assert.Equal(4, margins.Count);
+
+        Assert.True(margins.ContainsKey("right"));
+        JToken? right = margins["right"];
+        Assert.NotNull(right);
+        Assert.Equal(JTokenType.Float, right.Type);
+        Assert.Equal(2.54, right.Value<double>());
+
+        Assert.True(margins.ContainsKey("left"));
+        JToken? left = margins["left"];
+        Assert.NotNull(left);
+        Assert.Equal(JTokenType.Float, left.Type);
+        Assert.Equal(2.54, left.Value<double>());
+
+        Assert.True(margins.ContainsKey("top"));
+        JToken? top = margins["top"];
+        Assert.NotNull(top);
+        Assert.Equal(JTokenType.Float, top.Type);
+        Assert.Equal(2.54, top.Value<double>());
+
+        Assert.True(margins.ContainsKey("bottom"));
+        JToken? bottom = margins["bottom"];
+        Assert.NotNull(bottom);
+        Assert.Equal(JTokenType.Float, bottom.Type);
+        Assert.Equal(2.54, bottom.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullMarginValues()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -87,34 +99,36 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("margin"));
-            Assert.That(serialized["margin"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? margins = serialized["margin"] as JObject;
-        Assert.That(margins, Is.Not.Null);
-        Assert.That(margins, Has.Count.EqualTo(0));
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("margin"));
+        JToken? marginToken = serialized["margin"];
+        Assert.NotNull(marginToken);
+        Assert.Equal(JTokenType.Object, marginToken.Type);
+
+        JObject? margins = marginToken.Value<JObject>();
+        Assert.NotNull(margins);
+        Assert.Empty(margins);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingMarginsToInvalidValuesThrows()
     {
         PrintMarginParameters properties = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => properties.Top = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be greater than or equal to zero"));
-            Assert.That(() => properties.Bottom = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be greater than or equal to zero"));
-            Assert.That(() => properties.Left = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be greater than or equal to zero"));
-            Assert.That(() => properties.Right = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be greater than or equal to zero"));
-        }
+
+        Assert.Contains("Value must be greater than or equal to zero", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Top = -1).Message);
+        Assert.Contains("Value must be greater than or equal to zero", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Bottom = -1).Message);
+        Assert.Contains("Value must be greater than or equal to zero", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Left = -1).Message);
+        Assert.Contains("Value must be greater than or equal to zero", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Right = -1).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullPageSizeValues()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -127,32 +141,34 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("page"));
-            Assert.That(serialized["page"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? margins = serialized["page"] as JObject;
-        Assert.That(margins, Is.Not.Null);
-        Assert.That(margins, Has.Count.EqualTo(0));
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("page"));
+        JToken? pageToken = serialized["page"];
+        Assert.NotNull(pageToken);
+        Assert.Equal(JTokenType.Object, pageToken.Type);
+
+        JObject? margins = pageToken.Value<JObject>();
+        Assert.NotNull(margins);
+        Assert.Empty(margins);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingPageSizeToInvalidValuesThrows()
     {
         PrintPageParameters properties = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => properties.Width = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be greater than or equal to zero"));
-            Assert.That(() => properties.Height = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be greater than or equal to zero"));
-        }
+
+        Assert.Contains("Value must be greater than or equal to zero", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Width = -1).Message);
+        Assert.Contains("Value must be greater than or equal to zero", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Height = -1).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullMargins()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -161,16 +177,16 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPageSize()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -183,30 +199,37 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("page"));
-            Assert.That(serialized["page"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? pageSize = serialized["page"] as JObject;
-        Assert.That(pageSize, Is.Not.Null);
-        Assert.That(pageSize, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(pageSize!, Contains.Key("width"));
-            Assert.That(pageSize!["width"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(pageSize["width"]!.Value<double>(), Is.EqualTo(24));
-            Assert.That(pageSize, Contains.Key("height"));
-            Assert.That(pageSize["height"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(pageSize["height"]!.Value<double>(), Is.EqualTo(29.7));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("page"));
+        JToken? pageToken = serialized["page"];
+        Assert.NotNull(pageToken);
+        Assert.Equal(JTokenType.Object, pageToken.Type);
+
+        JObject? pageSize = pageToken.Value<JObject>();
+        Assert.NotNull(pageSize);
+        Assert.Equal(2, pageSize.Count);
+
+        Assert.True(pageSize.ContainsKey("width"));
+        JToken? width = pageSize["width"];
+        Assert.NotNull(width);
+        Assert.Equal(JTokenType.Float, width.Type);
+        Assert.Equal(24, width.Value<double>());
+
+        Assert.True(pageSize.ContainsKey("height"));
+        JToken? height = pageSize["height"];
+        Assert.NotNull(height);
+        Assert.Equal(JTokenType.Float, height.Type);
+        Assert.Equal(29.7, height.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullPageSize()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -215,16 +238,16 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOrientation()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -233,19 +256,22 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("orientation"));
-            Assert.That(serialized["orientation"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["orientation"]!.Value<string>(), Is.EqualTo("landscape"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("orientation"));
+        JToken? orientation = serialized["orientation"];
+        Assert.NotNull(orientation);
+        Assert.Equal(JTokenType.String, orientation.Type);
+        Assert.Equal("landscape", orientation.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullOrientation()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -254,16 +280,16 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBackground()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -272,19 +298,22 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("background"));
-            Assert.That(serialized["background"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["background"]!.Value<bool>(), Is.True);
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("background"));
+        JToken? background = serialized["background"];
+        Assert.NotNull(background);
+        Assert.Equal(JTokenType.Boolean, background.Type);
+        Assert.True(background.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullBackground()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -293,16 +322,16 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithScale()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -311,19 +340,22 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("scale"));
-            Assert.That(serialized["scale"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["scale"]!.Value<double>(), Is.EqualTo(1.5));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("scale"));
+        JToken? scale = serialized["scale"];
+        Assert.NotNull(scale);
+        Assert.Equal(JTokenType.Float, scale.Type);
+        Assert.Equal(1.5, scale.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullScale()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -332,29 +364,27 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingScaleToInvalidValueThrows()
     {
         PrintCommandParameters properties = new("myContextId");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => properties.Scale = -1, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be between 0.1 and 2.0"));
-            Assert.That(() => properties.Scale = 0.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be between 0.1 and 2.0"));
-            Assert.That(() => properties.Scale = 2.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be between 0.1 and 2.0"));
-            Assert.That(() => properties.Scale = 0, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Value must be between 0.1 and 2.0"));
-        }
+
+        Assert.Contains("Value must be between 0.1 and 2.0", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Scale = -1).Message);
+        Assert.Contains("Value must be between 0.1 and 2.0", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Scale = 0.01).Message);
+        Assert.Contains("Value must be between 0.1 and 2.0", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Scale = 2.01).Message);
+        Assert.Contains("Value must be between 0.1 and 2.0", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Scale = 0).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithShrinkToFit()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -363,19 +393,22 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("shrinkToFit"));
-            Assert.That(serialized["shrinkToFit"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["shrinkToFit"]!.Value<bool>(), Is.False);
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("shrinkToFit"));
+        JToken? shrinkToFit = serialized["shrinkToFit"];
+        Assert.NotNull(shrinkToFit);
+        Assert.Equal(JTokenType.Boolean, shrinkToFit.Type);
+        Assert.False(shrinkToFit.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNullShrinkToFit()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -384,16 +417,16 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPageRanges()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -406,44 +439,45 @@ public class PrintCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("pageRanges"));
-            Assert.That(serialized["pageRanges"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, serialized.Count);
 
-        JArray? pageRanges = serialized["pageRanges"] as JArray;
-        Assert.That(pageRanges, Is.Not.Null);
-        Assert.That(pageRanges, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(pageRanges![0].Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(pageRanges[0].Value<long>, Is.EqualTo(1));
-            Assert.That(pageRanges[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(pageRanges[1].Value<string>, Is.EqualTo("3-5"));
-        }
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("pageRanges"));
+        JToken? pageRangesToken = serialized["pageRanges"];
+        Assert.NotNull(pageRangesToken);
+        Assert.Equal(JTokenType.Array, pageRangesToken.Type);
+
+        JArray? pageRanges = pageRangesToken as JArray;
+        Assert.NotNull(pageRanges);
+        Assert.Equal(2, pageRanges.Count);
+
+        Assert.Equal(JTokenType.Integer, pageRanges[0].Type);
+        Assert.Equal(1L, pageRanges[0].Value<long>());
+        Assert.Equal(JTokenType.String, pageRanges[1].Type);
+        Assert.Equal("3-5", pageRanges[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNoPageRanges()
     {
         PrintCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestSerializeParametersWithInvalidPageRangesThrows()
     {
         PrintCommandParameters properties = new("myContextId")
@@ -455,6 +489,6 @@ public class PrintCommandParametersTests
                 true
             ]
         };
-        Assert.That(() => JsonSerializer.Serialize(properties), Throws.InstanceOf<ArgumentException>().With.Message.Contains("Page range must be a string or an integer value"));
+        Assert.Contains("Page range must be a string or an integer value", Assert.ThrowsAny<ArgumentException>(() => JsonSerializer.Serialize(properties)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/PrintCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/PrintCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class PrintCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class PrintCommandResultTests
                       }
                       """;
         PrintCommandResult? result = JsonSerializer.Deserialize<PrintCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Data, Is.EqualTo("some print data"));
+        Assert.NotNull(result);
+        Assert.Equal("some print data", result.Data);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class PrintCommandResultTests
                       }
                       """;
         PrintCommandResult? result = JsonSerializer.Deserialize<PrintCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         PrintCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<PrintCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrintCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class PrintCommandResultTests
                         "data": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrintCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrintCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/ReloadCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/ReloadCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ReloadCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ReloadCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.reload"));
+        Assert.Equal("browsingContext.reload", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ReloadCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithIgnoreCacheTrue()
     {
         ReloadCommandParameters properties = new("myContextId")
@@ -37,19 +36,22 @@ public class ReloadCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("ignoreCache"));
-            Assert.That(serialized["ignoreCache"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["ignoreCache"]!.Value<bool>(), Is.EqualTo(true));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("ignoreCache"));
+        JToken? ignoreCache = serialized["ignoreCache"];
+        Assert.NotNull(ignoreCache);
+        Assert.Equal(JTokenType.Boolean, ignoreCache.Type);
+        Assert.True(ignoreCache.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithIgnoreCacheFalse()
     {
         ReloadCommandParameters properties = new("myContextId")
@@ -58,19 +60,22 @@ public class ReloadCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("ignoreCache"));
-            Assert.That(serialized["ignoreCache"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["ignoreCache"]!.Value<bool>(), Is.EqualTo(false));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("ignoreCache"));
+        JToken? ignoreCache = serialized["ignoreCache"];
+        Assert.NotNull(ignoreCache);
+        Assert.Equal(JTokenType.Boolean, ignoreCache.Type);
+        Assert.False(ignoreCache.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptWaitNone()
     {
         ReloadCommandParameters properties = new("myContextId")
@@ -79,19 +84,22 @@ public class ReloadCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("wait"));
-            Assert.That(serialized["wait"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["wait"]!.Value<string>(), Is.EqualTo("none"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wait"));
+        JToken? wait = serialized["wait"];
+        Assert.NotNull(wait);
+        Assert.Equal(JTokenType.String, wait.Type);
+        Assert.Equal("none", wait.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptWaitInteractive()
     {
         ReloadCommandParameters properties = new("myContextId")
@@ -100,19 +108,22 @@ public class ReloadCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("wait"));
-            Assert.That(serialized["wait"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["wait"]!.Value<string>(), Is.EqualTo("interactive"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wait"));
+        JToken? wait = serialized["wait"];
+        Assert.NotNull(wait);
+        Assert.Equal(JTokenType.String, wait.Type);
+        Assert.Equal("interactive", wait.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAcceptWaitComplete()
     {
         ReloadCommandParameters properties = new("myContextId")
@@ -121,15 +132,18 @@ public class ReloadCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("wait"));
-            Assert.That(serialized["wait"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["wait"]!.Value<string>(), Is.EqualTo("complete"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wait"));
+        JToken? wait = serialized["wait"];
+        Assert.NotNull(wait);
+        Assert.Equal(JTokenType.String, wait.Type);
+        Assert.Equal("complete", wait.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/ReloadCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/ReloadCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ReloadCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,15 +13,13 @@ public class ReloadCommandResultTests
                       }
                       """;
         ReloadCommandResult? result = JsonSerializer.Deserialize<ReloadCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Url, Is.EqualTo("http://example.com"));
-            Assert.That(result.NavigationId, Is.Null);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("http://example.com", result.Url);
+        Assert.Null(result.NavigationId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNavigationId()
     {
         string json = """
@@ -32,15 +29,13 @@ public class ReloadCommandResultTests
                       }
                       """;
         ReloadCommandResult? result = JsonSerializer.Deserialize<ReloadCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Url, Is.EqualTo("http://example.com"));
-            Assert.That(result.NavigationId, Is.EqualTo("myNavigationId"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("http://example.com", result.Url);
+        Assert.Equal("myNavigationId", result.NavigationId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -49,19 +44,19 @@ public class ReloadCommandResultTests
                       }
                       """;
         ReloadCommandResult? result = JsonSerializer.Deserialize<ReloadCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ReloadCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingUrlThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<ReloadCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ReloadCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidUrlTypeThrows()
     {
         string json = """
@@ -69,10 +64,10 @@ public class ReloadCommandResultTests
                         "url": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ReloadCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ReloadCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidNavigationIdTypeThrows()
     {
         string json = """
@@ -81,6 +76,6 @@ public class ReloadCommandResultTests
                         "navigation": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ReloadCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ReloadCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/SetBypassCSPCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/SetBypassCSPCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetBypassCSPCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetBypassCSPCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.setBypassCSP"));
+        Assert.Equal("browsingContext.setBypassCSP", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetBypassCSPCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("bypass"));
-            Assert.That(serialized["bypass"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["bypass"]!.Value<bool?>(), Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("bypass"));
+        JToken? bypass = serialized["bypass"];
+        Assert.NotNull(bypass);
+        Assert.Equal(JTokenType.Null, bypass.Type);
+        Assert.Null(bypass.Value<bool?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEnabledTrue()
     {
         SetBypassCSPCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetBypassCSPCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("bypass"));
-            Assert.That(serialized["bypass"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["bypass"]!.Value<bool?>(), Is.True);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("bypass"));
+        JToken? bypass = serialized["bypass"];
+        Assert.NotNull(bypass);
+        Assert.Equal(JTokenType.Boolean, bypass.Type);
+        Assert.True(bypass.Value<bool?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEnabledFalse()
     {
         SetBypassCSPCommandParameters properties = new()
@@ -55,16 +54,16 @@ public class SetBypassCSPCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("bypass"));
-            Assert.That(serialized["bypass"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["bypass"]!.Value<bool?>(), Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("bypass"));
+        JToken? bypass = serialized["bypass"];
+        Assert.NotNull(bypass);
+        Assert.Equal(JTokenType.Null, bypass.Type);
+        Assert.Null(bypass.Value<bool?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetBypassCSPCommandParameters properties = new()
@@ -77,24 +76,28 @@ public class SetBypassCSPCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("bypass"));
-            Assert.That(serialized["bypass"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["bypass"]!.Value<bool?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("bypass"));
+        JToken? bypass = serialized["bypass"];
+        Assert.NotNull(bypass);
+        Assert.Equal(JTokenType.Null, bypass.Type);
+        Assert.Null(bypass.Value<bool?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetBypassCSPCommandParameters properties = new()
@@ -107,41 +110,43 @@ public class SetBypassCSPCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("bypass"));
-            Assert.That(serialized["bypass"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["bypass"]!.Value<bool?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("bypass"));
+        JToken? bypass = serialized["bypass"];
+        Assert.NotNull(bypass);
+        Assert.Equal(JTokenType.Null, bypass.Type);
+        Assert.Null(bypass.Value<bool?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetBypassCSPCommandParameters properties = SetBypassCSPCommandParameters.ResetBypassCSP;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Bypass, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.Bypass);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetBypassCSPCommandParameters firstInstance = SetBypassCSPCommandParameters.ResetBypassCSP;
         SetBypassCSPCommandParameters secondInstance = SetBypassCSPCommandParameters.ResetBypassCSP;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/SetBypassCSPCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/SetBypassCSPCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetBypassCSPCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetBypassCSPCommandResult? result = JsonSerializer.Deserialize<SetBypassCSPCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetBypassCSPCommandResult? result = JsonSerializer.Deserialize<SetBypassCSPCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetBypassCSPCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/SetViewportCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/SetViewportCommandParametersTests.cs
@@ -3,26 +3,25 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetViewportCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetViewportCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.setViewport"));
+        Assert.Equal("browsingContext.setViewport", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetViewportCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBrowsingContext()
     {
         SetViewportCommandParameters properties = new()
@@ -31,16 +30,16 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContext", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithViewport()
     {
         SetViewportCommandParameters properties = new()
@@ -53,24 +52,30 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("viewport"));
-            Assert.That(serialized["viewport"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? viewportObject = serialized["viewport"]!.Value<JObject>();
-            Assert.That(viewportObject, Is.Not.Null);
-            Assert.That(viewportObject, Has.Count.EqualTo(2));
-            Assert.That(viewportObject, Contains.Key("width"));
-            Assert.That(viewportObject!["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(viewportObject!["width"]!.Value<ulong>(), Is.EqualTo(1280));
-            Assert.That(viewportObject, Contains.Key("height"));
-            Assert.That(viewportObject!["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(viewportObject!["height"]!.Value<ulong>(), Is.EqualTo(1024));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("viewport"));
+        JToken? viewportToken = serialized["viewport"];
+        Assert.NotNull(viewportToken);
+        Assert.Equal(JTokenType.Object, viewportToken.Type);
+        JObject? viewportObject = viewportToken.Value<JObject>();
+        Assert.NotNull(viewportObject);
+        Assert.Equal(2, viewportObject.Count);
+
+        Assert.True(viewportObject.ContainsKey("width"));
+        JToken? viewportWidth = viewportObject["width"];
+        Assert.NotNull(viewportWidth);
+        Assert.Equal(JTokenType.Integer, viewportWidth.Type);
+        Assert.Equal(1280UL, viewportWidth.Value<ulong>());
+
+        Assert.True(viewportObject.ContainsKey("height"));
+        JToken? viewportHeight = viewportObject["height"];
+        Assert.NotNull(viewportHeight);
+        Assert.Equal(JTokenType.Integer, viewportHeight.Type);
+        Assert.Equal(1024UL, viewportHeight.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDefaultViewport()
     {
         SetViewportCommandParameters properties = new()
@@ -79,24 +84,30 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("viewport"));
-            Assert.That(serialized["viewport"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? viewportObject = serialized["viewport"]!.Value<JObject>();
-            Assert.That(viewportObject, Is.Not.Null);
-            Assert.That(viewportObject, Has.Count.EqualTo(2));
-            Assert.That(viewportObject, Contains.Key("width"));
-            Assert.That(viewportObject!["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(viewportObject!["width"]!.Value<ulong>(), Is.EqualTo(0));
-            Assert.That(viewportObject, Contains.Key("height"));
-            Assert.That(viewportObject!["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(viewportObject!["height"]!.Value<ulong>(), Is.EqualTo(0));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("viewport"));
+        JToken? viewportToken = serialized["viewport"];
+        Assert.NotNull(viewportToken);
+        Assert.Equal(JTokenType.Object, viewportToken.Type);
+        JObject? viewportObject = viewportToken.Value<JObject>();
+        Assert.NotNull(viewportObject);
+        Assert.Equal(2, viewportObject.Count);
+
+        Assert.True(viewportObject.ContainsKey("width"));
+        JToken? viewportWidth = viewportObject["width"];
+        Assert.NotNull(viewportWidth);
+        Assert.Equal(JTokenType.Integer, viewportWidth.Type);
+        Assert.Equal(0U, viewportWidth.Value<ulong>());
+
+        Assert.True(viewportObject.ContainsKey("height"));
+        JToken? viewportHeight = viewportObject["height"];
+        Assert.NotNull(viewportHeight);
+        Assert.Equal(JTokenType.Integer, viewportHeight.Type);
+        Assert.Equal(0U, viewportHeight.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithViewportReset()
     {
         SetViewportCommandParameters properties = new()
@@ -105,15 +116,15 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("viewport"));
-            Assert.That(serialized["viewport"]!.Type, Is.EqualTo(JTokenType.Null));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("viewport"));
+        JToken? viewport = serialized["viewport"];
+        Assert.NotNull(viewport);
+        Assert.Equal(JTokenType.Null, viewport.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDevicePixelRatio()
     {
         SetViewportCommandParameters properties = new()
@@ -122,16 +133,16 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("devicePixelRatio"));
-            Assert.That(serialized["devicePixelRatio"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["devicePixelRatio"]!.Value<double>(), Is.EqualTo(1.5));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("devicePixelRatio"));
+        JToken? devicePixelRatio = serialized["devicePixelRatio"];
+        Assert.NotNull(devicePixelRatio);
+        Assert.Equal(JTokenType.Float, devicePixelRatio.Type);
+        Assert.Equal(1.5, devicePixelRatio.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithResetDevicePixelRatio()
     {
         SetViewportCommandParameters properties = new()
@@ -140,15 +151,15 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("devicePixelRatio"));
-            Assert.That(serialized["devicePixelRatio"]!.Type, Is.EqualTo(JTokenType.Null));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("devicePixelRatio"));
+        JToken? devicePixelRatio = serialized["devicePixelRatio"];
+        Assert.NotNull(devicePixelRatio);
+        Assert.Equal(JTokenType.Null, devicePixelRatio.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUserContexts()
     {
         SetViewportCommandParameters properties = new()
@@ -157,16 +168,16 @@ public class SetViewportCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.ContainsKey("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Is.Not.Null);
-            Assert.That(userContextsArray, Has.Count.EqualTo(1));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray![0].Value<string>(), Is.EqualTo("myUserContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Single(userContextsArray);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("myUserContextId", userContextsArray[0].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/SetViewportCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/SetViewportCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetViewportCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetViewportCommandResult? result = JsonSerializer.Deserialize<SetViewportCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetViewportCommandResult? result = JsonSerializer.Deserialize<SetViewportCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetViewportCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/TraverseHistoryCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/TraverseHistoryCommandParametersTests.cs
@@ -3,67 +3,75 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class TraverseHistoryCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         TraverseHistoryCommandParameters properties = new("myContextId", 0);
-        Assert.That(properties.MethodName, Is.EqualTo("browsingContext.traverseHistory"));
+        Assert.Equal("browsingContext.traverseHistory", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         TraverseHistoryCommandParameters properties = new("myContextId", 0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("delta"));
-            Assert.That(serialized["delta"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["delta"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("delta"));
+        JToken? delta = serialized["delta"];
+        Assert.NotNull(delta);
+        Assert.Equal(JTokenType.Integer, delta.Type);
+        Assert.Equal(0L, delta.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPositiveDelta()
     {
         TraverseHistoryCommandParameters properties = new("myContextId", 1);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("delta"));
-            Assert.That(serialized["delta"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["delta"]!.Value<long>(), Is.EqualTo(1));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("delta"));
+        JToken? delta = serialized["delta"];
+        Assert.NotNull(delta);
+        Assert.Equal(JTokenType.Integer, delta.Type);
+        Assert.Equal(1L, delta.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNegativeDelta()
     {
         TraverseHistoryCommandParameters properties = new("myContextId", -1);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("delta"));
-            Assert.That(serialized["delta"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["delta"]!.Value<long>(), Is.EqualTo(-1));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("delta"));
+        JToken? delta = serialized["delta"];
+        Assert.NotNull(delta);
+        Assert.Equal(JTokenType.Integer, delta.Type);
+        Assert.Equal(-1L, delta.Value<long>());
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/TraverseHistoryCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/TraverseHistoryCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class TraverseHistoryCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         TraverseHistoryCommandResult? result = JsonSerializer.Deserialize<TraverseHistoryCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         TraverseHistoryCommandResult? result = JsonSerializer.Deserialize<TraverseHistoryCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         TraverseHistoryCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/UserPromptClosedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/UserPromptClosedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.BrowsingContext;
 
 using System.Text.Json;
 
-[TestFixture]
 public class UserPromptClosedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithAcceptedTrue()
     {
         string json = """
@@ -15,16 +14,14 @@ public class UserPromptClosedEventArgsTests
                       }
                       """;
         UserPromptClosedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsAccepted, Is.True);
-            Assert.That(eventArgs.UserText, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.True(eventArgs.IsAccepted);
+        Assert.Null(eventArgs.UserText);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithAcceptedFalse()
     {
         string json = """
@@ -34,16 +31,14 @@ public class UserPromptClosedEventArgsTests
                       }
                       """;
         UserPromptClosedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsAccepted, Is.False);
-            Assert.That(eventArgs.UserText, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.False(eventArgs.IsAccepted);
+        Assert.Null(eventArgs.UserText);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserText()
     {
         string json = """
@@ -54,16 +49,14 @@ public class UserPromptClosedEventArgsTests
                       }
                       """;
         UserPromptClosedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsAccepted, Is.True);
-            Assert.That(eventArgs.UserText, Is.EqualTo("some text"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.True(eventArgs.IsAccepted);
+        Assert.Equal("some text", eventArgs.UserText);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserContext()
     {
         string json = """
@@ -74,16 +67,14 @@ public class UserPromptClosedEventArgsTests
                       }
                       """;
         UserPromptClosedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsAccepted, Is.True);
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.True(eventArgs.IsAccepted);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -93,12 +84,12 @@ public class UserPromptClosedEventArgsTests
                       }
                       """;
         UserPromptClosedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         UserPromptClosedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingContextValueThrows()
     {
         string json = """
@@ -106,10 +97,10 @@ public class UserPromptClosedEventArgsTests
                         "accepted": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidContextValueThrows()
     {
         string json = """
@@ -118,10 +109,10 @@ public class UserPromptClosedEventArgsTests
                         "accepted": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingAcceptedValueThrows()
     {
         string json = """
@@ -129,10 +120,10 @@ public class UserPromptClosedEventArgsTests
                         "context": "myContextId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidAcceptedValueThrows()
     {
         string json = """
@@ -141,10 +132,10 @@ public class UserPromptClosedEventArgsTests
                         "accepted": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidUserTextValueThrows()
     {
         string json = """
@@ -154,6 +145,6 @@ public class UserPromptClosedEventArgsTests
                         "userText": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptClosedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/BrowsingContext/UserPromptOpenEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/UserPromptOpenEventArgsTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.BrowsingContext;
 using System.Text.Json;
 using WebDriverBiDi.Session;
 
-[TestFixture]
 public class UserPromptOpenedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithTypeAlert()
     {
         string json = """
@@ -18,17 +17,15 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Alert));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Alert, eventArgs.PromptType);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithTypeConfirm()
     {
         string json = """
@@ -40,18 +37,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Confirm));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Confirm, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Accept, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithTypePrompt()
     {
         string json = """
@@ -63,18 +58,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Prompt));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Prompt, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Accept, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithTypeBeforeUnload()
     {
         string json = """
@@ -86,18 +79,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.BeforeUnload));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.BeforeUnload, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Accept, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithHandlerAccept()
     {
         string json = """
@@ -109,18 +100,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Alert));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Alert, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Accept, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithHandlerDismiss()
     {
         string json = """
@@ -132,18 +121,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Alert));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Alert, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Dismiss, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithHandlerIgnore()
     {
         string json = """
@@ -155,18 +142,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Alert));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Ignore));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Alert, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Ignore, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Null(eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalDefaultValue()
     {
         string json = """
@@ -179,18 +164,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Prompt));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.DefaultValue, Is.EqualTo("prompt default"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Prompt, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Accept, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Equal("prompt default", eventArgs.DefaultValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserContext()
     {
         string json = """
@@ -203,18 +186,16 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.PromptType, Is.EqualTo(UserPromptType.Prompt));
-            Assert.That(eventArgs.Handler, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(eventArgs.Message, Is.EqualTo("some prompt message"));
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal(UserPromptType.Prompt, eventArgs.PromptType);
+        Assert.Equal(UserPromptHandlerType.Accept, eventArgs.Handler);
+        Assert.Equal("some prompt message", eventArgs.Message);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -226,12 +207,12 @@ public class UserPromptOpenedEventArgsTests
                       }
                       """;
         UserPromptOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         UserPromptOpenedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingContextValueThrows()
     {
         string json = """
@@ -241,10 +222,10 @@ public class UserPromptOpenedEventArgsTests
                         "message": "some prompt message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidContextValueThrows()
     {
         string json = """
@@ -255,10 +236,10 @@ public class UserPromptOpenedEventArgsTests
                         "message": "some prompt message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingTypeValueThrows()
     {
         string json = """
@@ -268,10 +249,10 @@ public class UserPromptOpenedEventArgsTests
                         "message": "some prompt message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidTypeValueThrows()
     {
         string json = """
@@ -282,10 +263,10 @@ public class UserPromptOpenedEventArgsTests
                         "message": "some prompt message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingHandlerTypeValueThrows()
     {
         string json = """
@@ -295,10 +276,10 @@ public class UserPromptOpenedEventArgsTests
                         "message": "some prompt message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidHandlerTypeValueThrows()
     {
         string json = """
@@ -309,10 +290,10 @@ public class UserPromptOpenedEventArgsTests
                         "message": "some prompt message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingMessageValueThrows()
     {
         string json = """
@@ -322,10 +303,10 @@ public class UserPromptOpenedEventArgsTests
                         "handler": "accept"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidMessageValueThrows()
     {
         string json = """
@@ -336,6 +317,6 @@ public class UserPromptOpenedEventArgsTests
                         "message": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptOpenedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/CollectionDefinitions.cs
+++ b/test/WebDriverBiDi.Tests/CollectionDefinitions.cs
@@ -1,0 +1,11 @@
+// <copyright file="CollectionDefinitions.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi;
+
+[CollectionDefinition("EventSourceTests", DisableParallelization = true)]
+public class EventSourceTestsCollectionDefinition
+{
+}

--- a/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.DigitalCredentials;
 
 using TestUtilities;
 
-[TestFixture]
 public class DigitalCredentialsModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecuteSetVirtualWalletBehavior()
     {
         TestWebSocketConnection connection = new();
@@ -22,13 +21,12 @@ public class DigitalCredentialsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         DigitalCredentialsModule module = driver.DigitalCredentials;
 
-        Task<SetVirtualWalletBehaviorCommandResult> task = module.SetVirtualWalletBehaviorAsync(new SetVirtualWalletBehaviorCommandParameters(VirtualWalletAction.Clear));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetVirtualWalletBehaviorCommandResult result = task.Result;
+        Task<SetVirtualWalletBehaviorCommandResult> task = module.SetVirtualWalletBehaviorAsync(new SetVirtualWalletBehaviorCommandParameters(VirtualWalletAction.Clear), cancellationToken: TestContext.Current.CancellationToken);
+        SetVirtualWalletBehaviorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
@@ -20,7 +20,7 @@ public class DigitalCredentialsModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         DigitalCredentialsModule module = driver.DigitalCredentials;
 

--- a/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
@@ -21,7 +21,7 @@ public class DigitalCredentialsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         DigitalCredentialsModule module = driver.DigitalCredentials;
 
         Task<SetVirtualWalletBehaviorCommandResult> task = module.SetVirtualWalletBehaviorAsync(new SetVirtualWalletBehaviorCommandParameters(VirtualWalletAction.Clear), cancellationToken: TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/DigitalCredentials/SetVirtualWalletBehaviorCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/DigitalCredentials/SetVirtualWalletBehaviorCommandParametersTests.cs
@@ -3,77 +3,76 @@ namespace WebDriverBiDi.DigitalCredentials;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetVirtualWalletBehaviorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Respond);
-        Assert.That(properties.MethodName, Is.EqualTo("digitalCredentials.setVirtualWalletBehavior"));
+        Assert.Equal("digitalCredentials.setVirtualWalletBehavior", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForRespondAction()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Respond);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("respond"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("respond", action.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForWaitAction()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Wait);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("wait"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("wait", action.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForDeclineAction()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Decline);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("decline"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("decline", action.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersForClearAction()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Clear);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("clear"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("clear", action.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithContext()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Respond)
@@ -82,19 +81,22 @@ public class SetVirtualWalletBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("respond"));
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("respond", action.Value<string>());
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithProtocol()
     {
         SetVirtualWalletBehaviorCommandParameters properties = new(VirtualWalletAction.Respond)
@@ -103,20 +105,22 @@ public class SetVirtualWalletBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("respond"));
-            Assert.That(serialized, Contains.Key("protocol"));
-            Assert.That(serialized["protocol"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["protocol"]!.Value<string>(), Is.EqualTo("myProtocol"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("respond", action.Value<string>());
+
+        Assert.True(serialized.ContainsKey("protocol"));
+        JToken? protocol = serialized["protocol"];
+        Assert.NotNull(protocol);
+        Assert.Equal(JTokenType.String, protocol.Type);
+        Assert.Equal("myProtocol", protocol.Value<string>());
     }
 
-
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithResponse()
     {
         Dictionary<string, object?> response = new()
@@ -129,20 +133,25 @@ public class SetVirtualWalletBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("respond"));
-            Assert.That(serialized, Contains.Key("response"));
-            Assert.That(serialized["response"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? responseObject = serialized["response"] as JObject;
-            Assert.That(responseObject, Is.Not.Null);
-            Assert.That(responseObject, Has.Count.EqualTo(1));
-            Assert.That(responseObject, Contains.Key("name"));
-            Assert.That(responseObject!["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(responseObject!["name"]!.Value<string>(), Is.EqualTo("value"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("respond", action.Value<string>());
+
+        Assert.True(serialized.ContainsKey("response"));
+        JToken? responseToken = serialized["response"];
+        Assert.NotNull(responseToken);
+        Assert.Equal(JTokenType.Object, responseToken.Type);
+        JObject? responseObject = responseToken as JObject;
+        Assert.NotNull(responseObject);
+        Assert.Single(responseObject);
+        Assert.True(responseObject.ContainsKey("name"));
+        JToken? responseName = responseObject["name"];
+        Assert.NotNull(responseName);
+        Assert.Equal(JTokenType.String, responseName.Type);
+        Assert.Equal("value", responseName.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/DigitalCredentials/SetVirtualWalletBehaviorCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/DigitalCredentials/SetVirtualWalletBehaviorCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.DigitalCredentials;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetVirtualWalletBehaviorCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetVirtualWalletBehaviorCommandResult? result = JsonSerializer.Deserialize<SetVirtualWalletBehaviorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetVirtualWalletBehaviorCommandResult? result = JsonSerializer.Deserialize<SetVirtualWalletBehaviorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetVirtualWalletBehaviorCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
@@ -20,7 +20,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -46,7 +46,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -72,7 +72,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -98,7 +98,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -124,7 +124,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -150,7 +150,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -176,7 +176,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -202,7 +202,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -228,7 +228,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -254,7 +254,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -283,7 +283,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 

--- a/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Emulation;
 
 using TestUtilities;
 
-[TestFixture]
 public class EmulationModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestSetGeolocationOverrideCommandWithCoordinates()
     {
         TestWebSocketConnection connection = new();
@@ -22,17 +21,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetGeolocationOverrideCommandResult> task = module.SetGeolocationOverrideAsync(new SetGeolocationOverrideCoordinatesCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetGeolocationOverrideCommandResult result = task.Result;
+        Task<SetGeolocationOverrideCommandResult> task = module.SetGeolocationOverrideAsync(new SetGeolocationOverrideCoordinatesCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetGeolocationOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetLocaleOverrideCommandWithCoordinates()
     {
         TestWebSocketConnection connection = new();
@@ -49,17 +47,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetLocaleOverrideCommandResult> task = module.SetLocaleOverrideAsync(new SetLocaleOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetLocaleOverrideCommandResult result = task.Result;
+        Task<SetLocaleOverrideCommandResult> task = module.SetLocaleOverrideAsync(new SetLocaleOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetLocaleOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetForcedColorsModeThemeOverrideCommandWithCoordinates()
     {
         TestWebSocketConnection connection = new();
@@ -76,17 +73,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetForcedColorsModeThemeOverrideCommandResult> task = module.SetForcedColorsModeThemeOverrideAsync(new SetForcedColorsModeThemeOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetForcedColorsModeThemeOverrideCommandResult result = task.Result;
+        Task<SetForcedColorsModeThemeOverrideCommandResult> task = module.SetForcedColorsModeThemeOverrideAsync(new SetForcedColorsModeThemeOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetForcedColorsModeThemeOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetScreenOrientationOverrideCommand()
     {
         TestWebSocketConnection connection = new();
@@ -103,17 +99,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetScreenOrientationOverrideCommandResult> task = module.SetScreenOrientationOverrideAsync(new SetScreenOrientationOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetScreenOrientationOverrideCommandResult result = task.Result;
+        Task<SetScreenOrientationOverrideCommandResult> task = module.SetScreenOrientationOverrideAsync(new SetScreenOrientationOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetScreenOrientationOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetScreenSettingsOverrideCommand()
     {
         TestWebSocketConnection connection = new();
@@ -130,17 +125,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetScreenSettingsOverrideCommandResult> task = module.SetScreenSettingsOverrideAsync(new SetScreenSettingsOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetScreenSettingsOverrideCommandResult result = task.Result;
+        Task<SetScreenSettingsOverrideCommandResult> task = module.SetScreenSettingsOverrideAsync(new SetScreenSettingsOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetScreenSettingsOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetScriptingEnabledCommand()
     {
         TestWebSocketConnection connection = new();
@@ -157,17 +151,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetScriptingEnabledCommandResult> task = module.SetScriptingEnabledAsync(new SetScriptingEnabledCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetScriptingEnabledCommandResult result = task.Result;
+        Task<SetScriptingEnabledCommandResult> task = module.SetScriptingEnabledAsync(new SetScriptingEnabledCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetScriptingEnabledCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetTimeZoneOverrideCommandWithCoordinates()
     {
         TestWebSocketConnection connection = new();
@@ -184,17 +177,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetTimeZoneOverrideCommandResult> task = module.SetTimeZoneOverrideAsync(new SetTimeZoneOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetTimeZoneOverrideCommandResult result = task.Result;
+        Task<SetTimeZoneOverrideCommandResult> task = module.SetTimeZoneOverrideAsync(new SetTimeZoneOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetTimeZoneOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetScrollbarTypeOverrideCommand()
     {
         TestWebSocketConnection connection = new();
@@ -211,17 +203,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetScrollbarTypeOverrideCommandResult> task = module.SetScrollbarTypeOverrideAsync(new SetScrollbarTypeOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetScrollbarTypeOverrideCommandResult result = task.Result;
+        Task<SetScrollbarTypeOverrideCommandResult> task = module.SetScrollbarTypeOverrideAsync(new SetScrollbarTypeOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetScrollbarTypeOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetTouchOverrideCommandWithCoordinates()
     {
         TestWebSocketConnection connection = new();
@@ -238,17 +229,16 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
-        Task<SetTouchOverrideCommandResult> task = module.SetTouchOverrideAsync(new SetTouchOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetTouchOverrideCommandResult result = task.Result;
+        Task<SetTouchOverrideCommandResult> task = module.SetTouchOverrideAsync(new SetTouchOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetTouchOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetNetworkConditionsCommandWithCoordinates()
     {
         TestWebSocketConnection connection = new();
@@ -265,20 +255,19 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetNetworkConditionsCommandResult> task = module.SetNetworkConditionsAsync(new SetNetworkConditionsCommandParameters()
         {
             NetworkConditions = new NetworkConditionsOffline()
-        });
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetNetworkConditionsCommandResult result = task.Result;
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        SetNetworkConditionsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetUserAgentOverrideCommand()
     {
         TestWebSocketConnection connection = new();
@@ -295,16 +284,15 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetUserAgentOverrideCommandResult> task = module.SetUserAgentOverrideAsync(new SetUserAgentOverrideCommandParameters()
         {
             UserAgent = "WebDriverBiDi.NET/1.0 (no platform)"
-        });
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetUserAgentOverrideCommandResult result = task.Result;
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        SetUserAgentOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
@@ -21,7 +21,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetGeolocationOverrideCommandResult> task = module.SetGeolocationOverrideAsync(new SetGeolocationOverrideCoordinatesCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -47,7 +47,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetLocaleOverrideCommandResult> task = module.SetLocaleOverrideAsync(new SetLocaleOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -73,7 +73,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetForcedColorsModeThemeOverrideCommandResult> task = module.SetForcedColorsModeThemeOverrideAsync(new SetForcedColorsModeThemeOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -99,7 +99,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetScreenOrientationOverrideCommandResult> task = module.SetScreenOrientationOverrideAsync(new SetScreenOrientationOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -125,7 +125,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetScreenSettingsOverrideCommandResult> task = module.SetScreenSettingsOverrideAsync(new SetScreenSettingsOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -151,7 +151,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetScriptingEnabledCommandResult> task = module.SetScriptingEnabledAsync(new SetScriptingEnabledCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -177,7 +177,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetTimeZoneOverrideCommandResult> task = module.SetTimeZoneOverrideAsync(new SetTimeZoneOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -203,7 +203,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetScrollbarTypeOverrideCommandResult> task = module.SetScrollbarTypeOverrideAsync(new SetScrollbarTypeOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -229,7 +229,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetTouchOverrideCommandResult> task = module.SetTouchOverrideAsync(new SetTouchOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
@@ -255,7 +255,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetNetworkConditionsCommandResult> task = module.SetNetworkConditionsAsync(new SetNetworkConditionsCommandParameters()
@@ -284,7 +284,7 @@ public class EmulationModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
         Task<SetUserAgentOverrideCommandResult> task = module.SetUserAgentOverrideAsync(new SetUserAgentOverrideCommandParameters()

--- a/test/WebDriverBiDi.Tests/Emulation/GeolocationCoordinatesTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/GeolocationCoordinatesTests.cs
@@ -3,28 +3,30 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GeolocationCoordinatesTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeCoordinates()
     {
         GeolocationCoordinates coordinates = new(123.45, -67.89);
         string json = JsonSerializer.Serialize(coordinates);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("longitude"));
-            Assert.That(serialized["longitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["longitude"]!.Value<double>(), Is.EqualTo(123.45));
-            Assert.That(serialized, Contains.Key("latitude"));
-            Assert.That(serialized["latitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["latitude"]!.Value<double>(), Is.EqualTo(-67.89));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("longitude"));
+        JToken? longitude = serialized["longitude"];
+        Assert.NotNull(longitude);
+        Assert.Equal(JTokenType.Float, longitude.Type);
+        Assert.Equal(123.45, longitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("latitude"));
+        JToken? latitude = serialized["latitude"];
+        Assert.NotNull(latitude);
+        Assert.Equal(JTokenType.Float, latitude.Type);
+        Assert.Equal(-67.89, latitude.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCoordinatesWithAccuracy()
     {
         GeolocationCoordinates coordinates = new(123.45, -67.89)
@@ -33,22 +35,28 @@ public class GeolocationCoordinatesTests
         };
         string json = JsonSerializer.Serialize(coordinates);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("longitude"));
-            Assert.That(serialized["longitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["longitude"]!.Value<double>(), Is.EqualTo(123.45));
-            Assert.That(serialized, Contains.Key("latitude"));
-            Assert.That(serialized["latitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["latitude"]!.Value<double>(), Is.EqualTo(-67.89));
-            Assert.That(serialized, Contains.Key("accuracy"));
-            Assert.That(serialized["accuracy"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["accuracy"]!.Value<double>(), Is.EqualTo(0.95));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("longitude"));
+        JToken? longitude = serialized["longitude"];
+        Assert.NotNull(longitude);
+        Assert.Equal(JTokenType.Float, longitude.Type);
+        Assert.Equal(123.45, longitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("latitude"));
+        JToken? latitude = serialized["latitude"];
+        Assert.NotNull(latitude);
+        Assert.Equal(JTokenType.Float, latitude.Type);
+        Assert.Equal(-67.89, latitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("accuracy"));
+        JToken? accuracy = serialized["accuracy"];
+        Assert.NotNull(accuracy);
+        Assert.Equal(JTokenType.Float, accuracy.Type);
+        Assert.Equal(0.95, accuracy.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCoordinatesWithAltitudeAndAltitudeAccuracy()
     {
         GeolocationCoordinates coordinates = new(123.45, -67.89)
@@ -58,25 +66,34 @@ public class GeolocationCoordinatesTests
         };
         string json = JsonSerializer.Serialize(coordinates);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("longitude"));
-            Assert.That(serialized["longitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["longitude"]!.Value<double>(), Is.EqualTo(123.45));
-            Assert.That(serialized, Contains.Key("latitude"));
-            Assert.That(serialized["latitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["latitude"]!.Value<double>(), Is.EqualTo(-67.89));
-            Assert.That(serialized, Contains.Key("altitude"));
-            Assert.That(serialized["altitude"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["altitude"]!.Value<double>(), Is.EqualTo(1.0));
-            Assert.That(serialized, Contains.Key("altitudeAccuracy"));
-            Assert.That(serialized["altitudeAccuracy"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["altitudeAccuracy"]!.Value<double>(), Is.EqualTo(2.0));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("longitude"));
+        JToken? longitude = serialized["longitude"];
+        Assert.NotNull(longitude);
+        Assert.Equal(JTokenType.Float, longitude.Type);
+        Assert.Equal(123.45, longitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("latitude"));
+        JToken? latitude = serialized["latitude"];
+        Assert.NotNull(latitude);
+        Assert.Equal(JTokenType.Float, latitude.Type);
+        Assert.Equal(-67.89, latitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("altitude"));
+        JToken? altitude = serialized["altitude"];
+        Assert.NotNull(altitude);
+        Assert.Equal(JTokenType.Integer, altitude.Type);
+        Assert.Equal(1.0, altitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("altitudeAccuracy"));
+        JToken? altitudeAccuracy = serialized["altitudeAccuracy"];
+        Assert.NotNull(altitudeAccuracy);
+        Assert.Equal(JTokenType.Integer, altitudeAccuracy.Type);
+        Assert.Equal(2.0, altitudeAccuracy.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCoordinatesWithSpeedAndHeading()
     {
         GeolocationCoordinates coordinates = new(123.45, -67.89)
@@ -86,25 +103,34 @@ public class GeolocationCoordinatesTests
         };
         string json = JsonSerializer.Serialize(coordinates);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("longitude"));
-            Assert.That(serialized["longitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["longitude"]!.Value<double>(), Is.EqualTo(123.45));
-            Assert.That(serialized, Contains.Key("latitude"));
-            Assert.That(serialized["latitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["latitude"]!.Value<double>(), Is.EqualTo(-67.89));
-            Assert.That(serialized, Contains.Key("speed"));
-            Assert.That(serialized["speed"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["speed"]!.Value<double>(), Is.EqualTo(10.0));
-            Assert.That(serialized, Contains.Key("heading"));
-            Assert.That(serialized["heading"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["heading"]!.Value<double>(), Is.EqualTo(137.5));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("longitude"));
+        JToken? longitude = serialized["longitude"];
+        Assert.NotNull(longitude);
+        Assert.Equal(JTokenType.Float, longitude.Type);
+        Assert.Equal(123.45, longitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("latitude"));
+        JToken? latitude = serialized["latitude"];
+        Assert.NotNull(latitude);
+        Assert.Equal(JTokenType.Float, latitude.Type);
+        Assert.Equal(-67.89, latitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("speed"));
+        JToken? speed = serialized["speed"];
+        Assert.NotNull(speed);
+        Assert.Equal(JTokenType.Integer, speed.Type);
+        Assert.Equal(10.0, speed.Value<double>());
+
+        Assert.True(serialized.ContainsKey("heading"));
+        JToken? heading = serialized["heading"];
+        Assert.NotNull(heading);
+        Assert.Equal(JTokenType.Float, heading.Type);
+        Assert.Equal(137.5, heading.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCoordinatesWithStationarySpeedAndHeading()
     {
         GeolocationCoordinates coordinates = new(123.45, -67.89)
@@ -114,21 +140,30 @@ public class GeolocationCoordinatesTests
         };
         string json = JsonSerializer.Serialize(coordinates);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("longitude"));
-            Assert.That(serialized["longitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["longitude"]!.Value<double>(), Is.EqualTo(123.45));
-            Assert.That(serialized, Contains.Key("latitude"));
-            Assert.That(serialized["latitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["latitude"]!.Value<double>(), Is.EqualTo(-67.89));
-            Assert.That(serialized, Contains.Key("speed"));
-            Assert.That(serialized["speed"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["speed"]!.Value<double>(), Is.EqualTo(0.0));
-            Assert.That(serialized, Contains.Key("heading"));
-            Assert.That(serialized["heading"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["heading"]!.Value<string>(), Is.EqualTo("NaN"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("longitude"));
+        JToken? longitude = serialized["longitude"];
+        Assert.NotNull(longitude);
+        Assert.Equal(JTokenType.Float, longitude.Type);
+        Assert.Equal(123.45, longitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("latitude"));
+        JToken? latitude = serialized["latitude"];
+        Assert.NotNull(latitude);
+        Assert.Equal(JTokenType.Float, latitude.Type);
+        Assert.Equal(-67.89, latitude.Value<double>());
+
+        Assert.True(serialized.ContainsKey("speed"));
+        JToken? speed = serialized["speed"];
+        Assert.NotNull(speed);
+        Assert.Equal(JTokenType.Integer, speed.Type);
+        Assert.Equal(0.0, speed.Value<double>());
+
+        Assert.True(serialized.ContainsKey("heading"));
+        JToken? heading = serialized["heading"];
+        Assert.NotNull(heading);
+        Assert.Equal(JTokenType.String, heading.Type);
+        Assert.Equal("NaN", heading.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetForcedColorsModeThemeOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetForcedColorsModeThemeOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetForcedColorsModeThemeOverrideCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetForcedColorsModeThemeOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setForcedColorsModeThemeOverride"));
+        Assert.Equal("emulation.setForcedColorsModeThemeOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetForcedColorsModeThemeOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("theme"));
-            Assert.That(serialized["theme"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["theme"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("theme"));
+        JToken? theme = serialized["theme"];
+        Assert.NotNull(theme);
+        Assert.Equal(JTokenType.Null, theme.Type);
+        Assert.Null(theme.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithNoneMode()
     {
         SetForcedColorsModeThemeOverrideCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetForcedColorsModeThemeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("theme"));
-            Assert.That(serialized["theme"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["theme"]!.Value<string>(), Is.EqualTo("none"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("theme"));
+        JToken? theme = serialized["theme"];
+        Assert.NotNull(theme);
+        Assert.Equal(JTokenType.String, theme.Type);
+        Assert.Equal("none", theme.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithLightMode()
     {
         SetForcedColorsModeThemeOverrideCommandParameters properties = new()
@@ -55,16 +54,16 @@ public class SetForcedColorsModeThemeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("theme"));
-            Assert.That(serialized["theme"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["theme"]!.Value<string>(), Is.EqualTo("light"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("theme"));
+        JToken? theme = serialized["theme"];
+        Assert.NotNull(theme);
+        Assert.Equal(JTokenType.String, theme.Type);
+        Assert.Equal("light", theme.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDarkMode()
     {
         SetForcedColorsModeThemeOverrideCommandParameters properties = new()
@@ -73,33 +72,31 @@ public class SetForcedColorsModeThemeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("theme"));
-            Assert.That(serialized["theme"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["theme"]!.Value<string>(), Is.EqualTo("dark"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("theme"));
+        JToken? theme = serialized["theme"];
+        Assert.NotNull(theme);
+        Assert.Equal(JTokenType.String, theme.Type);
+        Assert.Equal("dark", theme.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetForcedColorsModeThemeOverrideCommandParameters properties = SetForcedColorsModeThemeOverrideCommandParameters.ResetForcedColorsModeThemeOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Theme, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.Theme);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetForcedColorsModeThemeOverrideCommandParameters firstInstance = SetForcedColorsModeThemeOverrideCommandParameters.ResetForcedColorsModeThemeOverride;
         SetForcedColorsModeThemeOverrideCommandParameters secondInstance = SetForcedColorsModeThemeOverrideCommandParameters.ResetForcedColorsModeThemeOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetForcedColorsModeThemeOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetForcedColorsModeThemeOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetForcedColorsModeThemeOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetForcedColorsModeThemeOverrideCommandResult? result = JsonSerializer.Deserialize<SetForcedColorsModeThemeOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetForcedColorsModeThemeOverrideCommandResult? result = JsonSerializer.Deserialize<SetForcedColorsModeThemeOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetForcedColorsModeThemeOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideCommandParametersTests.cs
@@ -3,35 +3,32 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetGeolocationOverrideCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetGeolocationOverrideCommandParameters properties = SetGeolocationOverrideCommandParameters.ResetGeolocationOverrideCoordinates;
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setGeolocationOverride"));
+        Assert.Equal("emulation.setGeolocationOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetGeolocationOverrideCommandParameters properties = SetGeolocationOverrideCommandParameters.ResetGeolocationOverrideCoordinates;
-        Assert.That(properties, Is.Not.Null);
-        Assert.That(properties, Is.InstanceOf<SetGeolocationOverrideCommandParameters>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(((SetGeolocationOverrideCoordinatesCommandParameters)properties).Coordinates, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+        Assert.IsType<SetGeolocationOverrideCommandParameters>(properties, exactMatch: false);
+
+        Assert.Null(((SetGeolocationOverrideCoordinatesCommandParameters)properties).Coordinates);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetGeolocationOverrideCommandParameters firstInstance = SetGeolocationOverrideCommandParameters.ResetGeolocationOverrideCoordinates;
         SetGeolocationOverrideCommandParameters secondInstance = SetGeolocationOverrideCommandParameters.ResetGeolocationOverrideCoordinates;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetGeolocationOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetGeolocationOverrideCommandResult? result = JsonSerializer.Deserialize<SetGeolocationOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetGeolocationOverrideCommandResult? result = JsonSerializer.Deserialize<SetGeolocationOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetGeolocationOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideCoordinatesCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideCoordinatesCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetGeolocationOverrideCoordinatesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetGeolocationOverrideCoordinatesCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setGeolocationOverride"));
+        Assert.Equal("emulation.setGeolocationOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetGeolocationOverrideCoordinatesCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("coordinates"));
-            Assert.That(serialized["coordinates"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["coordinates"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("coordinates"));
+        JToken? coordinates = serialized["coordinates"];
+        Assert.NotNull(coordinates);
+        Assert.Equal(JTokenType.Null, coordinates.Type);
+        Assert.Null(coordinates.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCoordinates()
     {
         SetGeolocationOverrideCoordinatesCommandParameters properties = new()
@@ -37,23 +36,30 @@ public class SetGeolocationOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("coordinates"));
-            Assert.That(serialized["coordinates"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? coordinatesObject = serialized["coordinates"] as JObject;
-            Assert.That(coordinatesObject, Has.Count.EqualTo(2));
-            Assert.That(coordinatesObject, Contains.Key("longitude"));
-            Assert.That(coordinatesObject!["longitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(coordinatesObject!["longitude"]!.Value<double>, Is.EqualTo(123.45));
-            Assert.That(coordinatesObject, Contains.Key("latitude"));
-            Assert.That(coordinatesObject!["latitude"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(coordinatesObject!["latitude"]!.Value<double>, Is.EqualTo(-67.89));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("coordinates"));
+        JToken? coordinatesToken = serialized["coordinates"];
+        Assert.NotNull(coordinatesToken);
+        Assert.Equal(JTokenType.Object, coordinatesToken.Type);
+        JObject? coordinatesObject = coordinatesToken as JObject;
+        Assert.NotNull(coordinatesObject);
+        Assert.Equal(2, coordinatesObject.Count);
+
+        Assert.True(coordinatesObject.ContainsKey("longitude"));
+        JToken? longitude = coordinatesObject["longitude"];
+        Assert.NotNull(longitude);
+        Assert.Equal(JTokenType.Float, longitude.Type);
+        Assert.Equal(123.45, longitude.Value<double>());
+
+        Assert.True(coordinatesObject.ContainsKey("latitude"));
+        JToken? latitude = coordinatesObject["latitude"];
+        Assert.NotNull(latitude);
+        Assert.Equal(JTokenType.Float, latitude.Type);
+        Assert.Equal(-67.89, latitude.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetGeolocationOverrideCoordinatesCommandParameters properties = new()
@@ -66,24 +72,28 @@ public class SetGeolocationOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("coordinates"));
-            Assert.That(serialized["coordinates"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["coordinates"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("coordinates"));
+        JToken? coordinates = serialized["coordinates"];
+        Assert.NotNull(coordinates);
+        Assert.Equal(JTokenType.Null, coordinates.Type);
+        Assert.Null(coordinates.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetGeolocationOverrideCoordinatesCommandParameters properties = new()
@@ -96,20 +106,24 @@ public class SetGeolocationOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("coordinates"));
-            Assert.That(serialized["coordinates"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["coordinates"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("coordinates"));
+        JToken? coordinates = serialized["coordinates"];
+        Assert.NotNull(coordinates);
+        Assert.Equal(JTokenType.Null, coordinates.Type);
+        Assert.Null(coordinates.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideErrorCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetGeolocationOverrideErrorCommandParametersTests.cs
@@ -3,37 +3,39 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetGeolocationOverrideErrorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetGeolocationOverrideErrorCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setGeolocationOverride"));
+        Assert.Equal("emulation.setGeolocationOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetGeolocationOverrideErrorCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("error"));
-            Assert.That(serialized["error"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? errorObject = serialized["error"]!.ToObject<JObject>();
-            Assert.That(errorObject, Has.Count.EqualTo(1));
-            Assert.That(errorObject, Contains.Key("type"));
-            Assert.That(errorObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(errorObject!["type"]!.Value<string>(), Is.EqualTo("positionUnavailable"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("error"));
+        JToken? errorToken = serialized["error"];
+        Assert.NotNull(errorToken);
+        Assert.Equal(JTokenType.Object, errorToken.Type);
+        JObject? errorObject = errorToken.ToObject<JObject>();
+        Assert.NotNull(errorObject);
+        Assert.Single(errorObject);
+
+        Assert.True(errorObject.ContainsKey("type"));
+        JToken? type = errorObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("positionUnavailable", type.Value<string>());
     }
 
-
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetGeolocationOverrideErrorCommandParameters properties = new()
@@ -46,23 +48,27 @@ public class SetGeolocationOverrideErrorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("error"));
-            Assert.That(serialized["error"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("error"));
+        JToken? error = serialized["error"];
+        Assert.NotNull(error);
+        Assert.Equal(JTokenType.Object, error.Type);
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetGeolocationOverrideErrorCommandParameters properties = new()
@@ -75,19 +81,23 @@ public class SetGeolocationOverrideErrorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("error"));
-            Assert.That(serialized["error"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("error"));
+        JToken? error = serialized["error"];
+        Assert.NotNull(error);
+        Assert.Equal(JTokenType.Object, error.Type);
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetLocaleOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetLocaleOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetLocaleOverrideCoordinatesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetLocaleOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setLocaleOverride"));
+        Assert.Equal("emulation.setLocaleOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetLocaleOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("locale"));
-            Assert.That(serialized["locale"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["locale"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("locale"));
+        JToken? locale = serialized["locale"];
+        Assert.NotNull(locale);
+        Assert.Equal(JTokenType.Null, locale.Type);
+        Assert.Null(locale.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithLocale()
     {
         SetLocaleOverrideCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetLocaleOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("locale"));
-            Assert.That(serialized["locale"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["locale"]!.Value<string>(), Is.EqualTo("en-US"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("locale"));
+        JToken? locale = serialized["locale"];
+        Assert.NotNull(locale);
+        Assert.Equal(JTokenType.String, locale.Type);
+        Assert.Equal("en-US", locale.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetLocaleOverrideCommandParameters properties = new()
@@ -59,24 +58,28 @@ public class SetLocaleOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("locale"));
-            Assert.That(serialized["locale"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["locale"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("locale"));
+        JToken? locale = serialized["locale"];
+        Assert.NotNull(locale);
+        Assert.Equal(JTokenType.Null, locale.Type);
+        Assert.Null(locale.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetLocaleOverrideCommandParameters properties = new()
@@ -89,41 +92,43 @@ public class SetLocaleOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("locale"));
-            Assert.That(serialized["locale"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["locale"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("locale"));
+        JToken? locale = serialized["locale"];
+        Assert.NotNull(locale);
+        Assert.Equal(JTokenType.Null, locale.Type);
+        Assert.Null(locale.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetLocaleOverrideCommandParameters properties = SetLocaleOverrideCommandParameters.ResetLocaleOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Locale, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.Locale);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetLocaleOverrideCommandParameters firstInstance = SetLocaleOverrideCommandParameters.ResetLocaleOverride;
         SetLocaleOverrideCommandParameters secondInstance = SetLocaleOverrideCommandParameters.ResetLocaleOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetLocaleOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetLocaleOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetLocaleOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetLocaleOverrideCommandResult? result = JsonSerializer.Deserialize<SetLocaleOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetLocaleOverrideCommandResult? result = JsonSerializer.Deserialize<SetLocaleOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetLocaleOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetNetworkConditionsCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetNetworkConditionsCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetNetworkConditionsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetNetworkConditionsCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setNetworkConditions"));
+        Assert.Equal("emulation.setNetworkConditions", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetNetworkConditionsCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("networkConditions"));
-            Assert.That(serialized["networkConditions"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["networkConditions"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("networkConditions"));
+        JToken? networkConditions = serialized["networkConditions"];
+        Assert.NotNull(networkConditions);
+        Assert.Equal(JTokenType.Null, networkConditions.Type);
+        Assert.Null(networkConditions.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOffline()
     {
         SetNetworkConditionsCommandParameters properties = new()
@@ -37,20 +36,24 @@ public class SetNetworkConditionsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("networkConditions"));
-            Assert.That(serialized["networkConditions"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? conditionsObject = serialized["networkConditions"] as JObject;
-            Assert.That(conditionsObject, Has.Count.EqualTo(1));
-            Assert.That(conditionsObject, Contains.Key("type"));
-            Assert.That(conditionsObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(conditionsObject!["type"]!.Value<string>(), Is.EqualTo("offline"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("networkConditions"));
+        JToken? networkConditionsToken = serialized["networkConditions"];
+        Assert.NotNull(networkConditionsToken);
+        Assert.Equal(JTokenType.Object, networkConditionsToken.Type);
+        JObject? conditionsObject = networkConditionsToken as JObject;
+        Assert.NotNull(conditionsObject);
+        Assert.Single(conditionsObject);
+
+        Assert.True(conditionsObject.ContainsKey("type"));
+        JToken? type = conditionsObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("offline", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetNetworkConditionsCommandParameters properties = new()
@@ -63,24 +66,28 @@ public class SetNetworkConditionsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("networkConditions"));
-            Assert.That(serialized["networkConditions"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["networkConditions"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("networkConditions"));
+        JToken? networkConditions = serialized["networkConditions"];
+        Assert.NotNull(networkConditions);
+        Assert.Equal(JTokenType.Null, networkConditions.Type);
+        Assert.Null(networkConditions.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetNetworkConditionsCommandParameters properties = new()
@@ -93,41 +100,43 @@ public class SetNetworkConditionsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("networkConditions"));
-            Assert.That(serialized["networkConditions"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["networkConditions"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("networkConditions"));
+        JToken? networkConditions = serialized["networkConditions"];
+        Assert.NotNull(networkConditions);
+        Assert.Equal(JTokenType.Null, networkConditions.Type);
+        Assert.Null(networkConditions.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetNetworkConditionsCommandParameters properties = SetNetworkConditionsCommandParameters.ResetNetworkConditions;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.NetworkConditions, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.NetworkConditions);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetNetworkConditionsCommandParameters firstInstance = SetNetworkConditionsCommandParameters.ResetNetworkConditions;
         SetNetworkConditionsCommandParameters secondInstance = SetNetworkConditionsCommandParameters.ResetNetworkConditions;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetNetworkConditionsCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetNetworkConditionsCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetNetworkConditionsCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetNetworkConditionsCommandResult? result = JsonSerializer.Deserialize<SetNetworkConditionsCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetNetworkConditionsCommandResult? result = JsonSerializer.Deserialize<SetNetworkConditionsCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetNetworkConditionsCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScreenOrientationOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScreenOrientationOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetScreenOrientationOverrideCoordinatesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetScreenOrientationOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setScreenOrientationOverride"));
+        Assert.Equal("emulation.setScreenOrientationOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetScreenOrientationOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenOrientation"));
-            Assert.That(serialized["screenOrientation"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["screenOrientation"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("screenOrientation"));
+        JToken? screenOrientation = serialized["screenOrientation"];
+        Assert.NotNull(screenOrientation);
+        Assert.Equal(JTokenType.Null, screenOrientation.Type);
+        Assert.Null(screenOrientation.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithScreenOrientation()
     {
         SetScreenOrientationOverrideCommandParameters properties = new()
@@ -37,23 +36,30 @@ public class SetScreenOrientationOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenOrientation"));
-            Assert.That(serialized["screenOrientation"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? coordinatesObject = serialized["screenOrientation"] as JObject;
-            Assert.That(coordinatesObject, Has.Count.EqualTo(2));
-            Assert.That(coordinatesObject, Contains.Key("natural"));
-            Assert.That(coordinatesObject!["natural"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(coordinatesObject!["natural"]!.Value<string>, Is.EqualTo("landscape"));
-            Assert.That(coordinatesObject, Contains.Key("type"));
-            Assert.That(coordinatesObject!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(coordinatesObject!["type"]!.Value<string>, Is.EqualTo("portrait-secondary"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("screenOrientation"));
+        JToken? screenOrientationToken = serialized["screenOrientation"];
+        Assert.NotNull(screenOrientationToken);
+        Assert.Equal(JTokenType.Object, screenOrientationToken.Type);
+        JObject? coordinatesObject = screenOrientationToken as JObject;
+        Assert.NotNull(coordinatesObject);
+        Assert.Equal(2, coordinatesObject.Count);
+
+        Assert.True(coordinatesObject.ContainsKey("natural"));
+        JToken? natural = coordinatesObject["natural"];
+        Assert.NotNull(natural);
+        Assert.Equal(JTokenType.String, natural.Type);
+        Assert.Equal("landscape", natural.Value<string>());
+
+        Assert.True(coordinatesObject.ContainsKey("type"));
+        JToken? type = coordinatesObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("portrait-secondary", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetScreenOrientationOverrideCommandParameters properties = new()
@@ -66,24 +72,28 @@ public class SetScreenOrientationOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenOrientation"));
-            Assert.That(serialized["screenOrientation"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["screenOrientation"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("screenOrientation"));
+        JToken? screenOrientation = serialized["screenOrientation"];
+        Assert.NotNull(screenOrientation);
+        Assert.Equal(JTokenType.Null, screenOrientation.Type);
+        Assert.Null(screenOrientation.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetScreenOrientationOverrideCommandParameters properties = new()
@@ -96,41 +106,43 @@ public class SetScreenOrientationOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenOrientation"));
-            Assert.That(serialized["screenOrientation"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["screenOrientation"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("screenOrientation"));
+        JToken? screenOrientation = serialized["screenOrientation"];
+        Assert.NotNull(screenOrientation);
+        Assert.Equal(JTokenType.Null, screenOrientation.Type);
+        Assert.Null(screenOrientation.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetScreenOrientationOverrideCommandParameters properties = SetScreenOrientationOverrideCommandParameters.ResetScreenOrientationOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.ScreenOrientation, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.ScreenOrientation);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetScreenOrientationOverrideCommandParameters firstInstance = SetScreenOrientationOverrideCommandParameters.ResetScreenOrientationOverride;
         SetScreenOrientationOverrideCommandParameters secondInstance = SetScreenOrientationOverrideCommandParameters.ResetScreenOrientationOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScreenOrientationOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScreenOrientationOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetScreenOrientationOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetScreenOrientationOverrideCommandResult? result = JsonSerializer.Deserialize<SetScreenOrientationOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetScreenOrientationOverrideCommandResult? result = JsonSerializer.Deserialize<SetScreenOrientationOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetScreenOrientationOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScreenSettingsOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScreenSettingsOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetScreenSettingsOverrideCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetScreenSettingsOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setScreenSettingsOverride"));
+        Assert.Equal("emulation.setScreenSettingsOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetScreenSettingsOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenArea"));
-            Assert.That(serialized["screenArea"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["screenArea"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("screenArea"));
+        JToken? screenArea = serialized["screenArea"];
+        Assert.NotNull(screenArea);
+        Assert.Equal(JTokenType.Null, screenArea.Type);
+        Assert.Null(screenArea.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDefaultScreenArea()
     {
         SetScreenSettingsOverrideCommandParameters properties = new()
@@ -37,23 +36,30 @@ public class SetScreenSettingsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenArea"));
-            Assert.That(serialized["screenArea"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? screenArea = serialized["screenArea"] as JObject;
-            Assert.That(screenArea, Has.Count.EqualTo(2));
-            Assert.That(screenArea, Contains.Key("width"));
-            Assert.That(screenArea!["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(screenArea!["width"]!.Value<ulong>, Is.EqualTo(0));
-            Assert.That(screenArea, Contains.Key("height"));
-            Assert.That(screenArea!["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(screenArea!["height"]!.Value<ulong>, Is.EqualTo(0));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("screenArea"));
+        JToken? screenAreaToken = serialized["screenArea"];
+        Assert.NotNull(screenAreaToken);
+        Assert.Equal(JTokenType.Object, screenAreaToken.Type);
+        JObject? screenAreaObject = screenAreaToken as JObject;
+        Assert.NotNull(screenAreaObject);
+        Assert.Equal(2, screenAreaObject.Count);
+
+        Assert.True(screenAreaObject.ContainsKey("width"));
+        JToken? width = screenAreaObject["width"];
+        Assert.NotNull(width);
+        Assert.Equal(JTokenType.Integer, width.Type);
+        Assert.Equal(0UL, width.Value<ulong>());
+
+        Assert.True(screenAreaObject.ContainsKey("height"));
+        JToken? height = screenAreaObject["height"];
+        Assert.NotNull(height);
+        Assert.Equal(JTokenType.Integer, height.Type);
+        Assert.Equal(0UL, height.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithScreenArea()
     {
         SetScreenSettingsOverrideCommandParameters properties = new()
@@ -66,23 +72,30 @@ public class SetScreenSettingsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenArea"));
-            Assert.That(serialized["screenArea"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? screenArea = serialized["screenArea"] as JObject;
-            Assert.That(screenArea, Has.Count.EqualTo(2));
-            Assert.That(screenArea, Contains.Key("width"));
-            Assert.That(screenArea!["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(screenArea!["width"]!.Value<ulong>, Is.EqualTo(1280));
-            Assert.That(screenArea, Contains.Key("height"));
-            Assert.That(screenArea!["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(screenArea!["height"]!.Value<ulong>, Is.EqualTo(1024));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("screenArea"));
+        JToken? screenAreaToken = serialized["screenArea"];
+        Assert.NotNull(screenAreaToken);
+        Assert.Equal(JTokenType.Object, screenAreaToken.Type);
+        JObject? screenAreaObject = screenAreaToken as JObject;
+        Assert.NotNull(screenAreaObject);
+        Assert.Equal(2, screenAreaObject.Count);
+
+        Assert.True(screenAreaObject.ContainsKey("width"));
+        JToken? width = screenAreaObject["width"];
+        Assert.NotNull(width);
+        Assert.Equal(JTokenType.Integer, width.Type);
+        Assert.Equal(1280UL, width.Value<ulong>());
+
+        Assert.True(screenAreaObject.ContainsKey("height"));
+        JToken? height = screenAreaObject["height"];
+        Assert.NotNull(height);
+        Assert.Equal(JTokenType.Integer, height.Type);
+        Assert.Equal(1024UL, height.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetScreenSettingsOverrideCommandParameters properties = new()
@@ -95,24 +108,28 @@ public class SetScreenSettingsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenArea"));
-            Assert.That(serialized["screenArea"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["screenArea"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("screenArea"));
+        JToken? screenArea = serialized["screenArea"];
+        Assert.NotNull(screenArea);
+        Assert.Equal(JTokenType.Null, screenArea.Type);
+        Assert.Null(screenArea.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetScreenSettingsOverrideCommandParameters properties = new()
@@ -125,41 +142,43 @@ public class SetScreenSettingsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("screenArea"));
-            Assert.That(serialized["screenArea"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["screenArea"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("screenArea"));
+        JToken? screenArea = serialized["screenArea"];
+        Assert.NotNull(screenArea);
+        Assert.Equal(JTokenType.Null, screenArea.Type);
+        Assert.Null(screenArea.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetScreenSettingsOverrideCommandParameters properties = SetScreenSettingsOverrideCommandParameters.ResetScreenSettingsOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.ScreenArea, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.ScreenArea);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetScreenSettingsOverrideCommandParameters firstInstance = SetScreenSettingsOverrideCommandParameters.ResetScreenSettingsOverride;
         SetScreenSettingsOverrideCommandParameters secondInstance = SetScreenSettingsOverrideCommandParameters.ResetScreenSettingsOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScreenSettingsOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScreenSettingsOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetScreenSettingsOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetScreenSettingsOverrideCommandResult? result = JsonSerializer.Deserialize<SetScreenSettingsOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetScreenSettingsOverrideCommandResult? result = JsonSerializer.Deserialize<SetScreenSettingsOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetScreenSettingsOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScriptingEnabledCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScriptingEnabledCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetScriptingEnabledCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetScriptingEnabledCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setScriptingEnabled"));
+        Assert.Equal("emulation.setScriptingEnabled", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetScriptingEnabledCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("enabled"));
-            Assert.That(serialized["enabled"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["enabled"]!.Value<bool?>(), Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("enabled"));
+        JToken? enabled = serialized["enabled"];
+        Assert.NotNull(enabled);
+        Assert.Equal(JTokenType.Null, enabled.Type);
+        Assert.Null(enabled.Value<bool?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEnabledTrue()
     {
         SetScriptingEnabledCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetScriptingEnabledCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("enabled"));
-            Assert.That(serialized["enabled"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["enabled"]!.Value<bool?>(), Is.True);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("enabled"));
+        JToken? enabled = serialized["enabled"];
+        Assert.NotNull(enabled);
+        Assert.Equal(JTokenType.Boolean, enabled.Type);
+        Assert.True(enabled.Value<bool?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEnabledFalse()
     {
         SetScriptingEnabledCommandParameters properties = new()
@@ -55,16 +54,16 @@ public class SetScriptingEnabledCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("enabled"));
-            Assert.That(serialized["enabled"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["enabled"]!.Value<bool?>(), Is.False);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("enabled"));
+        JToken? enabled = serialized["enabled"];
+        Assert.NotNull(enabled);
+        Assert.Equal(JTokenType.Boolean, enabled.Type);
+        Assert.False(enabled.Value<bool?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetScriptingEnabledCommandParameters properties = new()
@@ -77,24 +76,28 @@ public class SetScriptingEnabledCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("enabled"));
-            Assert.That(serialized["enabled"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["enabled"]!.Value<bool?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("enabled"));
+        JToken? enabled = serialized["enabled"];
+        Assert.NotNull(enabled);
+        Assert.Equal(JTokenType.Null, enabled.Type);
+        Assert.Null(enabled.Value<bool?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetScriptingEnabledCommandParameters properties = new()
@@ -107,41 +110,43 @@ public class SetScriptingEnabledCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("enabled"));
-            Assert.That(serialized["enabled"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["enabled"]!.Value<bool?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("enabled"));
+        JToken? enabled = serialized["enabled"];
+        Assert.NotNull(enabled);
+        Assert.Equal(JTokenType.Null, enabled.Type);
+        Assert.Null(enabled.Value<bool?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetScriptingEnabledCommandParameters properties = SetScriptingEnabledCommandParameters.ResetScriptingEnabled;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.IsScriptingEnabled, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.IsScriptingEnabled);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetScriptingEnabledCommandParameters firstInstance = SetScriptingEnabledCommandParameters.ResetScriptingEnabled;
         SetScriptingEnabledCommandParameters secondInstance = SetScriptingEnabledCommandParameters.ResetScriptingEnabled;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScriptingEnabledCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScriptingEnabledCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetScriptingEnabledCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetScriptingEnabledCommandResult? result = JsonSerializer.Deserialize<SetScriptingEnabledCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetScriptingEnabledCommandResult? result = JsonSerializer.Deserialize<SetScriptingEnabledCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetScriptingEnabledCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScrollbarTypeOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScrollbarTypeOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetScrollbarTypeOverrideCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetScrollbarTypeOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setScrollbarTypeOverride"));
+        Assert.Equal("emulation.setScrollbarTypeOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetScrollbarTypeOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("scrollbarType"));
-            Assert.That(serialized["scrollbarType"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["scrollbarType"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("scrollbarType"));
+        JToken? scrollbarType = serialized["scrollbarType"];
+        Assert.NotNull(scrollbarType);
+        Assert.Equal(JTokenType.Null, scrollbarType.Type);
+        Assert.Null(scrollbarType.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithClassicScrollbarType()
     {
         SetScrollbarTypeOverrideCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetScrollbarTypeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("scrollbarType"));
-            Assert.That(serialized["scrollbarType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["scrollbarType"]!.Value<string>(), Is.EqualTo("classic"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("scrollbarType"));
+        JToken? scrollbarType = serialized["scrollbarType"];
+        Assert.NotNull(scrollbarType);
+        Assert.Equal(JTokenType.String, scrollbarType.Type);
+        Assert.Equal("classic", scrollbarType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOverlayScrollbarType()
     {
         SetScrollbarTypeOverrideCommandParameters properties = new()
@@ -55,16 +54,16 @@ public class SetScrollbarTypeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("scrollbarType"));
-            Assert.That(serialized["scrollbarType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["scrollbarType"]!.Value<string>(), Is.EqualTo("overlay"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("scrollbarType"));
+        JToken? scrollbarType = serialized["scrollbarType"];
+        Assert.NotNull(scrollbarType);
+        Assert.Equal(JTokenType.String, scrollbarType.Type);
+        Assert.Equal("overlay", scrollbarType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetScrollbarTypeOverrideCommandParameters properties = new()
@@ -77,24 +76,28 @@ public class SetScrollbarTypeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("scrollbarType"));
-            Assert.That(serialized["scrollbarType"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["scrollbarType"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("scrollbarType"));
+        JToken? scrollbarType = serialized["scrollbarType"];
+        Assert.NotNull(scrollbarType);
+        Assert.Equal(JTokenType.Null, scrollbarType.Type);
+        Assert.Null(scrollbarType.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetScrollbarTypeOverrideCommandParameters properties = new()
@@ -107,41 +110,43 @@ public class SetScrollbarTypeOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("scrollbarType"));
-            Assert.That(serialized["scrollbarType"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["scrollbarType"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("scrollbarType"));
+        JToken? scrollbarType = serialized["scrollbarType"];
+        Assert.NotNull(scrollbarType);
+        Assert.Equal(JTokenType.Null, scrollbarType.Type);
+        Assert.Null(scrollbarType.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetScrollbarTypeOverrideCommandParameters properties = SetScrollbarTypeOverrideCommandParameters.ResetScrollbarTypeOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.ScrollbarType, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.ScrollbarType);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetScrollbarTypeOverrideCommandParameters firstInstance = SetScrollbarTypeOverrideCommandParameters.ResetScrollbarTypeOverride;
         SetScrollbarTypeOverrideCommandParameters secondInstance = SetScrollbarTypeOverrideCommandParameters.ResetScrollbarTypeOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetScrollbarTypeOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetScrollbarTypeOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetScrollbarTypeOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetScrollbarTypeOverrideCommandResult? result = JsonSerializer.Deserialize<SetScrollbarTypeOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetScrollbarTypeOverrideCommandResult? result = JsonSerializer.Deserialize<SetScrollbarTypeOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetScrollbarTypeOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetTimeZoneOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetTimeZoneOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetTimeZoneOverrideCoordinatesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetTimeZoneOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setTimezoneOverride"));
+        Assert.Equal("emulation.setTimezoneOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetTimeZoneOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("timezone"));
-            Assert.That(serialized["timezone"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["timezone"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("timezone"));
+        JToken? timezone = serialized["timezone"];
+        Assert.NotNull(timezone);
+        Assert.Equal(JTokenType.Null, timezone.Type);
+        Assert.Null(timezone.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithLocale()
     {
         SetTimeZoneOverrideCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetTimeZoneOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("timezone"));
-            Assert.That(serialized["timezone"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["timezone"]!.Value<string>(), Is.EqualTo("US/Eastern"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("timezone"));
+        JToken? timezone = serialized["timezone"];
+        Assert.NotNull(timezone);
+        Assert.Equal(JTokenType.String, timezone.Type);
+        Assert.Equal("US/Eastern", timezone.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetTimeZoneOverrideCommandParameters properties = new()
@@ -59,24 +58,28 @@ public class SetTimeZoneOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("timezone"));
-            Assert.That(serialized["timezone"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["timezone"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("timezone"));
+        JToken? timezone = serialized["timezone"];
+        Assert.NotNull(timezone);
+        Assert.Equal(JTokenType.Null, timezone.Type);
+        Assert.Null(timezone.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetTimeZoneOverrideCommandParameters properties = new()
@@ -89,41 +92,43 @@ public class SetTimeZoneOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("timezone"));
-            Assert.That(serialized["timezone"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["timezone"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("timezone"));
+        JToken? timezone = serialized["timezone"];
+        Assert.NotNull(timezone);
+        Assert.Equal(JTokenType.Null, timezone.Type);
+        Assert.Null(timezone.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetTimeZoneOverrideCommandParameters properties = SetTimeZoneOverrideCommandParameters.ResetTimeZoneOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.TimeZone, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.TimeZone);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetTimeZoneOverrideCommandParameters firstInstance = SetTimeZoneOverrideCommandParameters.ResetTimeZoneOverride;
         SetTimeZoneOverrideCommandParameters secondInstance = SetTimeZoneOverrideCommandParameters.ResetTimeZoneOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetTimeZoneOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetTimeZoneOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetTimeZoneOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetTimeZoneOverrideCommandResult? result = JsonSerializer.Deserialize<SetTimeZoneOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetTimeZoneOverrideCommandResult? result = JsonSerializer.Deserialize<SetTimeZoneOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetTimeZoneOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetTouchOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetTouchOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetTouchOverrideCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetTouchOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setTouchOverride"));
+        Assert.Equal("emulation.setTouchOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetTouchOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("maxTouchPoints"));
-            Assert.That(serialized["maxTouchPoints"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["maxTouchPoints"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("maxTouchPoints"));
+        JToken? maxTouchPoints = serialized["maxTouchPoints"];
+        Assert.NotNull(maxTouchPoints);
+        Assert.Equal(JTokenType.Null, maxTouchPoints.Type);
+        Assert.Null(maxTouchPoints.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithScreenOrientation()
     {
         SetTouchOverrideCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetTouchOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("maxTouchPoints"));
-            Assert.That(serialized["maxTouchPoints"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxTouchPoints"]!.Value<ulong>(), Is.EqualTo(100));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("maxTouchPoints"));
+        JToken? maxTouchPoints = serialized["maxTouchPoints"];
+        Assert.NotNull(maxTouchPoints);
+        Assert.Equal(JTokenType.Integer, maxTouchPoints.Type);
+        Assert.Equal(100UL, maxTouchPoints.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetTouchOverrideCommandParameters properties = new()
@@ -59,24 +58,28 @@ public class SetTouchOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("maxTouchPoints"));
-            Assert.That(serialized["maxTouchPoints"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["maxTouchPoints"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("maxTouchPoints"));
+        JToken? maxTouchPoints = serialized["maxTouchPoints"];
+        Assert.NotNull(maxTouchPoints);
+        Assert.Equal(JTokenType.Null, maxTouchPoints.Type);
+        Assert.Null(maxTouchPoints.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetTouchOverrideCommandParameters properties = new()
@@ -89,41 +92,43 @@ public class SetTouchOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("maxTouchPoints"));
-            Assert.That(serialized["maxTouchPoints"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["maxTouchPoints"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("maxTouchPoints"));
+        JToken? maxTouchPoints = serialized["maxTouchPoints"];
+        Assert.NotNull(maxTouchPoints);
+        Assert.Equal(JTokenType.Null, maxTouchPoints.Type);
+        Assert.Null(maxTouchPoints.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetTouchOverrideCommandParameters properties = SetTouchOverrideCommandParameters.ResetTouchOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.MaxTouchPoints, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.MaxTouchPoints);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetTouchOverrideCommandParameters firstInstance = SetTouchOverrideCommandParameters.ResetTouchOverride;
         SetTouchOverrideCommandParameters secondInstance = SetTouchOverrideCommandParameters.ResetTouchOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetTouchOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetTouchOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetTouchOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetTouchOverrideCommandResult? result = JsonSerializer.Deserialize<SetTouchOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetTouchOverrideCommandResult? result = JsonSerializer.Deserialize<SetTouchOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetTouchOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetUserAgentOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetUserAgentOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Emulation;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetUserAgentOverrideCoordinatesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetUserAgentOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("emulation.setUserAgentOverride"));
+        Assert.Equal("emulation.setUserAgentOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetUserAgentOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("userAgent"));
-            Assert.That(serialized["userAgent"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["userAgent"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("userAgent"));
+        JToken? userAgent = serialized["userAgent"];
+        Assert.NotNull(userAgent);
+        Assert.Equal(JTokenType.Null, userAgent.Type);
+        Assert.Null(userAgent.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithLocale()
     {
         SetUserAgentOverrideCommandParameters properties = new()
@@ -37,16 +36,16 @@ public class SetUserAgentOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("userAgent"));
-            Assert.That(serialized["userAgent"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userAgent"]!.Value<string>(), Is.EqualTo("WebDriverBiDi.NET/1.0 (no platform)"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("userAgent"));
+        JToken? userAgent = serialized["userAgent"];
+        Assert.NotNull(userAgent);
+        Assert.Equal(JTokenType.String, userAgent.Type);
+        Assert.Equal("WebDriverBiDi.NET/1.0 (no platform)", userAgent.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetUserAgentOverrideCommandParameters properties = new()
@@ -59,24 +58,28 @@ public class SetUserAgentOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("userAgent"));
-            Assert.That(serialized["userAgent"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["userAgent"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("userAgent"));
+        JToken? userAgent = serialized["userAgent"];
+        Assert.NotNull(userAgent);
+        Assert.Equal(JTokenType.Null, userAgent.Type);
+        Assert.Null(userAgent.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken.Value<JArray>();
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetUserAgentOverrideCommandParameters properties = new()
@@ -89,41 +92,43 @@ public class SetUserAgentOverrideCoordinatesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("userAgent"));
-            Assert.That(serialized["userAgent"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["userAgent"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("userAgent"));
+        JToken? userAgent = serialized["userAgent"];
+        Assert.NotNull(userAgent);
+        Assert.Equal(JTokenType.Null, userAgent.Type);
+        Assert.Null(userAgent.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken.Value<JArray>();
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetUserAgentOverrideCommandParameters properties = SetUserAgentOverrideCommandParameters.ResetUserAgentOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.UserAgent, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.UserAgent);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetUserAgentOverrideCommandParameters firstInstance = SetUserAgentOverrideCommandParameters.ResetUserAgentOverride;
         SetUserAgentOverrideCommandParameters secondInstance = SetUserAgentOverrideCommandParameters.ResetUserAgentOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Emulation/SetUserAgentOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/SetUserAgentOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Emulation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetUserAgentOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetUserAgentOverrideCommandResult? result = JsonSerializer.Deserialize<SetUserAgentOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetUserAgentOverrideCommandResult? result = JsonSerializer.Deserialize<SetUserAgentOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetUserAgentOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/ErrorResultTests.cs
+++ b/test/WebDriverBiDi.Tests/ErrorResultTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi;
 using System.Text.Json;
 using WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class ErrorResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateErrorResult()
     {
         // ErrorResult constructor is internal, so we will create it by
@@ -22,20 +21,18 @@ public class ErrorResultTests
                       }
                       """;
         ErrorResponseMessage? messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(messageResult, Is.Not.Null);
+        Assert.NotNull(messageResult);
         ErrorResult result = messageResult.GetErrorResponseData();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsError, Is.True);
-            Assert.That(result.ErrorType, Is.EqualTo("unknown error"));
-            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCode.UnknownError));
-            Assert.That(result.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(result.AdditionalData, Is.Empty);
-            Assert.That(result.StackTrace, Is.EqualTo("full stack trace"));
-        }
+
+        Assert.True(result.IsError);
+        Assert.Equal("unknown error", result.ErrorType);
+        Assert.Equal(ErrorCode.UnknownError, result.ErrorCode);
+        Assert.Equal("This is a test error message", result.ErrorMessage);
+        Assert.Empty(result.AdditionalData);
+        Assert.Equal("full stack trace", result.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         // ErrorResult constructor is internal, so we will create it by
@@ -51,9 +48,9 @@ public class ErrorResultTests
                       }
                       """;
         ErrorResponseMessage? messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(messageResult, Is.Not.Null);
+        Assert.NotNull(messageResult);
         ErrorResult result = messageResult.GetErrorResponseData();
         ErrorResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/EventDataCollectorTests.cs
+++ b/test/WebDriverBiDi.Tests/EventDataCollectorTests.cs
@@ -136,33 +136,36 @@ public class EventDataCollectorTests
         List<TestObservableEventArgs> drained = [];
 
         // Single reader drains concurrently with all writers.
-        Task readerTask = Task.Run(() =>
-        {
-            startBarrier.SignalAndWait();
-            while (!readerCts.IsCancellationRequested)
+        Task readerTask = Task.Run(
+            () =>
             {
-                drained.AddRange(collector.GetCollectedEventData());
-            }
+                startBarrier.SignalAndWait();
+                while (!readerCts.IsCancellationRequested)
+                {
+                    drained.AddRange(collector.GetCollectedEventData());
+                }
 
-            // Final drain: picks up anything enqueued between the last loop
-            // iteration and the writers completing.
-            drained.AddRange(collector.GetCollectedEventData());
-        }
-        , TestContext.Current.CancellationToken);
+                // Final drain: picks up anything enqueued between the last loop
+                // iteration and the writers completing.
+                drained.AddRange(collector.GetCollectedEventData());
+            },
+            TestContext.Current.CancellationToken);
 
         List<Task> writerTasks = [];
         for (int i = 0; i < writerCount; i++)
         {
             int writerId = i;
-            writerTasks.Add(Task.Run(async () =>
-            {
-                startBarrier.SignalAndWait();
-                for (int j = 0; j < eventsPerWriter; j++)
+            writerTasks.Add(Task.Run(
+                async () =>
                 {
-                    await testEventSource.RaiseTestEventAsync($"w{writerId}-e{j}");
-                }
-            },
-            TestContext.Current.CancellationToken));
+                    startBarrier.SignalAndWait();
+                    for (int j = 0; j < eventsPerWriter; j++)
+                    {
+                        await testEventSource.RaiseTestEventAsync($"w{writerId}-e{j}");
+                    }
+                },
+                TestContext.Current.CancellationToken)
+            );
         }
 
         // Cancel the reader only after all writers have finished — no new

--- a/test/WebDriverBiDi.Tests/EventDataCollectorTests.cs
+++ b/test/WebDriverBiDi.Tests/EventDataCollectorTests.cs
@@ -2,21 +2,20 @@ namespace WebDriverBiDi;
 
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class EventDataCollectorTests
 {
-    [Test]
+    [Fact]
     public async Task TestCanCaptureEventData()
     {
         TestEventSource testEventSource = new();
         await using EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         await testEventSource.RaiseTestEventAsync("myValue");
         IReadOnlyList<TestObservableEventArgs> eventArgsList = collector.GetCollectedEventData();
-        Assert.That(eventArgsList, Has.Count.EqualTo(1));
-        Assert.That(eventArgsList[0].EventValue, Is.EqualTo("myValue"));
+        Assert.Single(eventArgsList);
+        Assert.Equal("myValue", eventArgsList[0].EventValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanFilterCapturedEventData()
     {
         TestEventSource testEventSource = new();
@@ -24,12 +23,11 @@ public class EventDataCollectorTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
         IReadOnlyList<TestObservableEventArgs> eventArgsList = collector.GetCollectedEventData();
-        Assert.That(eventArgsList, Has.Count.EqualTo(1));
-        Assert.That(eventArgsList[0].EventValue, Is.EqualTo("myValue1"));
+        Assert.Single(eventArgsList);
+        Assert.Equal("myValue1", eventArgsList[0].EventValue);
     }
 
-
-    [Test]
+    [Fact]
     public async Task TestCanOnlyCaptureNewEventData()
     {
         TestEventSource testEventSource = new();
@@ -37,33 +35,30 @@ public class EventDataCollectorTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
         IReadOnlyList<TestObservableEventArgs> eventArgsList = collector.GetCollectedEventData();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgsList, Has.Count.EqualTo(2));
-            Assert.That(eventArgsList[0].EventValue, Is.EqualTo("myValue1"));
-            Assert.That(eventArgsList[1].EventValue, Is.EqualTo("myValue2"));
-        }
+
+        Assert.Equal(2, eventArgsList.Count);
+        Assert.Equal("myValue1", eventArgsList[0].EventValue);
+        Assert.Equal("myValue2", eventArgsList[1].EventValue);
+
         await testEventSource.RaiseTestEventAsync("myValue3");
         await testEventSource.RaiseTestEventAsync("myValue4");
         eventArgsList = collector.GetCollectedEventData();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgsList, Has.Count.EqualTo(2));
-            Assert.That(eventArgsList[0].EventValue, Is.EqualTo("myValue3"));
-            Assert.That(eventArgsList[1].EventValue, Is.EqualTo("myValue4"));
-        }
+
+        Assert.Equal(2, eventArgsList.Count);
+        Assert.Equal("myValue3", eventArgsList[0].EventValue);
+        Assert.Equal("myValue4", eventArgsList[1].EventValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReturnZeroEvents()
     {
         TestEventSource testEventSource = new();
         await using EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         IReadOnlyList<TestObservableEventArgs> eventArgsList = collector.GetCollectedEventData();
-        Assert.That(eventArgsList, Has.Count.Zero);
+        Assert.Empty(eventArgsList);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAsyncRemovesCollector()
     {
         TestEventSource testEventSource = new();
@@ -71,61 +66,61 @@ public class EventDataCollectorTests
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         await testEventSource.RaiseTestEventAsync("myValue1");
         IReadOnlyList<TestObservableEventArgs> eventArgsList = disposingCollector.GetCollectedEventData();
-        Assert.That(eventArgsList, Has.Count.EqualTo(1));
+        Assert.Single(eventArgsList);
 
         await disposingCollector.DisposeAsync();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
 
-        Assert.That(async () => await testEventSource.RaiseTestEventAsync("myValue2"), Throws.Nothing);
-        Assert.That(collector.GetCollectedEventData(), Has.Count.EqualTo(2));
+        await testEventSource.RaiseTestEventAsync("myValue2");
+        Assert.Equal(2, collector.GetCollectedEventData().Count);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAfterDisposeAsyncDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         await collector.DisposeAsync();
-        Assert.That(() => collector.Dispose(), Throws.Nothing);
+        collector.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeAsyncDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         await collector.DisposeAsync();
-        Assert.That(async () => await collector.DisposeAsync(), Throws.Nothing);
+        await collector.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAsyncAfterDisposeDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         collector.Dispose();
-        Assert.That(async () => await collector.DisposeAsync(), Throws.Nothing);
+        await collector.DisposeAsync();
     }
 
-    [Test]
-    public void TestGettingCollectedDataAfterDisposeThrows()
+    [Fact]
+    public async Task TestGettingCollectedDataAfterDisposeThrows()
     {
         TestEventSource testEventSource = new();
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         collector.Dispose();
-        Assert.That(() => collector.GetCollectedEventData(), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.ThrowsAny<ObjectDisposedException>(() => collector.GetCollectedEventData());
     }
 
-    [Test]
+    [Fact]
     public async Task TestGettingCollectedDataAfterDisposeAsyncThrows()
     {
         TestEventSource testEventSource = new();
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         await collector.DisposeAsync();
-        Assert.That(() => collector.GetCollectedEventData(), Throws.InstanceOf<ObjectDisposedException>());
+        Assert.ThrowsAny<ObjectDisposedException>(() => collector.GetCollectedEventData());
     }
 
-    [Test]
+    [Fact]
     public async Task TestConcurrentEnqueueAndDrainYieldsAllItems()
     {
         const int writerCount = 4;
@@ -152,7 +147,8 @@ public class EventDataCollectorTests
             // Final drain: picks up anything enqueued between the last loop
             // iteration and the writers completing.
             drained.AddRange(collector.GetCollectedEventData());
-        });
+        }
+        , TestContext.Current.CancellationToken);
 
         List<Task> writerTasks = [];
         for (int i = 0; i < writerCount; i++)
@@ -165,7 +161,8 @@ public class EventDataCollectorTests
                 {
                     await testEventSource.RaiseTestEventAsync($"w{writerId}-e{j}");
                 }
-            }));
+            },
+            TestContext.Current.CancellationToken));
         }
 
         // Cancel the reader only after all writers have finished — no new
@@ -174,26 +171,26 @@ public class EventDataCollectorTests
         readerCts.Cancel();
         await readerTask;
 
-        Assert.That(drained, Has.Count.EqualTo(totalEvents));
+        Assert.Equal(totalEvents, drained.Count);
     }
 
-    [Test]
+    [Fact]
     public async Task TestToStringReturnsDescription()
     {
         TestEventSource testEventSource = new();
         await using EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector(description: "My first data collector");
-        Assert.That(collector.ToString(), Is.EqualTo("My first data collector"));
+        Assert.Equal("My first data collector", collector.ToString());
     }
 
-    [Test]
+    [Fact]
     public async Task TestToStringReturnsDefaultDescription()
     {
         TestEventSource testEventSource = new();
         await using EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
-        Assert.That(collector.ToString(), Does.StartWith("EventDataCollector<TestObservableEventArgs> (id:"));
+        Assert.StartsWith("EventDataCollector<TestObservableEventArgs> (id:", collector.ToString());
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventsYieldsBufferedItemsInOrder()
     {
         TestEventSource testEventSource = new();
@@ -211,16 +208,13 @@ public class EventDataCollectorTests
             }
         }
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(received, Has.Count.EqualTo(3));
-            Assert.That(received[0].EventValue, Is.EqualTo("value1"));
-            Assert.That(received[1].EventValue, Is.EqualTo("value2"));
-            Assert.That(received[2].EventValue, Is.EqualTo("value3"));
-        }
+        Assert.Equal(3, received.Count);
+        Assert.Equal("value1", received[0].EventValue);
+        Assert.Equal("value2", received[1].EventValue);
+        Assert.Equal("value3", received[2].EventValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventsRespectsFilter()
     {
         TestEventSource testEventSource = new();
@@ -234,11 +228,11 @@ public class EventDataCollectorTests
             break;
         }
 
-        Assert.That(received, Has.Count.EqualTo(1));
-        Assert.That(received[0].EventValue, Is.EqualTo("myValue1"));
+        Assert.Single(received);
+        Assert.Equal("myValue1", received[0].EventValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventsTerminatesAndDrainsBufferWhenCollectorDisposed()
     {
         TestEventSource testEventSource = new();
@@ -255,30 +249,27 @@ public class EventDataCollectorTests
             received.Add(args);
         }
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(received, Has.Count.EqualTo(2));
-            Assert.That(received[0].EventValue, Is.EqualTo("value1"));
-            Assert.That(received[1].EventValue, Is.EqualTo("value2"));
-        }
+        Assert.Equal(2, received.Count);
+        Assert.Equal("value1", received[0].EventValue);
+        Assert.Equal("value2", received[1].EventValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventsCancellationTokenCancelsIteration()
     {
         TestEventSource testEventSource = new();
         await using EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         using CancellationTokenSource cts = new();
         cts.Cancel();
-        Assert.That(async () =>
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
             await foreach (TestObservableEventArgs _ in collector.Events.WithCancellation(cts.Token))
             {
             }
-        }, Throws.InstanceOf<OperationCanceledException>());
+        });
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventsAndGetCollectedEventDataShareBuffer()
     {
         TestEventSource testEventSource = new();
@@ -296,12 +287,10 @@ public class EventDataCollectorTests
 
         // GetCollectedEventData only sees the remaining item
         IReadOnlyList<TestObservableEventArgs> fromDrain = collector.GetCollectedEventData();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(fromEvents, Has.Count.EqualTo(1));
-            Assert.That(fromDrain, Has.Count.EqualTo(1));
-            Assert.That(fromEvents[0].EventValue, Is.EqualTo("value1"));
-            Assert.That(fromDrain[0].EventValue, Is.EqualTo("value2"));
-        }
+
+        Assert.Single(fromEvents);
+        Assert.Single(fromDrain);
+        Assert.Equal("value1", fromEvents[0].EventValue);
+        Assert.Equal("value2", fromDrain[0].EventValue);
     }
 }

--- a/test/WebDriverBiDi.Tests/EventHandlerErrorOccurredEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/EventHandlerErrorOccurredEventArgsTests.cs
@@ -1,9 +1,8 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class EventHandlerErrorOccurredEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateEventArgs()
     {
         EventObserverErrorInfo errorInfo = new EventObserverErrorInfo
@@ -18,10 +17,10 @@ public class EventHandlerErrorOccurredEventArgsTests
 
         EventHandlerErrorOccurredEventArgs eventArgs = new EventHandlerErrorOccurredEventArgs(errorInfo);
 
-        Assert.That(eventArgs.ErrorInfo, Is.EqualTo(errorInfo));
+        Assert.Equal(errorInfo, eventArgs.ErrorInfo);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         EventObserverErrorInfo errorInfo = new EventObserverErrorInfo
@@ -37,11 +36,11 @@ public class EventHandlerErrorOccurredEventArgsTests
         EventHandlerErrorOccurredEventArgs eventArgs = new EventHandlerErrorOccurredEventArgs(errorInfo);
         EventHandlerErrorOccurredEventArgs copy = eventArgs with { };
 
-        Assert.That(eventArgs, Is.EqualTo(copy));
-        Assert.That(copy, Is.Not.SameAs(eventArgs));
+        Assert.Equal(copy, eventArgs);
+        Assert.NotSame(eventArgs, copy);
 
         EventObserverErrorInfo copyErrorInfo = copy.ErrorInfo with { };
-        Assert.That(copyErrorInfo, Is.EqualTo(copy.ErrorInfo));
-        Assert.That(copyErrorInfo, Is.Not.SameAs(copy.ErrorInfo));
+        Assert.Equal(copy.ErrorInfo, copyErrorInfo);
+        Assert.NotSame(copy.ErrorInfo, copyErrorInfo);
     }
 }

--- a/test/WebDriverBiDi.Tests/EventInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/EventInfoTests.cs
@@ -2,64 +2,55 @@ namespace WebDriverBiDi;
 
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class EventInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateEventArgsFromEventInfo()
     {
         EventInfo<TestEventArgs> eventInfo = new(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
         TestEventArgs eventArgs = eventInfo.ToEventArgs<TestEventArgs>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.ParamName, Is.EqualTo("paramValue"));
-            Assert.That(eventArgs.AdditionalData, Has.Count.EqualTo(0));
-            Assert.That(eventArgs with { }, Is.EqualTo(eventArgs));
-        }
+
+        Assert.Equal("paramValue", eventArgs.ParamName);
+        Assert.Empty(eventArgs.AdditionalData);
+        Assert.Equal(eventArgs, eventArgs with { });
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToInvalidTypeThrows()
     {
         EventInfo<TestInvalidEventData> eventInfo = new(new TestInvalidEventData(), ReceivedDataDictionary.EmptyDictionary);
-        Assert.That(() => eventInfo.ToEventArgs<TestParameterizedEventArgs>(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("Could not produce an EventArgs of type"));
+        Assert.Contains("Could not produce an EventArgs of type", Assert.ThrowsAny<WebDriverBiDiException>(() => eventInfo.ToEventArgs<TestParameterizedEventArgs>()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateEventArgsFromFactoryWithSameType()
     {
         EventInfo<TestEventArgs> eventInfo = new(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
         TestEventArgs eventArgs = eventInfo.ToEventArgs(data => data);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.ParamName, Is.EqualTo("paramValue"));
-            Assert.That(eventArgs.AdditionalData, Has.Count.EqualTo(0));
-        }
+
+        Assert.Equal("paramValue", eventArgs.ParamName);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateEventArgsFromFactoryWithDifferentType()
     {
         EventInfo<TestValidEventData> eventInfo = new(new TestValidEventData("eventName"), ReceivedDataDictionary.EmptyDictionary);
         TestParameterizedEventArgs eventArgs = eventInfo.ToEventArgs(data => new TestParameterizedEventArgs(data));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.EventName, Is.EqualTo("eventName"));
-            Assert.That(eventArgs.AdditionalData, Has.Count.EqualTo(0));
-        }
+
+        Assert.Equal("eventName", eventArgs.EventName);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestFactoryOverloadSetsAdditionalData()
     {
         Dictionary<string, object?> additionalDataValues = new() { ["extra"] = "value" };
         ReceivedDataDictionary additionalData = new(additionalDataValues);
         EventInfo<TestEventArgs> eventInfo = new(new TestEventArgs(), additionalData);
         TestEventArgs eventArgs = eventInfo.ToEventArgs(data => data);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(eventArgs.AdditionalData["extra"], Is.EqualTo("value"));
-        }
+
+        Assert.Single(eventArgs.AdditionalData);
+        Assert.Equal("value", eventArgs.AdditionalData["extra"]);
     }
 }

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -503,22 +503,44 @@ public class EventObserverTests
     {
         // Two concurrent callers each asking for 3 tasks should receive unique,
         // non-interleaved batches — one gets tasks 1-3, the other gets tasks 4-6.
+        //
+        // Determinism guarantee: same technique as
+        // TestWaitForCapturedTasksAsyncDoesNotRemovePendingTasksWhenConcurrentWaiterIsActive.
+        // Prime with one event so waiter1 is inside its read loop (holding the semaphore,
+        // waiting for its 2nd and 3rd tasks). waiter2 must then have already incremented
+        // waitingReaderCount before we raise the remaining events. Raise 5 more: waiter1
+        // collects 2 (completing its batch of 3), waiter2 collects 3.
+        TaskCompletionSource firstTaskConsumedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int taskCount = 0;
         TestEventSource testEventSource = new();
 
         // Local function typed as Task so the Func<T,Task> overload is chosen rather than
         // Action<T>. An Action<T> wrapper always returns Task.CompletedTask (a singleton), which
         // would collapse all tasks in the HashSet to a count of 1. Task.FromResult(Guid.NewGuid())
         // creates a distinct Task<Guid> object on every invocation.
-        static Task DistinctTaskHandler(TestObservableEventArgs _) => Task.FromResult(Guid.NewGuid());
+        Task DistinctTaskHandler(TestObservableEventArgs _)
+        {
+            if (Interlocked.Increment(ref taskCount) == 1)
+            {
+                firstTaskConsumedTaskCompletionSource.TrySetResult();
+            }
+
+            return Task.FromResult(Guid.NewGuid());
+        }
+
         await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(DistinctTaskHandler);
         observer.StartCapturingTasks();
 
-        // Start both waiters before any events are raised.
+        // Start waiter1, raise one priming event so it is inside its read loop
+        // waiting for tasks 2 and 3, then start waiter2.
         Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await testEventSource.RaiseTestEventAsync("prime");
+        await firstTaskConsumedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        // Raise 6 events so both waiters can be satisfied.
-        for (int i = 0; i < 6; i++)
+        // Raise 5 more events: waiter1 gets 2 (completing its batch of 3),
+        // waiter2 gets 3 (its full batch).
+        for (int i = 0; i < 5; i++)
         {
             await testEventSource.RaiseTestEventAsync($"value{i}");
         }

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -504,43 +504,25 @@ public class EventObserverTests
         // Two concurrent callers each asking for 3 tasks should receive unique,
         // non-interleaved batches — one gets tasks 1-3, the other gets tasks 4-6.
         //
-        // Determinism guarantee: same technique as
-        // TestWaitForCapturedTasksAsyncDoesNotRemovePendingTasksWhenConcurrentWaiterIsActive.
-        // Prime with one event so waiter1 is inside its read loop (holding the semaphore,
-        // waiting for its 2nd and 3rd tasks). waiter2 must then have already incremented
-        // waitingReaderCount before we raise the remaining events. Raise 5 more: waiter1
-        // collects 2 (completing its batch of 3), waiter2 collects 3.
-        TaskCompletionSource firstTaskConsumedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        int taskCount = 0;
+        // Determinism guarantee: waitingReaderCount++ executes synchronously under
+        // captureLock before the first await in WaitForCapturedTasksAsync. Starting
+        // both waiters before raising any events guarantees waitingReaderCount == 2
+        // when the first task is written to the channel.
         TestEventSource testEventSource = new();
 
         // Local function typed as Task so the Func<T,Task> overload is chosen rather than
         // Action<T>. An Action<T> wrapper always returns Task.CompletedTask (a singleton), which
         // would collapse all tasks in the HashSet to a count of 1. Task.FromResult(Guid.NewGuid())
         // creates a distinct Task<Guid> object on every invocation.
-        Task DistinctTaskHandler(TestObservableEventArgs _)
-        {
-            if (Interlocked.Increment(ref taskCount) == 1)
-            {
-                firstTaskConsumedTaskCompletionSource.TrySetResult();
-            }
-
-            return Task.FromResult(Guid.NewGuid());
-        }
+        static Task DistinctTaskHandler(TestObservableEventArgs _) => Task.FromResult(Guid.NewGuid());
 
         await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(DistinctTaskHandler);
         observer.StartCapturingTasks();
 
-        // Start waiter1, raise one priming event so it is inside its read loop
-        // waiting for tasks 2 and 3, then start waiter2.
         Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-        await testEventSource.RaiseTestEventAsync("prime");
-        await firstTaskConsumedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        // Raise 5 more events: waiter1 gets 2 (completing its batch of 3),
-        // waiter2 gets 3 (its full batch).
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 6; i++)
         {
             await testEventSource.RaiseTestEventAsync($"value{i}");
         }
@@ -744,40 +726,20 @@ public class EventObserverTests
         // the first to finish must NOT drain the channel — those tasks belong to the
         // second waiter.
         //
-        // Determinism guarantee: both waiters need to have incremented waitingReaderCount
-        // before the final events are raised. We achieve this by priming with one event
-        // before starting waiter2. By the time waiter1 has consumed the first primed task
-        // (observable via firstTaskConsumedTaskCompletionSource), it holds the semaphore
-        // and is blocking inside WaitToReadAsync waiting for its second task. waiter2 must
-        // therefore have already completed its synchronous preamble (incrementing
-        // waitingReaderCount) and be blocked on captureReadSemaphore.WaitAsync. Both are
-        // registered as active readers before the remaining events are raised.
-        TaskCompletionSource firstTaskConsumedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        int taskCount = 0;
+        // Determinism guarantee: waitingReaderCount++ executes synchronously under
+        // captureLock before the first await in WaitForCapturedTasksAsync. Starting
+        // both waiters before raising any events guarantees waitingReaderCount == 2
+        // when the first task is written to the channel.
         TestEventSource testEventSource = new();
-        Task DistinctTaskHandler(TestObservableEventArgs _)
-        {
-            if (Interlocked.Increment(ref taskCount) == 1)
-            {
-                firstTaskConsumedTaskCompletionSource.TrySetResult();
-            }
-
-            return Task.FromResult(Guid.NewGuid());
-        }
+        static Task DistinctTaskHandler(TestObservableEventArgs _) => Task.FromResult(Guid.NewGuid());
 
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(DistinctTaskHandler);
         observer.StartCapturingTasks();
 
-        // Start waiter1, raise one priming event so it is inside its read loop
-        // waiting for a second task, then start waiter2.
         Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-        await testEventSource.RaiseTestEventAsync("prime");
-        await firstTaskConsumedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        // Raise 3 more events: waiter1 gets 1 (to complete its batch of 2),
-        // waiter2 gets 2 (its full batch).
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 4; i++)
         {
             await testEventSource.RaiseTestEventAsync($"value{i}");
         }
@@ -788,8 +750,6 @@ public class EventObserverTests
         Assert.Equal(2, results[1].Length);
         HashSet<Task> all = [.. results[0], .. results[1]];
         Assert.Equal(4, all.Count);
-
-        observer.StopCapturingTasks();
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -1,115 +1,116 @@
 namespace WebDriverBiDi;
 
+using System.Collections.ObjectModel;
 using Microsoft.Extensions.Time.Testing;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
+[Collection("EventSourceTests")]
 public class EventObserverTests
 {
-    [Test]
+    [Fact]
     public async Task TestObserverCanHandleObservableEvent()
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
         await testEventSource.RaiseTestEventAsync("myValue");
-        Assert.That(observedValue, Is.Not.Null);
-        Assert.That(observedValue, Is.EqualTo("myValue"));
+        Assert.NotNull(observedValue);
+        Assert.Equal("myValue", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAfterDisposeAsyncDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
         await observer.DisposeAsync();
-        Assert.That(() => observer.Dispose(), Throws.Nothing);
+        observer.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeAsyncDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
         await observer.DisposeAsync();
-        Assert.That(async () => await observer.DisposeAsync(), Throws.Nothing);
+        await observer.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAsyncAfterDisposeDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
         observer.Dispose();
-        Assert.That(async () => await observer.DisposeAsync(), Throws.Nothing);
+        await observer.DisposeAsync();
     }
 
-    [Test]
-    public void TestIsCapturingReturnsFalseWhenNotCapturing()
+    [Fact]
+    public async Task TestIsCapturingReturnsFalseWhenNotCapturing()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
-        Assert.That(observer.IsCapturing, Is.False);
+        Assert.False(observer.IsCapturing);
     }
 
-    [Test]
-    public void TestIsCapturingReturnsTrueWhenCapturing()
-    {
-        TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
-        observer.StartCapturingTasks();
-        Assert.That(observer.IsCapturing, Is.True);
-        observer.StopCapturingTasks();
-    }
-
-    [Test]
-    public void TestStartCapturingWithActiveCaptureThrows()
+    [Fact]
+    public async Task TestIsCapturingReturnsTrueWhenCapturing()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
-        Assert.That(() => observer.StartCapturingTasks(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("already has an active capture session"));
+        Assert.True(observer.IsCapturing);
         observer.StopCapturingTasks();
     }
 
-    [Test]
-    public void TestStopCapturingWithoutStartCapturingIsNoOp()
+    [Fact]
+    public async Task TestStartCapturingWithActiveCaptureThrows()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
-        Assert.That(() => observer.StopCapturingTasks(), Throws.Nothing);
-        Assert.That(observer.IsCapturing, Is.False);
+        observer.StartCapturingTasks();
+        Assert.Contains("already has an active capture session", Assert.ThrowsAny<WebDriverBiDiException>(() => observer.StartCapturingTasks()).Message);
+        observer.StopCapturingTasks();
     }
 
-    [Test]
-    public void TestCallingStopCapturingRepeatedlyDoesNotThrow()
+    [Fact]
+    public async Task TestStopCapturingWithoutStartCapturingIsNoOp()
+    {
+        TestEventSource testEventSource = new();
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        observer.StopCapturingTasks();
+        Assert.False(observer.IsCapturing);
+    }
+
+    [Fact]
+    public async Task TestCallingStopCapturingRepeatedlyDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
         observer.StopCapturingTasks();
-        Assert.That(() => observer.StopCapturingTasks(), Throws.Nothing);
+        observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncCountZeroThrows()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
-        Assert.That(async () => await observer.WaitForCapturedTasksAsync(0, TimeSpan.FromMilliseconds(100)), Throws.InstanceOf<ArgumentException>().With.Message.Contains("must be greater than 0"));
+        Assert.Contains("must be greater than 0", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await observer.WaitForCapturedTasksAsync(0, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken))).Message);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncWithoutStartCapturingThrows()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
-        Assert.That(async () => await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromMilliseconds(100)), Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("No capture session is active"));
+        Assert.Contains("No capture session is active", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsync()
     {
         TestEventSource testEventSource = new();
@@ -117,12 +118,12 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromMilliseconds(100));
-        Assert.That(tasks, Has.Length.EqualTo(2));
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(2, tasks.Length);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncCanTimeout()
     {
         TimeSpan timeout = TimeSpan.FromSeconds(1);
@@ -134,16 +135,16 @@ public class EventObserverTests
 
         // WaitForCapturedTasksAsync is now suspended at WaitToReadAsync with 1 of 2 tasks
         // collected and its CTS timer registered with fakeTimeProvider.
-        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, timeout);
+        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
         fakeTimeProvider.Advance(timeout + TimeSpan.FromMilliseconds(1));
         Task[] tasks = await waitTask;
 
-        Assert.That(tasks, Has.Length.EqualTo(1));
-        Assert.That(observer.IsCapturing, Is.True);
+        _ = Assert.Single(tasks);
+        Assert.True(observer.IsCapturing);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncCanBeCancelled()
     {
         CancellationTokenSource cancellationTokenSource = new();
@@ -153,32 +154,32 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         Task waitTask = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
-        Assert.That(async () => await waitTask, Throws.InstanceOf<OperationCanceledException>().With.Message.Contains("Wait cancelled waiting for captured event handler tasks"));
-        Assert.That(observer.IsCapturing, Is.True);
+        Assert.Contains("Wait cancelled waiting for captured event handler tasks", (await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await waitTask)).Message);
+        Assert.True(observer.IsCapturing);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestGetCapturedTasksWithWithoutStartCaptureReturnsEmptyArray()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         Task[] tasks = observer.GetCapturedTasks();
-        Assert.That(tasks, Is.Empty);
+        Assert.Empty(tasks);
     }
 
-    [Test]
+    [Fact]
     public async Task TestGetCapturedTasksWithActiveCaptureAndNoTasksReturnsEmptyArray()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
         Task[] tasks = observer.GetCapturedTasks();
-        Assert.That(tasks, Is.Empty);
+        Assert.Empty(tasks);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestGetCapturedTasksWithActiveCaptureReturnsPendingTasks()
     {
         TestEventSource testEventSource = new();
@@ -187,11 +188,11 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
         Task[] tasks = observer.GetCapturedTasks();
-        Assert.That(tasks, Has.Length.EqualTo(2));
+        Assert.Equal(2, tasks.Length);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsync()
     {
         TestEventSource testEventSource = new();
@@ -199,12 +200,12 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
-        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100));
-        Assert.That(fulfilled, Is.True);
+        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(fulfilled);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncCanTimeout()
     {
         TimeSpan timeout = TimeSpan.FromSeconds(1);
@@ -214,16 +215,16 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
 
-        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout);
+        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
         fakeTimeProvider.Advance(timeout + TimeSpan.FromMilliseconds(1));
         bool fulfilled = await waitTask;
 
-        Assert.That(fulfilled, Is.False);
-        Assert.That(observer.IsCapturing, Is.True);
+        Assert.False(fulfilled);
+        Assert.True(observer.IsCapturing);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncCanBeCancelledWaitingForTaskCapture()
     {
         CancellationTokenSource cancellationTokenSource = new();
@@ -233,12 +234,12 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         Task waitTask = observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
-        Assert.That(async () => await waitTask, Throws.InstanceOf<OperationCanceledException>().With.Message.Contains("Wait cancelled waiting for captured event handler tasks"));
-        Assert.That(observer.IsCapturing, Is.True);
+        Assert.Contains("Wait cancelled waiting for captured event handler tasks", (await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await waitTask)).Message);
+        Assert.True(observer.IsCapturing);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncCanBeCancelledWaitingForTaskCompletion()
     {
         CountdownEvent countdownEvent = new(2);
@@ -257,18 +258,18 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue2");
 
         // Ensure both handlers have started before cancelling.
-        countdownEvent.Wait();
+        countdownEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
 
         Task waitTask = observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
-        Assert.That(async () => await waitTask, Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await waitTask);
 
         // WaitForAsync auto-closes the channel once count tasks are collected, so
         // IsCapturing is false by the time the task-completion wait is cancelled.
-        Assert.That(observer.IsCapturing, Is.False);
+        Assert.False(observer.IsCapturing);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncReturnsFalseWhenNoRemainingTimeAfterCapture()
     {
         TimeSpan timeout = TimeSpan.FromSeconds(1);
@@ -283,15 +284,15 @@ public class EventObserverTests
         // Advancing the fake clock fires its CTS, causing it to time out and return the 1 task it
         // collected. tasksToWait.Length (1) != count (2), so WaitForCapturedTasksCompleteAsync
         // returns false via the final line without entering the remainingTime branch.
-        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout);
+        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
         fakeTimeProvider.Advance(timeout + TimeSpan.FromMilliseconds(1));
         bool fulfilled = await waitTask;
 
-        Assert.That(fulfilled, Is.False);
+        Assert.False(fulfilled);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncReturnsFalseWhenExecutionTimesOut()
     {
         CountdownEvent countdownEvent = new(2);
@@ -310,16 +311,16 @@ public class EventObserverTests
 
         // Ensure both handlers have started before waiting, so capture completes
         // immediately and the remaining timeout is spent waiting for slow execution.
-        countdownEvent.Wait();
+        countdownEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
 
-        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100));
-        Assert.That(fulfilled, Is.False);
+        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(fulfilled);
 
         // Capture session is auto-closed once count tasks are collected.
-        Assert.That(observer.IsCapturing, Is.False);
+        Assert.False(observer.IsCapturing);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncReturnsFalseWhenTimeExpiredDuringCapture()
     {
         TimeSpan timeout = TimeSpan.FromSeconds(1);
@@ -339,16 +340,13 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
 
-        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, timeout);
+        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(fulfilled, Is.False);
-            Assert.That(observer.IsCapturing, Is.False);
-        }
+        Assert.False(fulfilled);
+        Assert.False(observer.IsCapturing);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncPropagatesHandlerException()
     {
         TestEventSource testEventSource = new();
@@ -365,33 +363,33 @@ public class EventObserverTests
         {
         }
 
-        Assert.That(async () => await observer.WaitForCapturedTasksCompleteAsync(1, TimeSpan.FromMilliseconds(100)), Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("capture failure"));
+        Assert.Equal("capture failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksCompleteAsync(1, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken))).Message);
         observer.StopCapturingTasks();
     }
 
-    [Test]
-    public void TestDisposeWithActiveCaptureDoesNotThrow()
+    [Fact]
+    public async Task TestDisposeWithActiveCaptureDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
-        Assert.That(observer.IsCapturing, Is.True);
-        Assert.That(() => observer.Dispose(), Throws.Nothing);
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.True(observer.IsCapturing);
+        observer.Dispose();
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAsyncWithActiveCaptureDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
-        Assert.That(observer.IsCapturing, Is.True);
-        Assert.That(async () => await observer.DisposeAsync(), Throws.Nothing);
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.True(observer.IsCapturing);
+        await observer.DisposeAsync();
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCapturingTasksFromSynchronousHandler()
     {
         TestEventSource testEventSource = new();
@@ -401,12 +399,12 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue");
         Task[] tasks = observer.GetCapturedTasks();
-        Assert.That(tasks, Has.Length.EqualTo(1));
-        Assert.That(tasks[0].IsCompletedSuccessfully, Is.True);
+        _ = Assert.Single(tasks);
+        Assert.True(tasks[0].IsCompletedSuccessfully);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCapturingTasksFromAsynchronousHandler()
     {
         bool handlerCompleted = false;
@@ -423,17 +421,17 @@ public class EventObserverTests
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue");
-        handlerReachedGate.Wait(TimeSpan.FromSeconds(5));
+        handlerReachedGate.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Task[] tasks = observer.GetCapturedTasks();
-        Assert.That(tasks, Has.Length.EqualTo(1));
-        Assert.That(tasks[0].IsCompleted, Is.False, "Captured task should still be running");
+        _ = Assert.Single(tasks);
+        Assert.False(tasks[0].IsCompleted);
         handlerGate.SetResult();
         await tasks[0];
-        Assert.That(handlerCompleted, Is.True);
+        Assert.True(handlerCompleted);
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsynchronousHandlerExceptionCanBeCaptured()
     {
         bool unobservedExceptionRaised = false;
@@ -460,10 +458,10 @@ public class EventObserverTests
             await testEventSource.RaiseTestEventAsync("myValue");
 
             Task[] tasks = observer.GetCapturedTasks();
-            Assert.That(tasks, Has.Length.EqualTo(1));
+            _ = Assert.Single(tasks);
 
             // Wait for the handler to fault before triggering GC.
-            handlerFaulted.Wait(TimeSpan.FromSeconds(5));
+            handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -471,9 +469,12 @@ public class EventObserverTests
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unobservedExceptionRaised, Is.False, "Captured task exception should be observed by caller, not by the error reporter");
-            Assert.That(tasks[0].IsFaulted, Is.True);
-            Assert.That(tasks[0].Exception!.InnerException, Is.InstanceOf<InvalidOperationException>().With.Message.EqualTo("async capture failure"));
+            Assert.False(unobservedExceptionRaised);
+            Assert.True(tasks[0].IsFaulted);
+            AggregateException? aggregateException = tasks[0].Exception;
+            Assert.NotNull(aggregateException);
+            InvalidOperationException innerException = Assert.IsType<InvalidOperationException>(aggregateException.InnerException);
+            Assert.Equal("async capture failure", innerException.Message);
 
             observer.StopCapturingTasks();
         }
@@ -483,7 +484,7 @@ public class EventObserverTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestConcurrentWaitForForCapturedTasksAsyncCallsGetUniqueBatches()
     {
         // Two concurrent callers each asking for 3 tasks should receive unique,
@@ -499,8 +500,8 @@ public class EventObserverTests
         observer.StartCapturingTasks();
 
         // Start both waiters before any events are raised.
-        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5));
-        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5));
+        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         // Raise 6 events so both waiters can be satisfied.
         for (int i = 0; i < 6; i++)
@@ -512,18 +513,15 @@ public class EventObserverTests
         Task[] batch1 = results[0];
         Task[] batch2 = results[1];
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(batch1, Has.Length.EqualTo(3), "first waiter should receive exactly 3 tasks");
-            Assert.That(batch2, Has.Length.EqualTo(3), "second waiter should receive exactly 3 tasks");
+        Assert.Equal(3, batch1.Length);
+        Assert.Equal(3, batch2.Length);
 
-            // Every task should appear exactly once across both batches.
-            HashSet<Task> allTasks = [.. batch1, .. batch2];
-            Assert.That(allTasks, Has.Count.EqualTo(6), "no task should appear in both batches");
-        }
+        // Every task should appear exactly once across both batches.
+        HashSet<Task> allTasks = [.. batch1, .. batch2];
+        Assert.Equal(6, allTasks.Count);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncUnblocksOnStopCapturing()
     {
         // WaitForAsync blocked waiting for 3 tasks should return early (with however
@@ -534,16 +532,16 @@ public class EventObserverTests
 
         // Raise only 1 event, then start a waiter that needs 3.
         await testEventSource.RaiseTestEventAsync("value1");
-        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(10));
+        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
 
         // Stop the capture session from another thread — waiter should unblock.
         observer.StopCapturingTasks();
 
         Task[] tasks = await waitTask;
-        Assert.That(tasks, Has.Length.EqualTo(1), "should return the 1 task that arrived before StopCapturing");
+        _ = Assert.Single(tasks);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForAsyncAutoCloseWithStopCapturingAfterCountReached()
     {
         // Covers the ReferenceEquals-false branch inside WaitForAsync's auto-close block:
@@ -562,19 +560,16 @@ public class EventObserverTests
 
         // WaitForAsync(2) will collect both tasks and then try to auto-close.
         // StopCapturing() races with that auto-close from the calling thread.
-        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5));
+        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         observer.StopCapturingTasks();
 
         Task[] tasks = await waitTask;
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(tasks, Has.Length.EqualTo(2), "both tasks must be returned regardless of race outcome");
-            Assert.That(observer.IsCapturing, Is.False, "capture session must be ended");
-        }
+        Assert.Equal(2, tasks.Length);
+        Assert.False(observer.IsCapturing);
     }
 
-    [Test]
+    [Fact]
     public async Task TestFaultedTaskCapturedAfterWaitForCapturedTasksAsyncDoesNotCauseUnobservedTaskException()
     {
         // A task that races into the channel buffer after WaitForAsync has collected its
@@ -606,7 +601,7 @@ public class EventObserverTests
                         handlerStarted.Set();
                         try
                         {
-                            await Task.Run(() => allowFault.Wait(TimeSpan.FromSeconds(5)));
+                            await Task.Run(() => allowFault.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
                             throw new InvalidOperationException("raced task fault");
                         }
                         finally
@@ -624,15 +619,15 @@ public class EventObserverTests
 
             // Raise the raced event — its task will be in-flight when the channel closes.
             await testEventSource.RaiseTestEventAsync("raced");
-            handlerStarted.Wait(TimeSpan.FromSeconds(5));
+            handlerStarted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
             // WaitForAsync collects 1 task, auto-closes the channel, and drains the raced task.
-            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5));
-            Assert.That(tasks, Has.Length.EqualTo(1));
+            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            _ = Assert.Single(tasks);
 
             // Let the raced handler fault and wait for it to complete before triggering GC.
             allowFault.Set();
-            handlerFaulted.Wait(TimeSpan.FromSeconds(5));
+            handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -640,7 +635,7 @@ public class EventObserverTests
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unobservedExceptionRaised, Is.False, "raced task fault must be observed by the drain, not trigger UnobservedTaskException");
+            Assert.False(unobservedExceptionRaised);
         }
         finally
         {
@@ -648,7 +643,7 @@ public class EventObserverTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncAlreadyFaultedRacedTaskDoesNotCauseUnobservedTaskException()
     {
         // If the raced task is already faulted synchronously by the time the drain runs,
@@ -689,8 +684,8 @@ public class EventObserverTests
             }
 
             // WaitForAsync collects 1 task, auto-closes, and drains the already-faulted raced task.
-            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5));
-            Assert.That(tasks, Has.Length.EqualTo(1));
+            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            _ = Assert.Single(tasks);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -698,7 +693,7 @@ public class EventObserverTests
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unobservedExceptionRaised, Is.False, "already-faulted raced task must be observed by the direct drain path");
+            Assert.False(unobservedExceptionRaised);
         }
         finally
         {
@@ -706,7 +701,7 @@ public class EventObserverTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncDoesNotRemovePendingTasksWhenConcurrentWaiterIsActive()
     {
         // When two WaitForAsync callers are both active (waitingReaderCount == 2),
@@ -728,10 +723,10 @@ public class EventObserverTests
 
         // Start each waiter and yield once to advance it to its first await point,
         // guaranteeing waitingReaderCount == 2 before any events enter the channel.
-        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5));
-        await Task.Delay(0);
-        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5));
-        await Task.Delay(0);
+        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.Delay(TimeSpan.Zero, TestContext.Current.CancellationToken);
+        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.Delay(TimeSpan.Zero, TestContext.Current.CancellationToken);
 
         // Raise 4 events — enough for both waiters.
         for (int i = 0; i < 4; i++)
@@ -741,18 +736,15 @@ public class EventObserverTests
 
         Task[][] results = await Task.WhenAll(waiter1, waiter2);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(results[0], Has.Length.EqualTo(2), "first waiter should get its 2 tasks");
-            Assert.That(results[1], Has.Length.EqualTo(2), "second waiter should get its 2 tasks — not drained");
-            HashSet<Task> all = [.. results[0], .. results[1]];
-            Assert.That(all, Has.Count.EqualTo(4), "all 4 tasks must be delivered with no overlap");
-        }
+        Assert.Equal(2, results[0].Length);
+        Assert.Equal(2, results[1].Length);
+        HashSet<Task> all = [.. results[0], .. results[1]];
+        Assert.Equal(4, all.Count);
 
         observer.StopCapturingTasks();
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCapturedTasksAsyncAutoClosesChannelAfterCountReached()
     {
         // After WaitForAsync(N) collects N tasks, subsequent handler invocations should not
@@ -768,7 +760,7 @@ public class EventObserverTests
             await testEventSource.RaiseTestEventAsync($"value{i}");
         }
 
-        Task[] firstBatch = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5));
+        Task[] firstBatch = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         // Raise further events — these must not be captured because the channel is closed.
         for (int i = 3; i < 6; i++)
@@ -779,31 +771,28 @@ public class EventObserverTests
         // GetCapturedTasks should return nothing (no active capture) and not the extra events.
         Task[] remaining = observer.GetCapturedTasks();
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(firstBatch, Has.Length.EqualTo(2), "WaitForAsync should return exactly 2 tasks");
-            Assert.That(remaining, Has.Length.EqualTo(0), "no tasks should accumulate after channel auto-close");
-            Assert.That(observer.IsCapturing, Is.False, "capture session should be ended after count reached");
-        }
+        Assert.Equal(2, firstBatch.Length);
+        Assert.Empty(remaining);
+        Assert.False(observer.IsCapturing);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeRemovesObserver()
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
         await testEventSource.RaiseTestEventAsync("myValue1");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
 
         observer.Dispose();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.Zero);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
 
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestUsingPatternRemovesObserver()
     {
         string? observedValue = null;
@@ -812,45 +801,43 @@ public class EventObserverTests
         using (EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue))
         {
             await testEventSource.RaiseTestEventAsync("myValue1");
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(observedValue, Is.EqualTo("myValue1"));
-                Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
-            }
+
+            Assert.Equal("myValue1", observedValue);
+            Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
         }
 
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.Zero);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
 
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
     }
 
-    [Test]
-    public void TestDoubleDisposeDoesNotThrow()
+    [Fact]
+    public async Task TestDoubleDisposeDoesNotThrow()
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.Dispose();
-        Assert.That(observer.Dispose, Throws.Nothing);
+        observer.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeAsyncRemovesObserver()
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
         await testEventSource.RaiseTestEventAsync("myValue1");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
 
         await observer.DisposeAsync();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.Zero);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
 
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAwaitUsingPatternRemovesObserver()
     {
         string? observedValue = null;
@@ -859,20 +846,18 @@ public class EventObserverTests
         await using (EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue))
         {
             await testEventSource.RaiseTestEventAsync("myValue1");
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(observedValue, Is.EqualTo("myValue1"));
-                Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
-            }
+
+            Assert.Equal("myValue1", observedValue);
+            Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
         }
 
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.Zero);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
 
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestHandlerRunAsynchronouslyWithSynchronousExceptionPropagates()
     {
         TestEventSource testEventSource = new();
@@ -880,12 +865,10 @@ public class EventObserverTests
             _ => Task.FromException(new InvalidOperationException("sync fire-and-forget failure")),
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        Assert.That(
-            async () => await testEventSource.RaiseTestEventAsync("myValue"),
-            Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("sync fire-and-forget failure"));
+        Assert.Equal("sync fire-and-forget failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await testEventSource.RaiseTestEventAsync("myValue"))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestHandlerRunAsynchronouslyWithSynchronousExceptionDoesNotPreventSubsequentObservers()
     {
         string? observedValue = null;
@@ -895,13 +878,11 @@ public class EventObserverTests
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
         testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
 
-        Assert.That(
-            async () => await testEventSource.RaiseTestEventAsync("myValue"),
-            Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("sync fire-and-forget failure"));
-        Assert.That(observedValue, Is.EqualTo("myValue"));
+        Assert.Equal("sync fire-and-forget failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await testEventSource.RaiseTestEventAsync("myValue"))).Message);
+        Assert.Equal("myValue", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestHandlerRunAsynchronouslyWithAsyncExceptionDoesNotCauseUnobservedTaskException()
     {
         bool unobservedExceptionRaised = false;
@@ -928,7 +909,7 @@ public class EventObserverTests
             await testEventSource.RaiseTestEventAsync("myValue");
 
             // Wait for the handler to fault before triggering GC.
-            handlerFaulted.Wait(TimeSpan.FromSeconds(5));
+            handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -936,7 +917,7 @@ public class EventObserverTests
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unobservedExceptionRaised, Is.False);
+            Assert.False(unobservedExceptionRaised);
         }
         finally
         {
@@ -944,7 +925,7 @@ public class EventObserverTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestHandlerRunAsynchronouslyWithAsyncSuccessCompletesWithoutError()
     {
         bool handlerCompleted = false;
@@ -965,21 +946,21 @@ public class EventObserverTests
 
         // handlerReachedAsync is set before the first real await, so the handler
         // has started but has not yet set handlerCompleted.
-        handlerReachedAsync.Wait(TimeSpan.FromSeconds(5));
-        Assert.That(handlerCompleted, Is.False, "Fire-and-forget handler should not have completed synchronously");
+        handlerReachedAsync.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(handlerCompleted);
 
-        handlerFinished.Wait(TimeSpan.FromSeconds(5));
-        Assert.That(handlerCompleted, Is.True, "Fire-and-forget handler should have completed asynchronously");
+        handlerFinished.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(handlerCompleted);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncHandlerRaisesIncrementThenDecrementEventSourceEvent()
     {
         using ManualResetEventSlim release = new(initialState: false);
         using TestEventListener listener = new();
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver(
-            async _ => await Task.Run(() => release.Wait(TimeSpan.FromSeconds(5))),
+            async _ => await Task.Run(() => release.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken)),
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
         await testEventSource.RaiseTestEventAsync("myValue");
@@ -987,34 +968,38 @@ public class EventObserverTests
         // Wait for the increment event to land.
         for (int i = 0; i < 50 && listener.GetEventsForEventName("AsyncHandlerTaskCount").Count == 0; i++)
         {
-            await Task.Delay(20);
+            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
         }
 
         List<System.Diagnostics.Tracing.EventWrittenEventArgs> incrementEvents = listener.GetEventsForEventName("AsyncHandlerTaskCount");
-        Assert.That(incrementEvents, Is.Not.Empty, "increment should raise an AsyncHandlerTaskCount event");
+        Assert.NotEmpty(incrementEvents);
         int? incrementPayload = incrementEvents[0].Payload is [int c] ? c : null;
-        Assert.That(incrementPayload, Is.Not.Null);
+        Assert.NotNull(incrementPayload);
 
         release.Set();
 
         // Wait for the decrement event to land.
         for (int i = 0; i < 50 && listener.GetEventsForEventName("AsyncHandlerTaskCount").Count < 2; i++)
         {
-            await Task.Delay(20);
+            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
         }
 
         List<System.Diagnostics.Tracing.EventWrittenEventArgs> allEvents = listener.GetEventsForEventName("AsyncHandlerTaskCount");
-        Assert.That(allEvents, Has.Count.GreaterThanOrEqualTo(2), "both increment and decrement should raise events");
+        Assert.True(allEvents.Count >= 2);
 
         // The decrement value must be strictly less than the increment value, regardless
         // of any concurrent activity from other tests, because each increment is paired
         // with exactly one decrement.
-        int firstValue = (int)allEvents[0].Payload![0]!;
-        int lastValue = (int)allEvents[^1].Payload![0]!;
-        Assert.That(lastValue, Is.LessThan(firstValue), "decrement value should be lower than preceding increment value");
+        ReadOnlyCollection<object?>? firstPayload = allEvents[0].Payload;
+        Assert.NotNull(firstPayload);
+        int firstValue = Assert.IsType<int>(firstPayload[0]);
+        ReadOnlyCollection<object?>? lastPayload = allEvents[^1].Payload;
+        Assert.NotNull(lastPayload);
+        int lastValue = Assert.IsType<int>(lastPayload[0]);
+        Assert.True(lastValue < firstValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncHandlerFaultStillRaisesDecrementEventSourceEvent()
     {
         using TestEventListener listener = new();
@@ -1031,14 +1016,14 @@ public class EventObserverTests
 
         for (int i = 0; i < 50 && listener.GetEventsForEventName("AsyncHandlerTaskCount").Count < 2; i++)
         {
-            await Task.Delay(20);
+            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
         }
 
         List<System.Diagnostics.Tracing.EventWrittenEventArgs> allEvents = listener.GetEventsForEventName("AsyncHandlerTaskCount");
-        Assert.That(allEvents, Has.Count.GreaterThanOrEqualTo(2), "increment and decrement should both fire even when handler faults");
+        Assert.True(allEvents.Count >= 2);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSynchronouslyCompletedAsyncHandlerDoesNotRaiseCounterEvents()
     {
         using TestEventListener listener = new();
@@ -1050,12 +1035,12 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue");
 
         // Give any would-be continuation a chance to fire.
-        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
-        Assert.That(listener.GetEventsForEventName("AsyncHandlerTaskCount"), Is.Empty, "no counter events should fire when async handler completes synchronously");
+        Assert.Empty(listener.GetEventsForEventName("AsyncHandlerTaskCount"));
     }
 
-    [Test]
+    [Fact]
     public async Task TestSynchronousHandlerDoesNotRaiseCounterEvents()
     {
         using TestEventListener listener = new();
@@ -1066,12 +1051,12 @@ public class EventObserverTests
 
         await testEventSource.RaiseTestEventAsync("myValue");
 
-        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
-        Assert.That(listener.GetEventsForEventName("AsyncHandlerTaskCount"), Is.Empty, "no counter events should fire for synchronous handlers");
+        Assert.Empty(listener.GetEventsForEventName("AsyncHandlerTaskCount"));
     }
 
-    [Test]
+    [Fact]
     public async Task TestConcurrentAddRemoveAgainstNotifyIsCoherent()
     {
         // Fan out a fixed number of add/remove and raise iterations against a
@@ -1102,7 +1087,8 @@ public class EventObserverTests
                     EventObserver<TestObservableEventArgs> transient = observable.AddObserver(_ => { });
                     transient.Unobserve();
                 }
-            }));
+            },
+            TestContext.Current.CancellationToken));
         }
 
         for (int i = 0; i < notificationWorkers; i++)
@@ -1113,24 +1099,25 @@ public class EventObserverTests
                 {
                     await testEventSource.RaiseTestEventAsync("stress");
                 }
-            }));
+            },
+            TestContext.Current.CancellationToken));
         }
 
         await Task.WhenAll(workers);
 
         // After all churn has ceased, only the two steady-state observers should remain.
-        Assert.That(observable.CurrentObserverCount, Is.EqualTo(2), "only the steady-state observers should remain after concurrent add/remove churn");
+        Assert.Equal(2, observable.CurrentObserverCount);
 
         // A final raise after the churn must invoke exactly the two steady observers.
         int invocationsBeforeFinalRaise = steadyInvocations;
         await testEventSource.RaiseTestEventAsync("post-stress");
-        Assert.That(steadyInvocations - invocationsBeforeFinalRaise, Is.EqualTo(2), "after churn, a single raise should invoke exactly the two remaining observers");
+        Assert.Equal(2, steadyInvocations - invocationsBeforeFinalRaise);
 
         steady1.Unobserve();
         steady2.Unobserve();
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncFaultAfterHandlerReturnInvokesErrorReporter()
     {
         EventObserverErrorInfo? reportedErrorInfo = null;
@@ -1157,22 +1144,20 @@ public class EventObserverTests
 
         await testEventSource.RaiseTestEventAsync("value");
 
-        handlerFaulted.Wait(TimeSpan.FromSeconds(5));
-        reporterInvoked.Wait(TimeSpan.FromSeconds(5));
+        handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        reporterInvoked.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(reportedErrorInfo, Is.Not.Null);
-            Assert.That(reportedErrorInfo!.ObservableEventName, Is.EqualTo("testModule.testEvent"));
-            Assert.That(reportedErrorInfo.ObserverId, Is.EqualTo(observer.Id));
-            Assert.That(reportedErrorInfo.ObserverDescription, Is.EqualTo("test observer description"));
-            Assert.That(reportedErrorInfo.Exception, Is.InstanceOf<InvalidOperationException>().With.Message.EqualTo("async reporter test failure"));
-            Assert.That(reportedErrorInfo.IsAsynchronousHandler, Is.True);
-            Assert.That(reportedErrorInfo.FaultOccurredAfterHandlerReturned, Is.True);
-        }
+        Assert.NotNull(reportedErrorInfo);
+        Assert.Equal("testModule.testEvent", reportedErrorInfo.ObservableEventName);
+        Assert.Equal(observer.Id, reportedErrorInfo.ObserverId);
+        Assert.Equal("test observer description", reportedErrorInfo.ObserverDescription);
+        InvalidOperationException exception = Assert.IsType<InvalidOperationException>(reportedErrorInfo.Exception);
+        Assert.Equal("async reporter test failure", exception.Message);
+        Assert.True(reportedErrorInfo.IsAsynchronousHandler);
+        Assert.True(reportedErrorInfo.FaultOccurredAfterHandlerReturned);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSynchronousFaultOnAsyncHandlerDoesNotInvokeErrorReporter()
     {
         bool reporterInvoked = false;
@@ -1199,32 +1184,32 @@ public class EventObserverTests
         }
 
         // Give any would-be reporter invocation a chance to arrive.
-        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
-        Assert.That(reporterInvoked, Is.False);
+        Assert.False(reporterInvoked);
     }
 
-    [Test]
+    [Fact]
     public async Task TestToStringReturnsDescription()
     {
         TestEventSource testEventSource = new();
         await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { }, ObservableEventHandlerOptions.RunHandlerSynchronously, "My first handler");
-        Assert.That(observer.ToString(), Is.EqualTo("My first handler"));
+        Assert.Equal("My first handler", observer.ToString());
     }
 
-    [Test]
+    [Fact]
     public async Task TestToStringReturnsDefaultDescription()
     {
         TestEventSource testEventSource = new();
         await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
-        Assert.That(observer.ToString(), Does.StartWith("EventObserver<TestObservableEventArgs> (id:"));
+        Assert.StartsWith("EventObserver<TestObservableEventArgs> (id:", observer.ToString());
     }
 
-    [Test]
+    [Fact]
     public async Task TestCompareToNullReturnsPositive()
     {
         TestEventSource testEventSource = new();
         await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
-        Assert.That(observer.CompareTo(null), Is.GreaterThan(0));
+        Assert.True(observer.CompareTo(null) > 0);
     }
 }

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -98,7 +98,7 @@ public class EventObserverTests
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
         observer.StartCapturingTasks();
-        Assert.Contains("must be greater than 0", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await observer.WaitForCapturedTasksAsync(0, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("must be greater than 0", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await observer.WaitForCapturedTasksAsync(0, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken))).Message);
         observer.StopCapturingTasks();
     }
 
@@ -107,7 +107,7 @@ public class EventObserverTests
     {
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
-        Assert.Contains("No capture session is active", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("No capture session is active", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         Assert.Equal(2, tasks.Length);
         observer.StopCapturingTasks();
     }
@@ -135,7 +135,7 @@ public class EventObserverTests
 
         // WaitForCapturedTasksAsync is now suspended at WaitToReadAsync with 1 of 2 tasks
         // collected and its CTS timer registered with fakeTimeProvider.
-        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, timeout, TestContext.Current.CancellationToken);
         fakeTimeProvider.Advance(timeout + TimeSpan.FromMilliseconds(1));
         Task[] tasks = await waitTask;
 
@@ -200,7 +200,7 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
-        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         Assert.True(fulfilled);
         observer.StopCapturingTasks();
     }
@@ -215,7 +215,7 @@ public class EventObserverTests
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
 
-        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
+        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout, TestContext.Current.CancellationToken);
         fakeTimeProvider.Advance(timeout + TimeSpan.FromMilliseconds(1));
         bool fulfilled = await waitTask;
 
@@ -258,7 +258,7 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue2");
 
         // Ensure both handlers have started before cancelling.
-        countdownEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
+        countdownEvent.Wait(TestContext.Current.CancellationToken);
 
         Task waitTask = observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
@@ -284,7 +284,7 @@ public class EventObserverTests
         // Advancing the fake clock fires its CTS, causing it to time out and return the 1 task it
         // collected. tasksToWait.Length (1) != count (2), so WaitForCapturedTasksCompleteAsync
         // returns false via the final line without entering the remainingTime branch.
-        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
+        Task<bool> waitTask = observer.WaitForCapturedTasksCompleteAsync(2, timeout, TestContext.Current.CancellationToken);
         fakeTimeProvider.Advance(timeout + TimeSpan.FromMilliseconds(1));
         bool fulfilled = await waitTask;
 
@@ -311,9 +311,9 @@ public class EventObserverTests
 
         // Ensure both handlers have started before waiting, so capture completes
         // immediately and the remaining timeout is spent waiting for slow execution.
-        countdownEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
+        countdownEvent.Wait(TestContext.Current.CancellationToken);
 
-        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         Assert.False(fulfilled);
 
         // Capture session is auto-closed once count tasks are collected.
@@ -340,7 +340,7 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
 
-        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, timeout, cancellationToken: TestContext.Current.CancellationToken);
+        bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, timeout, TestContext.Current.CancellationToken);
 
         Assert.False(fulfilled);
         Assert.False(observer.IsCapturing);
@@ -363,7 +363,7 @@ public class EventObserverTests
         {
         }
 
-        Assert.Equal("capture failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksCompleteAsync(1, TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Equal("capture failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksCompleteAsync(1, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken))).Message);
         observer.StopCapturingTasks();
     }
 
@@ -409,19 +409,19 @@ public class EventObserverTests
     {
         bool handlerCompleted = false;
         TaskCompletionSource handlerGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        using ManualResetEventSlim handlerReachedGate = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
             async (e) =>
             {
-                handlerReachedGate.Set();
+                taskCompletionSource.TrySetResult();
                 await handlerGate.Task;
                 handlerCompleted = true;
             },
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue");
-        handlerReachedGate.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Task[] tasks = observer.GetCapturedTasks();
         _ = Assert.Single(tasks);
         Assert.False(tasks[0].IsCompleted);
@@ -443,13 +443,13 @@ public class EventObserverTests
         TaskScheduler.UnobservedTaskException += handler;
         try
         {
-            using ManualResetEventSlim handlerFaulted = new(false);
+            TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TestEventSource testEventSource = new();
             EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
                 async (e) =>
                 {
                     await Task.Yield();
-                    handlerFaulted.Set();
+                    taskCompletionSource.TrySetResult();
                     throw new InvalidOperationException("async capture failure");
                 },
                 ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -461,7 +461,7 @@ public class EventObserverTests
             _ = Assert.Single(tasks);
 
             // Wait for the handler to fault before triggering GC.
-            handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -500,8 +500,8 @@ public class EventObserverTests
         observer.StartCapturingTasks();
 
         // Start both waiters before any events are raised.
-        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
-        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Raise 6 events so both waiters can be satisfied.
         for (int i = 0; i < 6; i++)
@@ -532,7 +532,7 @@ public class EventObserverTests
 
         // Raise only 1 event, then start a waiter that needs 3.
         await testEventSource.RaiseTestEventAsync("value1");
-        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(3, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         // Stop the capture session from another thread — waiter should unblock.
         observer.StopCapturingTasks();
@@ -560,7 +560,7 @@ public class EventObserverTests
 
         // WaitForAsync(2) will collect both tasks and then try to auto-close.
         // StopCapturing() races with that auto-close from the calling thread.
-        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waitTask = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         observer.StopCapturingTasks();
 
         Task[] tasks = await waitTask;
@@ -589,24 +589,24 @@ public class EventObserverTests
         {
             TestEventSource testEventSource = new();
 
-            using ManualResetEventSlim handlerStarted = new(false);
-            using ManualResetEventSlim allowFault = new(false);
-            using ManualResetEventSlim handlerFaulted = new(false);
+            TaskCompletionSource handlerStartedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource allowFaultTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource handlerFaultedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
                 async (TestObservableEventArgs e) =>
                 {
                     if (e.EventValue == "raced")
                     {
-                        handlerStarted.Set();
+                        handlerStartedTaskCompletionSource.TrySetResult();
                         try
                         {
-                            await Task.Run(() => allowFault.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
+                            await allowFaultTaskCompletionSource.Task;
                             throw new InvalidOperationException("raced task fault");
                         }
                         finally
                         {
-                            handlerFaulted.Set();
+                            handlerFaultedTaskCompletionSource.TrySetResult();
                         }
                     }
                 },
@@ -619,15 +619,15 @@ public class EventObserverTests
 
             // Raise the raced event — its task will be in-flight when the channel closes.
             await testEventSource.RaiseTestEventAsync("raced");
-            handlerStarted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            await handlerStartedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             // WaitForAsync collects 1 task, auto-closes the channel, and drains the raced task.
-            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             _ = Assert.Single(tasks);
 
             // Let the raced handler fault and wait for it to complete before triggering GC.
-            allowFault.Set();
-            handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            allowFaultTaskCompletionSource.TrySetResult();
+            await handlerFaultedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -684,7 +684,7 @@ public class EventObserverTests
             }
 
             // WaitForAsync collects 1 task, auto-closes, and drains the already-faulted raced task.
-            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             _ = Assert.Single(tasks);
 
             // Force garbage collection to trigger UnobservedTaskException
@@ -723,9 +723,9 @@ public class EventObserverTests
 
         // Start each waiter and yield once to advance it to its first await point,
         // guaranteeing waitingReaderCount == 2 before any events enter the channel.
-        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await Task.Delay(TimeSpan.Zero, TestContext.Current.CancellationToken);
-        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await Task.Delay(TimeSpan.Zero, TestContext.Current.CancellationToken);
 
         // Raise 4 events — enough for both waiters.
@@ -760,7 +760,7 @@ public class EventObserverTests
             await testEventSource.RaiseTestEventAsync($"value{i}");
         }
 
-        Task[] firstBatch = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Task[] firstBatch = await observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Raise further events — these must not be captured because the channel is closed.
         for (int i = 3; i < 6; i++)
@@ -895,13 +895,13 @@ public class EventObserverTests
         TaskScheduler.UnobservedTaskException += UnobservedHandler;
         try
         {
-            using ManualResetEventSlim handlerFaulted = new(false);
+            TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TestEventSource testEventSource = new();
             testEventSource.TestObservableEvent.AddObserver(
                 async (TestObservableEventArgs e) =>
                 {
                     await Task.Yield();
-                    handlerFaulted.Set();
+                    taskCompletionSource.TrySetResult();
                     throw new InvalidOperationException("async fire-and-forget failure");
                 },
                 ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -909,7 +909,7 @@ public class EventObserverTests
             await testEventSource.RaiseTestEventAsync("myValue");
 
             // Wait for the handler to fault before triggering GC.
-            handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+            await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -929,38 +929,38 @@ public class EventObserverTests
     public async Task TestHandlerRunAsynchronouslyWithAsyncSuccessCompletesWithoutError()
     {
         bool handlerCompleted = false;
-        using ManualResetEventSlim handlerReachedAsync = new(false);
-        using ManualResetEventSlim handlerFinished = new(false);
+        TaskCompletionSource handlerReachedAsyncTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource handlerFinishedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver(
             async _ =>
             {
-                handlerReachedAsync.Set();
+                handlerReachedAsyncTaskCompletionSource.TrySetResult();
                 await Task.Yield();
                 handlerCompleted = true;
-                handlerFinished.Set();
+                handlerFinishedTaskCompletionSource.TrySetResult();
             },
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
         await testEventSource.RaiseTestEventAsync("myValue");
 
-        // handlerReachedAsync is set before the first real await, so the handler
-        // has started but has not yet set handlerCompleted.
-        handlerReachedAsync.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        // handlerReachedAsyncTaskCompletionSource is set before the first real await, so the
+        // handler has started but has not yet set handlerCompleted.
+        await handlerReachedAsyncTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.False(handlerCompleted);
 
-        handlerFinished.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await handlerFinishedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(handlerCompleted);
     }
 
     [Fact]
     public async Task TestAsyncHandlerRaisesIncrementThenDecrementEventSourceEvent()
     {
-        using ManualResetEventSlim release = new(initialState: false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         using TestEventListener listener = new();
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver(
-            async _ => await Task.Run(() => release.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken)),
+            async _ => await taskCompletionSource.Task,
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
         await testEventSource.RaiseTestEventAsync("myValue");
@@ -976,7 +976,7 @@ public class EventObserverTests
         int? incrementPayload = incrementEvents[0].Payload is [int c] ? c : null;
         Assert.NotNull(incrementPayload);
 
-        release.Set();
+        taskCompletionSource.TrySetResult();
 
         // Wait for the decrement event to land.
         for (int i = 0; i < 50 && listener.GetEventsForEventName("AsyncHandlerTaskCount").Count < 2; i++)
@@ -1121,22 +1121,22 @@ public class EventObserverTests
     public async Task TestAsyncFaultAfterHandlerReturnInvokesErrorReporter()
     {
         EventObserverErrorInfo? reportedErrorInfo = null;
-        using ManualResetEventSlim reporterInvoked = new(false);
+        TaskCompletionSource reporterInvokedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestEventSource testEventSource = new();
         testEventSource.SetObserverErrorReporter(errorInfo =>
         {
             reportedErrorInfo = errorInfo with { };
-            reporterInvoked.Set();
+            reporterInvokedTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
-        using ManualResetEventSlim handlerFaulted = new(false);
+        TaskCompletionSource handlerFaultedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
             async _ =>
             {
                 await Task.Yield();
-                handlerFaulted.Set();
+                handlerFaultedTaskCompletionSource.TrySetResult();
                 throw new InvalidOperationException("async reporter test failure");
             },
             ObservableEventHandlerOptions.RunHandlerAsynchronously,
@@ -1144,8 +1144,8 @@ public class EventObserverTests
 
         await testEventSource.RaiseTestEventAsync("value");
 
-        handlerFaulted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
-        reporterInvoked.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await handlerFaultedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await reporterInvokedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.NotNull(reportedErrorInfo);
         Assert.Equal("testModule.testEvent", reportedErrorInfo.ObservableEventName);

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -12,7 +12,7 @@ public class EventObserverTests
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
+        testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
         await testEventSource.RaiseTestEventAsync("myValue");
         Assert.NotNull(observedValue);
         Assert.Equal("myValue", observedValue);
@@ -22,7 +22,7 @@ public class EventObserverTests
     public async Task TestDisposeAfterDisposeAsyncDoesNotThrow()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         await observer.DisposeAsync();
         observer.Dispose();
     }
@@ -31,7 +31,7 @@ public class EventObserverTests
     public async Task TestDoubleDisposeAsyncDoesNotThrow()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         await observer.DisposeAsync();
         await observer.DisposeAsync();
     }
@@ -40,7 +40,7 @@ public class EventObserverTests
     public async Task TestDisposeAsyncAfterDisposeDoesNotThrow()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.Dispose();
         await observer.DisposeAsync();
     }
@@ -49,7 +49,7 @@ public class EventObserverTests
     public async Task TestIsCapturingReturnsFalseWhenNotCapturing()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.False(observer.IsCapturing);
     }
 
@@ -57,7 +57,7 @@ public class EventObserverTests
     public async Task TestIsCapturingReturnsTrueWhenCapturing()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         Assert.True(observer.IsCapturing);
         observer.StopCapturingTasks();
@@ -67,7 +67,7 @@ public class EventObserverTests
     public async Task TestStartCapturingWithActiveCaptureThrows()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         Assert.Contains("already has an active capture session", Assert.ThrowsAny<WebDriverBiDiException>(() => observer.StartCapturingTasks()).Message);
         observer.StopCapturingTasks();
@@ -77,7 +77,7 @@ public class EventObserverTests
     public async Task TestStopCapturingWithoutStartCapturingIsNoOp()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StopCapturingTasks();
         Assert.False(observer.IsCapturing);
     }
@@ -86,7 +86,7 @@ public class EventObserverTests
     public async Task TestCallingStopCapturingRepeatedlyDoesNotThrow()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         observer.StopCapturingTasks();
         observer.StopCapturingTasks();
@@ -96,7 +96,7 @@ public class EventObserverTests
     public async Task TestWaitForCapturedTasksAsyncCountZeroThrows()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         Assert.Contains("must be greater than 0", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await observer.WaitForCapturedTasksAsync(0, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken))).Message);
         observer.StopCapturingTasks();
@@ -106,7 +106,7 @@ public class EventObserverTests
     public async Task TestWaitForCapturedTasksAsyncWithoutStartCapturingThrows()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.Contains("No capture session is active", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken))).Message);
     }
 
@@ -114,7 +114,7 @@ public class EventObserverTests
     public async Task TestWaitForCapturedTasksAsync()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
@@ -129,7 +129,7 @@ public class EventObserverTests
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         FakeTimeProvider fakeTimeProvider = new();
         TestEventSource testEventSource = new(fakeTimeProvider);
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
 
@@ -149,7 +149,7 @@ public class EventObserverTests
     {
         CancellationTokenSource cancellationTokenSource = new();
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         Task waitTask = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
@@ -163,7 +163,7 @@ public class EventObserverTests
     public async Task TestGetCapturedTasksWithWithoutStartCaptureReturnsEmptyArray()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         Task[] tasks = observer.GetCapturedTasks();
         Assert.Empty(tasks);
     }
@@ -172,7 +172,7 @@ public class EventObserverTests
     public async Task TestGetCapturedTasksWithActiveCaptureAndNoTasksReturnsEmptyArray()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         Task[] tasks = observer.GetCapturedTasks();
         Assert.Empty(tasks);
@@ -183,7 +183,7 @@ public class EventObserverTests
     public async Task TestGetCapturedTasksWithActiveCaptureReturnsPendingTasks()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
@@ -196,7 +196,7 @@ public class EventObserverTests
     public async Task TestWaitForCapturedTasksCompleteAsync()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         await testEventSource.RaiseTestEventAsync("myValue2");
@@ -211,7 +211,7 @@ public class EventObserverTests
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         FakeTimeProvider fakeTimeProvider = new();
         TestEventSource testEventSource = new(fakeTimeProvider);
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
 
@@ -229,7 +229,7 @@ public class EventObserverTests
     {
         CancellationTokenSource cancellationTokenSource = new();
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
         Task waitTask = observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
@@ -246,7 +246,7 @@ public class EventObserverTests
         CancellationTokenSource cancellationTokenSource = new();
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
-            async (TestObservableEventArgs e) =>
+            async e =>
             {
                 countdownEvent.Signal();
                 await Task.Delay(TimeSpan.FromSeconds(2));
@@ -275,7 +275,7 @@ public class EventObserverTests
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         FakeTimeProvider fakeTimeProvider = new();
         TestEventSource testEventSource = new(fakeTimeProvider);
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
 
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
@@ -334,7 +334,7 @@ public class EventObserverTests
             AutoAdvanceAmount = timeout + TimeSpan.FromMilliseconds(1)
         };
         TestEventSource testEventSource = new(fakeTimeProvider);
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
 
         observer.StartCapturingTasks();
         await testEventSource.RaiseTestEventAsync("myValue1");
@@ -371,7 +371,7 @@ public class EventObserverTests
     public async Task TestDisposeWithActiveCaptureDoesNotThrow()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         Assert.True(observer.IsCapturing);
         observer.Dispose();
@@ -382,7 +382,7 @@ public class EventObserverTests
     public async Task TestDisposeAsyncWithActiveCaptureDoesNotThrow()
     {
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         observer.StartCapturingTasks();
         Assert.True(observer.IsCapturing);
         await observer.DisposeAsync();
@@ -594,7 +594,7 @@ public class EventObserverTests
             TaskCompletionSource handlerFaultedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
-                async (TestObservableEventArgs e) =>
+                async e =>
                 {
                     if (e.EventValue == "raced")
                     {
@@ -898,7 +898,7 @@ public class EventObserverTests
             TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TestEventSource testEventSource = new();
             testEventSource.TestObservableEvent.AddObserver(
-                async (TestObservableEventArgs e) =>
+                async e =>
                 {
                     await Task.Yield();
                     taskCompletionSource.TrySetResult();
@@ -1080,27 +1080,29 @@ public class EventObserverTests
         List<Task> workers = [];
         for (int i = 0; i < registrationWorkers; i++)
         {
-            workers.Add(Task.Run(() =>
-            {
-                for (int j = 0; j < addRemoveIterationsPerWorker; j++)
+            workers.Add(Task.Run(
+                () =>
                 {
-                    EventObserver<TestObservableEventArgs> transient = observable.AddObserver(_ => { });
-                    transient.Unobserve();
-                }
-            },
-            TestContext.Current.CancellationToken));
+                    for (int j = 0; j < addRemoveIterationsPerWorker; j++)
+                    {
+                        EventObserver<TestObservableEventArgs> transient = observable.AddObserver(_ => { });
+                        transient.Unobserve();
+                    }
+                },
+                TestContext.Current.CancellationToken));
         }
 
         for (int i = 0; i < notificationWorkers; i++)
         {
-            workers.Add(Task.Run(async () =>
-            {
-                for (int j = 0; j < raisesPerWorker; j++)
+            workers.Add(Task.Run(
+                async () =>
                 {
-                    await testEventSource.RaiseTestEventAsync("stress");
-                }
-            },
-            TestContext.Current.CancellationToken));
+                    for (int j = 0; j < raisesPerWorker; j++)
+                    {
+                        await testEventSource.RaiseTestEventAsync("stress");
+                    }
+                },
+                TestContext.Current.CancellationToken));
         }
 
         await Task.WhenAll(workers);
@@ -1193,7 +1195,7 @@ public class EventObserverTests
     public async Task TestToStringReturnsDescription()
     {
         TestEventSource testEventSource = new();
-        await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { }, ObservableEventHandlerOptions.RunHandlerSynchronously, "My first handler");
+        await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { }, ObservableEventHandlerOptions.RunHandlerSynchronously, "My first handler");
         Assert.Equal("My first handler", observer.ToString());
     }
 
@@ -1201,7 +1203,7 @@ public class EventObserverTests
     public async Task TestToStringReturnsDefaultDescription()
     {
         TestEventSource testEventSource = new();
-        await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.StartsWith("EventObserver<TestObservableEventArgs> (id:", observer.ToString());
     }
 
@@ -1209,7 +1211,7 @@ public class EventObserverTests
     public async Task TestCompareToNullReturnsPositive()
     {
         TestEventSource testEventSource = new();
-        await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((e) => { });
+        await using EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.True(observer.CompareTo(null) > 0);
     }
 }

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -242,13 +242,17 @@ public class EventObserverTests
     [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncCanBeCancelledWaitingForTaskCompletion()
     {
-        CountdownEvent countdownEvent = new(2);
+        TaskCompletionSource bothStartedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int startedCount = 0;
         CancellationTokenSource cancellationTokenSource = new();
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
             async e =>
             {
-                countdownEvent.Signal();
+                if (Interlocked.Increment(ref startedCount) == 2)
+                {
+                    bothStartedTaskCompletionSource.TrySetResult();
+                }
                 await Task.Delay(TimeSpan.FromSeconds(2));
             },
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -258,7 +262,7 @@ public class EventObserverTests
         await testEventSource.RaiseTestEventAsync("myValue2");
 
         // Ensure both handlers have started before cancelling.
-        countdownEvent.Wait(TestContext.Current.CancellationToken);
+        await bothStartedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Task waitTask = observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromSeconds(1), cancellationTokenSource.Token);
         cancellationTokenSource.Cancel();
@@ -295,12 +299,16 @@ public class EventObserverTests
     [Fact]
     public async Task TestWaitForCapturedTasksCompleteAsyncReturnsFalseWhenExecutionTimesOut()
     {
-        CountdownEvent countdownEvent = new(2);
+        TaskCompletionSource bothStartedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int startedCount = 0;
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
-            async (e) =>
+            async e =>
             {
-                countdownEvent.Signal();
+                if (Interlocked.Increment(ref startedCount) == 2)
+                {
+                    bothStartedTaskCompletionSource.TrySetResult();
+                }
                 await Task.Delay(TimeSpan.FromSeconds(5));
             },
             ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -311,7 +319,7 @@ public class EventObserverTests
 
         // Ensure both handlers have started before waiting, so capture completes
         // immediately and the remaining timeout is spent waiting for slow execution.
-        countdownEvent.Wait(TestContext.Current.CancellationToken);
+        await bothStartedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         bool fulfilled = await observer.WaitForCapturedTasksCompleteAsync(2, TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         Assert.False(fulfilled);
@@ -446,11 +454,17 @@ public class EventObserverTests
             TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TestEventSource testEventSource = new();
             EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(
-                async (e) =>
+                async e =>
                 {
                     await Task.Yield();
-                    taskCompletionSource.TrySetResult();
-                    throw new InvalidOperationException("async capture failure");
+                    try
+                    {
+                        throw new InvalidOperationException("async capture failure");
+                    }
+                    finally
+                    {
+                        taskCompletionSource.TrySetResult();
+                    }
                 },
                 ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
@@ -708,28 +722,40 @@ public class EventObserverTests
         // the first to finish must NOT drain the channel — those tasks belong to the
         // second waiter.
         //
-        // Determinism guarantee: WaitForCapturedTasksAsync increments waitingReaderCount
-        // synchronously under captureLock before its first await point
-        // (captureReadSemaphore.WaitAsync). Awaiting Task.Delay(0) after starting each
-        // waiter drives each task's synchronous preamble to completion on the thread pool,
-        // ensuring both have incremented waitingReaderCount before any events are raised.
-        // waiter1 then blocks inside WaitToReadAsync on the empty channel (it holds the
-        // semaphore); waiter2 blocks on captureReadSemaphore.WaitAsync. Both are registered
-        // as active readers when the events arrive.
+        // Determinism guarantee: both waiters need to have incremented waitingReaderCount
+        // before the final events are raised. We achieve this by priming with one event
+        // before starting waiter2. By the time waiter1 has consumed the first primed task
+        // (observable via firstTaskConsumedTaskCompletionSource), it holds the semaphore
+        // and is blocking inside WaitToReadAsync waiting for its second task. waiter2 must
+        // therefore have already completed its synchronous preamble (incrementing
+        // waitingReaderCount) and be blocked on captureReadSemaphore.WaitAsync. Both are
+        // registered as active readers before the remaining events are raised.
+        TaskCompletionSource firstTaskConsumedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int taskCount = 0;
         TestEventSource testEventSource = new();
-        static Task DistinctTaskHandler(TestObservableEventArgs _) => Task.FromResult(Guid.NewGuid());
+        Task DistinctTaskHandler(TestObservableEventArgs _)
+        {
+            if (Interlocked.Increment(ref taskCount) == 1)
+            {
+                firstTaskConsumedTaskCompletionSource.TrySetResult();
+            }
+
+            return Task.FromResult(Guid.NewGuid());
+        }
+
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(DistinctTaskHandler);
         observer.StartCapturingTasks();
 
-        // Start each waiter and yield once to advance it to its first await point,
-        // guaranteeing waitingReaderCount == 2 before any events enter the channel.
+        // Start waiter1, raise one priming event so it is inside its read loop
+        // waiting for a second task, then start waiter2.
         Task<Task[]> waiter1 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-        await Task.Delay(TimeSpan.Zero, TestContext.Current.CancellationToken);
+        await testEventSource.RaiseTestEventAsync("prime");
+        await firstTaskConsumedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Task<Task[]> waiter2 = observer.WaitForCapturedTasksAsync(2, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-        await Task.Delay(TimeSpan.Zero, TestContext.Current.CancellationToken);
 
-        // Raise 4 events — enough for both waiters.
-        for (int i = 0; i < 4; i++)
+        // Raise 3 more events: waiter1 gets 1 (to complete its batch of 2),
+        // waiter2 gets 2 (its full batch).
+        for (int i = 0; i < 3; i++)
         {
             await testEventSource.RaiseTestEventAsync($"value{i}");
         }

--- a/test/WebDriverBiDi.Tests/Input/ElementOriginTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/ElementOriginTests.cs
@@ -5,10 +5,9 @@ using Newtonsoft.Json.Linq;
 
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class ElementOriginTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeOrigin()
     {
         string nodeJson = """
@@ -22,29 +21,33 @@ public class ElementOriginTests
                           }
                           """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         SharedReference node = ((NodeRemoteValue)remoteValue).ToSharedReference();
         ElementOrigin origin = new(node);
         string json = JsonSerializer.Serialize(origin);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("element"));
-            Assert.That(serialized, Contains.Key("element"));
-            Assert.That(serialized["element"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? serializedElementReference = serialized["element"]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serializedElementReference, Is.Not.Null);
-            Assert.That(serializedElementReference, Has.Count.EqualTo(1));
-            Assert.That(serializedElementReference, Contains.Key("sharedId"));
-            Assert.That(serializedElementReference!["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serializedElementReference["sharedId"]!.Value<string>(), Is.EqualTo("testSharedId"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("element", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("element"));
+        JToken? elementToken = serialized["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+
+        JObject? serializedElementReference = elementToken.Value<JObject>();
+        Assert.NotNull(serializedElementReference);
+        Assert.Single(serializedElementReference);
+        Assert.True(serializedElementReference.ContainsKey("sharedId"));
+
+        JToken? sharedId = serializedElementReference["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("testSharedId", sharedId.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/FileDialogOpenedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/FileDialogOpenedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Input;
 
 using System.Text.Json;
 
-[TestFixture]
 public class FileDialogInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMultipleTrue()
     {
         string json = """
@@ -15,17 +14,15 @@ public class FileDialogInfoTests
                         }
                         """;
         FileDialogOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        Assert.That(eventArgs, Is.InstanceOf<FileDialogOpenedEventArgs>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsMultiple, Is.True);
-            Assert.That(eventArgs.Element, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+        Assert.IsType<FileDialogOpenedEventArgs>(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.True(eventArgs.IsMultiple);
+        Assert.Null(eventArgs.Element);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMultipleFalse()
     {
         string json = """
@@ -35,17 +32,15 @@ public class FileDialogInfoTests
                         }
                         """;
         FileDialogOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        Assert.That(eventArgs, Is.InstanceOf<FileDialogOpenedEventArgs>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsMultiple, Is.False);
-            Assert.That(eventArgs.Element, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+        Assert.IsType<FileDialogOpenedEventArgs>(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.False(eventArgs.IsMultiple);
+        Assert.Null(eventArgs.Element);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithUserContext()
     {
         string json = """
@@ -56,18 +51,16 @@ public class FileDialogInfoTests
                         }
                         """;
         FileDialogOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        Assert.That(eventArgs, Is.InstanceOf<FileDialogOpenedEventArgs>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsMultiple, Is.False);
-            Assert.That(eventArgs.Element, Is.Null);
-            Assert.That(eventArgs.UserContextId, Is.EqualTo("myUserContextId"));
-        }
+        Assert.NotNull(eventArgs);
+        Assert.IsType<FileDialogOpenedEventArgs>(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.False(eventArgs.IsMultiple);
+        Assert.Null(eventArgs.Element);
+        Assert.Equal("myUserContextId", eventArgs.UserContextId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithElementReference()
     {
         string json = """
@@ -80,18 +73,16 @@ public class FileDialogInfoTests
                     }
                     """;
         FileDialogOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        Assert.That(eventArgs, Is.InstanceOf<FileDialogOpenedEventArgs>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.IsMultiple, Is.True);
-            Assert.That(eventArgs.Element, Is.Not.Null);
-            Assert.That(eventArgs.Element!.SharedId, Is.EqualTo("mySharedId"));
-        }
+        Assert.NotNull(eventArgs);
+        Assert.IsType<FileDialogOpenedEventArgs>(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.True(eventArgs.IsMultiple);
+        Assert.NotNull(eventArgs.Element);
+        Assert.Equal("mySharedId", eventArgs.Element.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -101,13 +92,13 @@ public class FileDialogInfoTests
                         }
                         """;
         FileDialogOpenedEventArgs? eventArgs = JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        Assert.That(eventArgs, Is.InstanceOf<FileDialogOpenedEventArgs>());
+        Assert.NotNull(eventArgs);
+        Assert.IsType<FileDialogOpenedEventArgs>(eventArgs);
         FileDialogOpenedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = """
@@ -115,10 +106,10 @@ public class FileDialogInfoTests
                         "multiple": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -127,10 +118,10 @@ public class FileDialogInfoTests
                         "multiple": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingMMultipleThrows()
     {
         string json = """
@@ -138,10 +129,10 @@ public class FileDialogInfoTests
                         "context": "myContextId"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidMMultipleTypeThrows()
     {
         string json = """
@@ -150,10 +141,10 @@ public class FileDialogInfoTests
                         "multiple": "true"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidUserContextTypeThrows()
     {
         string json = """
@@ -163,10 +154,10 @@ public class FileDialogInfoTests
                         "userContext": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidElementTypeThrows()
     {
         string json = """
@@ -176,10 +167,10 @@ public class FileDialogInfoTests
                         "element": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithNonSharedReferenceThrows()
     {
         string json = """
@@ -196,6 +187,6 @@ public class FileDialogInfoTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FileDialogOpenedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
@@ -125,7 +125,7 @@ public class InputModuleTests
         InputModule module = driver.Input;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnFileDialogOpened.AddObserver((FileDialogOpenedEventArgs e) =>
+        module.OnFileDialogOpened.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.True(e.IsMultiple);

--- a/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Input;
 using WebDriverBiDi.Script;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class InputModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecutePerformActions()
     {
         TestWebSocketConnection connection = new();
@@ -23,17 +22,16 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
-        Task<PerformActionsCommandResult> task = module.PerformActionsAsync(new PerformActionsCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        PerformActionsCommandResult result = task.Result;
+        Task<PerformActionsCommandResult> task = module.PerformActionsAsync(new PerformActionsCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        PerformActionsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteReleaseActions()
     {
         TestWebSocketConnection connection = new();
@@ -50,17 +48,16 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
-        Task<ReleaseActionsCommandResult> task = module.ReleaseActionsAsync(new ReleaseActionsCommandParameters("myContextId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        ReleaseActionsCommandResult result = task.Result;
+        Task<ReleaseActionsCommandResult> task = module.ReleaseActionsAsync(new ReleaseActionsCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
+        ReleaseActionsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSetFiles()
     {
         TestWebSocketConnection connection = new();
@@ -77,34 +74,32 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
         SharedReference element = new("mySharedId");
-        Task<SetFilesCommandResult> task = module.SetFilesAsync(new SetFilesCommandParameters("myContextId", element));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetFilesCommandResult result = task.Result;
+        Task<SetFilesCommandResult> task = module.SetFilesAsync(new SetFilesCommandParameters("myContextId", element), cancellationToken: TestContext.Current.CancellationToken);
+        SetFilesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveFileDialogOpenedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
         ManualResetEvent syncEvent = new(false);
         module.OnFileDialogOpened.AddObserver((FileDialogOpenedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.IsMultiple, Is.True);
-                Assert.That(e.Element, Is.Null);
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.True(e.IsMultiple);
+            Assert.Null(e.Element);
+
             syncEvent.Set();
         });
 
@@ -120,27 +115,26 @@ public class InputModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveFileDialogOpenedEventWithElementReference()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
         ManualResetEvent syncEvent = new(false);
         module.OnFileDialogOpened.AddObserver((FileDialogOpenedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.IsMultiple, Is.True);
-                Assert.That(e.Element, Is.Not.Null);
-                Assert.That(e.Element!.SharedId, Is.EqualTo("mySharedId"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.True(e.IsMultiple);
+            Assert.NotNull(e.Element);
+            Assert.Equal("mySharedId", e.Element.SharedId);
+
             syncEvent.Set();
         });
 
@@ -165,6 +159,6 @@ public class InputModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
@@ -22,7 +22,7 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
         Task<PerformActionsCommandResult> task = module.PerformActionsAsync(new PerformActionsCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -48,7 +48,7 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
         Task<ReleaseActionsCommandResult> task = module.ReleaseActionsAsync(new ReleaseActionsCommandParameters("myContextId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -74,7 +74,7 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
         SharedReference element = new("mySharedId");
@@ -89,18 +89,17 @@ public class InputModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnFileDialogOpened.AddObserver((FileDialogOpenedEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnFileDialogOpened.AddObserver(e =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.True(e.IsMultiple);
             Assert.Null(e.Element);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -114,8 +113,7 @@ public class InputModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -126,16 +124,15 @@ public class InputModuleTests
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnFileDialogOpened.AddObserver((FileDialogOpenedEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.True(e.IsMultiple);
             Assert.NotNull(e.Element);
             Assert.Equal("mySharedId", e.Element.SharedId);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -158,7 +155,6 @@ public class InputModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
@@ -21,7 +21,7 @@ public class InputModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -47,7 +47,7 @@ public class InputModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -73,7 +73,7 @@ public class InputModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -88,7 +88,7 @@ public class InputModuleTests
     public async Task TestCanReceiveFileDialogOpenedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -120,7 +120,7 @@ public class InputModuleTests
     public async Task TestCanReceiveFileDialogOpenedEventWithElementReference()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 

--- a/test/WebDriverBiDi.Tests/Input/KeyDownActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/KeyDownActionTests.cs
@@ -3,30 +3,32 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class KeyDownActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         KeyDownAction properties = new("a");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("keyDown"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["value"]!.Value<string>(), Is.EqualTo("a"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("keyDown", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.String, value.Type);
+        Assert.Equal("a", value.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCreatingActionWithEmptyValueThrows()
     {
-        Assert.That(() => new KeyDownAction(string.Empty), Throws.InstanceOf<ArgumentException>().With.Message.Contains("Action value cannot be null or the empty string"));
+        Assert.Contains("Action value cannot be null or the empty string", Assert.ThrowsAny<ArgumentException>(() => new KeyDownAction(string.Empty)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/KeySourceActionsTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/KeySourceActionsTests.cs
@@ -3,67 +3,82 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class KeySourceActionsTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         KeySourceActions properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("key"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("key", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithActions()
     {
         KeySourceActions properties = new();
         properties.Actions.Add(new KeyDownAction("a"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"], Is.Not.Null);
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("key"));
-            Assert.That(serialized["actions"], Is.Not.Null);
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["actions"]![0], Is.Not.Null);
-            Assert.That(serialized["actions"]![0]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? action = serialized["actions"]![0]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(action, Is.Not.Null);
-            Assert.That(action, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(action, Contains.Key("type"));
-            Assert.That(action!["type"], Is.Not.Null);
-            Assert.That(action!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(action!["type"]!.Value<string>(), Is.EqualTo("keyDown"));
-            Assert.That(action, Contains.Key("value"));
-            Assert.That(action!["value"], Is.Not.Null);
-            Assert.That(action!["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(action!["value"]!.Value<string>(), Is.EqualTo("a"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("key", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Single(actionsArray);
+
+        JToken? actionToken = actionsArray[0];
+        Assert.NotNull(actionToken);
+        Assert.Equal(JTokenType.Object, actionToken.Type);
+
+        JObject? action = actionToken.Value<JObject>();
+        Assert.NotNull(action);
+        Assert.Equal(2, action.Count);
+
+        Assert.True(action.ContainsKey("type"));
+        JToken? actionType = action["type"];
+        Assert.NotNull(actionType);
+        Assert.Equal(JTokenType.String, actionType.Type);
+        Assert.Equal("keyDown", actionType.Value<string>());
+
+        Assert.True(action.ContainsKey("value"));
+        JToken? value = action["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.String, value.Type);
+        Assert.Equal("a", value.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/KeyUpActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/KeyUpActionTests.cs
@@ -3,30 +3,32 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class KeyUpActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         KeyUpAction properties = new("a");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("keyUp"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["value"]!.Value<string>(), Is.EqualTo("a"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("keyUp", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.String, value.Type);
+        Assert.Equal("a", value.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCreatingActionWithEmptyValueThrows()
     {
-        Assert.That(() => new KeyUpAction(string.Empty), Throws.InstanceOf<ArgumentException>().With.Message.Contains("Action value cannot be null or the empty string"));
+        Assert.Contains("Action value cannot be null or the empty string", Assert.ThrowsAny<ArgumentException>(() => new KeyUpAction(string.Empty)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/NoneSourceActionsTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/NoneSourceActionsTests.cs
@@ -3,61 +3,76 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class NoneSourceActionsTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         NoneSourceActions properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("none"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("none", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithActions()
     {
         NoneSourceActions properties = new();
         properties.Actions.Add(new PauseAction());
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"], Is.Not.Null);
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("none"));
-            Assert.That(serialized["actions"], Is.Not.Null);
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["actions"]![0], Is.Not.Null);
-            Assert.That(serialized["actions"]![0]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? action = serialized["actions"]![0]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(action, Is.Not.Null);
-            Assert.That(action, Has.Count.EqualTo(1));
-            Assert.That(action, Contains.Key("type"));
-            Assert.That(action!["type"], Is.Not.Null);
-            Assert.That(action!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(action!["type"]!.Value<string>(), Is.EqualTo("pause"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("none", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Single(actionsArray);
+
+        JToken? actionToken = actionsArray[0];
+        Assert.NotNull(actionToken);
+        Assert.Equal(JTokenType.Object, actionToken.Type);
+
+        JObject? action = actionToken.Value<JObject>();
+        Assert.NotNull(action);
+        Assert.Single(action);
+
+        Assert.True(action.ContainsKey("type"));
+        JToken? actionType = action["type"];
+        Assert.NotNull(actionType);
+        Assert.Equal(JTokenType.String, actionType.Type);
+        Assert.Equal("pause", actionType.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/OriginTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/OriginTests.cs
@@ -5,30 +5,29 @@ using Newtonsoft.Json.Linq;
 
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class OriginTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeViewportOrigin()
     {
         Origin origin = Origin.Viewport;
         string json = JsonSerializer.Serialize(origin.Value);
         string? parsed = JsonSerializer.Deserialize<string>(json);
-        Assert.That(parsed, Is.InstanceOf<string>());
-        Assert.That(parsed, Is.EqualTo("viewport"));
+        Assert.IsType<string>(parsed);
+        Assert.Equal("viewport", parsed);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePointerOrigin()
     {
         Origin origin = Origin.Pointer;
         string json = JsonSerializer.Serialize(origin.Value);
         string? parsed = JsonSerializer.Deserialize<string>(json);
-        Assert.That(parsed, Is.InstanceOf<string>());
-        Assert.That(parsed, Is.EqualTo("pointer"));
+        Assert.IsType<string>(parsed);
+        Assert.Equal("pointer", parsed);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeElementOrigin()
     {
         string nodeJson = """
@@ -36,41 +35,45 @@ public class OriginTests
                             "type": "node",
                             "value": {
                               "nodeType": 1,
-                              "childNodeCount": 0 
+                              "childNodeCount": 0
                             },
                             "sharedId": "testSharedId"
                           }
                           """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         SharedReference node = ((NodeRemoteValue)remoteValue).ToSharedReference();
 
         ElementOrigin elementOrigin = new(node);
         Origin origin = Origin.Element(elementOrigin);
         string json = JsonSerializer.Serialize(origin.Value);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("element"));
-            Assert.That(serialized, Contains.Key("element"));
-            Assert.That(serialized["element"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? serializedElementReference = serialized["element"]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serializedElementReference, Is.Not.Null);
-            Assert.That(serializedElementReference, Has.Count.EqualTo(1));
-            Assert.That(serializedElementReference, Contains.Key("sharedId"));
-            Assert.That(serializedElementReference!["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serializedElementReference["sharedId"]!.Value<string>(), Is.EqualTo("testSharedId"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("element", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("element"));
+        JToken? elementToken = serialized["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+
+        JObject? serializedElementReference = elementToken.Value<JObject>();
+        Assert.NotNull(serializedElementReference);
+        Assert.Single(serializedElementReference);
+        Assert.True(serializedElementReference.ContainsKey("sharedId"));
+
+        JToken? sharedId = serializedElementReference["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("testSharedId", sharedId.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeElementOriginFromSharedReference()
     {
         string nodeJson = """
@@ -78,36 +81,40 @@ public class OriginTests
                             "type": "node",
                             "value": {
                               "nodeType": 1,
-                              "childNodeCount": 0 
+                              "childNodeCount": 0
                             },
                             "sharedId": "testSharedId"
                           }
                           """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         SharedReference node = ((NodeRemoteValue)remoteValue).ToSharedReference();
 
         Origin origin = Origin.Element(node);
         string json = JsonSerializer.Serialize(origin.Value);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("element"));
-            Assert.That(serialized, Contains.Key("element"));
-            Assert.That(serialized["element"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? serializedElementReference = serialized["element"]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serializedElementReference, Is.Not.Null);
-            Assert.That(serializedElementReference, Has.Count.EqualTo(1));
-            Assert.That(serializedElementReference, Contains.Key("sharedId"));
-            Assert.That(serializedElementReference!["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serializedElementReference["sharedId"]!.Value<string>(), Is.EqualTo("testSharedId"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("element", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("element"));
+        JToken? elementToken = serialized["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+
+        JObject? serializedElementReference = elementToken.Value<JObject>();
+        Assert.NotNull(serializedElementReference);
+        Assert.Single(serializedElementReference);
+        Assert.True(serializedElementReference.ContainsKey("sharedId"));
+
+        JToken? sharedId = serializedElementReference["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("testSharedId", sharedId.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PauseActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PauseActionTests.cs
@@ -3,25 +3,24 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PauseActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PauseAction properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pause"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pause", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalDuration()
     {
         PauseAction properties = new()
@@ -30,15 +29,18 @@ public class PauseActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pause"));
-            Assert.That(serialized, Contains.Key("duration"));
-            Assert.That(serialized["duration"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["duration"]!.Value<long>(), Is.EqualTo(1));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pause", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("duration"));
+        JToken? duration = serialized["duration"];
+        Assert.NotNull(duration);
+        Assert.Equal(JTokenType.Integer, duration.Type);
+        Assert.Equal(1L, duration.Value<long>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PerformActionsCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PerformActionsCommandParametersTests.cs
@@ -3,31 +3,35 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PerformActionsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         PerformActionsCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("input.performActions"));
+        Assert.Equal("input.performActions", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PerformActionsCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"], Is.Empty);
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PerformActionsCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PerformActionsCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Input;
 
 using System.Text.Json;
 
-[TestFixture]
 public class PerformActionsCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         PerformActionsCommandResult? result = JsonSerializer.Deserialize<PerformActionsCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         PerformActionsCommandResult? result = JsonSerializer.Deserialize<PerformActionsCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         PerformActionsCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PointerDownActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PointerDownActionTests.cs
@@ -3,28 +3,30 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PointerDownActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PointerDownAction properties = new(0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerDown"));
-            Assert.That(serialized, Contains.Key("button"));
-            Assert.That(serialized["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["button"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerDown", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("button"));
+        JToken? button = serialized["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0L, button.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalWidthAndHeight()
     {
         PointerDownAction properties = new(0)
@@ -34,25 +36,34 @@ public class PointerDownActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerDown"));
-            Assert.That(serialized, Contains.Key("button"));
-            Assert.That(serialized["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["button"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("width"));
-            Assert.That(serialized["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["width"]!.Value<long>(), Is.EqualTo(1));
-            Assert.That(serialized, Contains.Key("height"));
-            Assert.That(serialized["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["height"]!.Value<long>(), Is.EqualTo(1));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerDown", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("button"));
+        JToken? button = serialized["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0L, button.Value<long>());
+
+        Assert.True(serialized.ContainsKey("width"));
+        JToken? width = serialized["width"];
+        Assert.NotNull(width);
+        Assert.Equal(JTokenType.Integer, width.Type);
+        Assert.Equal(1L, width.Value<long>());
+
+        Assert.True(serialized.ContainsKey("height"));
+        JToken? height = serialized["height"];
+        Assert.NotNull(height);
+        Assert.Equal(JTokenType.Integer, height.Type);
+        Assert.Equal(1L, height.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalPressureProperties()
     {
         PointerDownAction properties = new(0)
@@ -62,25 +73,34 @@ public class PointerDownActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerDown"));
-            Assert.That(serialized, Contains.Key("button"));
-            Assert.That(serialized["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["button"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("pressure"));
-            Assert.That(serialized["pressure"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["pressure"]!.Value<double>(), Is.EqualTo(1));
-            Assert.That(serialized, Contains.Key("tangentialPressure"));
-            Assert.That(serialized["tangentialPressure"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["tangentialPressure"]!.Value<double>(), Is.EqualTo(1));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerDown", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("button"));
+        JToken? button = serialized["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0L, button.Value<long>());
+
+        Assert.True(serialized.ContainsKey("pressure"));
+        JToken? pressure = serialized["pressure"];
+        Assert.NotNull(pressure);
+        Assert.Equal(JTokenType.Float, pressure.Type);
+        Assert.Equal(1, pressure.Value<double>());
+
+        Assert.True(serialized.ContainsKey("tangentialPressure"));
+        JToken? tangentialPressure = serialized["tangentialPressure"];
+        Assert.NotNull(tangentialPressure);
+        Assert.Equal(JTokenType.Float, tangentialPressure.Type);
+        Assert.Equal(1, tangentialPressure.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalTwistProperty()
     {
         PointerDownAction properties = new(0)
@@ -89,29 +109,35 @@ public class PointerDownActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerDown"));
-            Assert.That(serialized, Contains.Key("button"));
-            Assert.That(serialized["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["button"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("twist"));
-            Assert.That(serialized["twist"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["twist"]!.Value<ulong>(), Is.EqualTo(1));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerDown", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("button"));
+        JToken? button = serialized["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0L, button.Value<long>());
+
+        Assert.True(serialized.ContainsKey("twist"));
+        JToken? twist = serialized["twist"];
+        Assert.NotNull(twist);
+        Assert.Equal(JTokenType.Integer, twist.Type);
+        Assert.Equal(1UL, twist.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingTwistPropertyToInvalidValueThrows()
     {
         PointerDownAction properties = new(0);
-        Assert.That(() => properties.Twist = 360, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Twist value must be between 0 and 359"));
+        Assert.Contains("Twist value must be between 0 and 359", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Twist = 360).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalAngleProperties()
     {
         PointerDownAction properties = new(0)
@@ -121,34 +147,41 @@ public class PointerDownActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerDown"));
-            Assert.That(serialized, Contains.Key("button"));
-            Assert.That(serialized["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["button"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("altitudeAngle"));
-            Assert.That(serialized["altitudeAngle"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["altitudeAngle"]!.Value<double>(), Is.EqualTo(1));
-            Assert.That(serialized, Contains.Key("azimuthAngle"));
-            Assert.That(serialized["azimuthAngle"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["azimuthAngle"]!.Value<double>(), Is.EqualTo(1));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerDown", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("button"));
+        JToken? button = serialized["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0L, button.Value<long>());
+
+        Assert.True(serialized.ContainsKey("altitudeAngle"));
+        JToken? altitudeAngle = serialized["altitudeAngle"];
+        Assert.NotNull(altitudeAngle);
+        Assert.Equal(JTokenType.Float, altitudeAngle.Type);
+        Assert.Equal(1, altitudeAngle.Value<double>());
+
+        Assert.True(serialized.ContainsKey("azimuthAngle"));
+        JToken? azimuthAngle = serialized["azimuthAngle"];
+        Assert.NotNull(azimuthAngle);
+        Assert.Equal(JTokenType.Float, azimuthAngle.Type);
+        Assert.Equal(1, azimuthAngle.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingAnglePropertiesToInvalidValueThrows()
     {
         PointerDownAction properties = new(0);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => properties.AltitudeAngle = -0.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive"));
-            Assert.That(() => properties.AltitudeAngle = 1.58, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive"));
-            Assert.That(() => properties.AzimuthAngle = -0.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive"));
-            Assert.That(() => properties.AzimuthAngle = 6.29, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive"));
-        }
+
+        Assert.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AltitudeAngle = -0.01).Message);
+        Assert.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AltitudeAngle = 1.58).Message);
+        Assert.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AzimuthAngle = -0.01).Message);
+        Assert.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AzimuthAngle = 6.29).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PointerMoveActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PointerMoveActionTests.cs
@@ -5,31 +5,36 @@ using Newtonsoft.Json.Linq;
 
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class PointerMoveActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PointerMoveAction properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithIntegerPosition()
     {
         PointerMoveAction properties = new()
@@ -39,22 +44,28 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(2));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(3));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(2L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(3L, y.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithFractionalPosition()
     {
         PointerMoveAction properties = new()
@@ -64,22 +75,28 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["x"]!.Value<decimal>(), Is.EqualTo(2.1));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["y"]!.Value<decimal>(), Is.EqualTo(3.4));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Float, x.Type);
+        Assert.Equal(2.1m, x.Value<decimal>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Float, y.Type);
+        Assert.Equal(3.4m, y.Value<decimal>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalDuration()
     {
         PointerMoveAction properties = new()
@@ -88,25 +105,34 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("duration"));
-            Assert.That(serialized["duration"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["duration"]!.Value<long>(), Is.EqualTo(1));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("duration"));
+        JToken? duration = serialized["duration"];
+        Assert.NotNull(duration);
+        Assert.Equal(JTokenType.Integer, duration.Type);
+        Assert.Equal(1L, duration.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalViewportOrigin()
     {
         PointerMoveAction properties = new()
@@ -115,25 +141,34 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("viewport"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("viewport", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalPointerOrigin()
     {
         PointerMoveAction properties = new()
@@ -142,25 +177,34 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("pointer"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("pointer", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalElementOrigin()
     {
         string nodeJson = """
@@ -168,14 +212,14 @@ public class PointerMoveActionTests
                             "type": "node",
                             "value": {
                               "nodeType": 1,
-                              "childNodeCount": 0 
+                              "childNodeCount": 0
                             },
                             "sharedId": "testSharedId"
                           }
                           """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         SharedReference node = ((NodeRemoteValue)remoteValue).ToSharedReference();
         PointerMoveAction properties = new()
         {
@@ -183,39 +227,56 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject originObject = (JObject)serialized["origin"]!;
-        Assert.That(originObject, Has.Count.EqualTo(2));
-        Assert.That(originObject, Contains.Key("type"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(originObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(originObject["type"]!.Value<string>(), Is.EqualTo("element"));
-            Assert.That(originObject, Contains.Key("element"));
-            Assert.That(originObject["element"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject elementObject = (JObject)originObject["element"]!;
-            Assert.That(elementObject, Has.Count.EqualTo(1));
-            Assert.That(elementObject, Contains.Key("sharedId"));
-            Assert.That(elementObject["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(elementObject["sharedId"]!.Value<string>(), Is.EqualTo("testSharedId"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? originToken = serialized["origin"];
+        Assert.NotNull(originToken);
+        Assert.Equal(JTokenType.Object, originToken.Type);
+
+        JObject originObject = (JObject)originToken;
+        Assert.Equal(2, originObject.Count);
+        Assert.True(originObject.ContainsKey("type"));
+
+        JToken? originType = originObject["type"];
+        Assert.NotNull(originType);
+        Assert.Equal(JTokenType.String, originType.Type);
+        Assert.Equal("element", originType.Value<string>());
+
+        Assert.True(originObject.ContainsKey("element"));
+        JToken? elementToken = originObject["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+
+        JObject elementObject = (JObject)elementToken;
+        Assert.Single(elementObject);
+        Assert.True(elementObject.ContainsKey("sharedId"));
+
+        JToken? sharedId = elementObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("testSharedId", sharedId.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalWidthAndHeight()
     {
         PointerMoveAction properties = new()
@@ -225,28 +286,40 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("width"));
-            Assert.That(serialized["width"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["width"]!.Value<long>(), Is.EqualTo(1));
-            Assert.That(serialized, Contains.Key("height"));
-            Assert.That(serialized["height"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["height"]!.Value<long>(), Is.EqualTo(1));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("width"));
+        JToken? width = serialized["width"];
+        Assert.NotNull(width);
+        Assert.Equal(JTokenType.Integer, width.Type);
+        Assert.Equal(1L, width.Value<long>());
+
+        Assert.True(serialized.ContainsKey("height"));
+        JToken? height = serialized["height"];
+        Assert.NotNull(height);
+        Assert.Equal(JTokenType.Integer, height.Type);
+        Assert.Equal(1L, height.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalPressureProperties()
     {
         PointerMoveAction properties = new()
@@ -256,28 +329,40 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("pressure"));
-            Assert.That(serialized["pressure"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["pressure"]!.Value<double>(), Is.EqualTo(1));
-            Assert.That(serialized, Contains.Key("tangentialPressure"));
-            Assert.That(serialized["tangentialPressure"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["tangentialPressure"]!.Value<double>(), Is.EqualTo(1));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("pressure"));
+        JToken? pressure = serialized["pressure"];
+        Assert.NotNull(pressure);
+        Assert.Equal(JTokenType.Float, pressure.Type);
+        Assert.Equal(1, pressure.Value<double>());
+
+        Assert.True(serialized.ContainsKey("tangentialPressure"));
+        JToken? tangentialPressure = serialized["tangentialPressure"];
+        Assert.NotNull(tangentialPressure);
+        Assert.Equal(JTokenType.Float, tangentialPressure.Type);
+        Assert.Equal(1, tangentialPressure.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalTwistProperty()
     {
         PointerMoveAction properties = new()
@@ -286,32 +371,41 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("twist"));
-            Assert.That(serialized["twist"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["twist"]!.Value<ulong>(), Is.EqualTo(1));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("twist"));
+        JToken? twist = serialized["twist"];
+        Assert.NotNull(twist);
+        Assert.Equal(JTokenType.Integer, twist.Type);
+        Assert.Equal(1UL, twist.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingTwistPropertyToInvalidValueThrows()
     {
         PointerMoveAction properties = new();
-        Assert.That(() => properties.Twist = 360, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("Twist value must be between 0 and 359"));
+        Assert.Contains("Twist value must be between 0 and 359", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.Twist = 360).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalAngleProperties()
     {
         PointerMoveAction properties = new()
@@ -321,37 +415,47 @@ public class PointerMoveActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerMove"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("altitudeAngle"));
-            Assert.That(serialized["altitudeAngle"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["altitudeAngle"]!.Value<double>(), Is.EqualTo(1));
-            Assert.That(serialized, Contains.Key("azimuthAngle"));
-            Assert.That(serialized["azimuthAngle"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(serialized["azimuthAngle"]!.Value<double>(), Is.EqualTo(1));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerMove", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("altitudeAngle"));
+        JToken? altitudeAngle = serialized["altitudeAngle"];
+        Assert.NotNull(altitudeAngle);
+        Assert.Equal(JTokenType.Float, altitudeAngle.Type);
+        Assert.Equal(1, altitudeAngle.Value<double>());
+
+        Assert.True(serialized.ContainsKey("azimuthAngle"));
+        JToken? azimuthAngle = serialized["azimuthAngle"];
+        Assert.NotNull(azimuthAngle);
+        Assert.Equal(JTokenType.Float, azimuthAngle.Type);
+        Assert.Equal(1, azimuthAngle.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingAnglePropertiesToInvalidValueThrows()
     {
         PointerDownAction properties = new(0);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => properties.AltitudeAngle = -0.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive"));
-            Assert.That(() => properties.AltitudeAngle = 1.58, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive"));
-            Assert.That(() => properties.AzimuthAngle = -0.01, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive"));
-            Assert.That(() => properties.AzimuthAngle = 6.29, Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive"));
-        }
+
+        Assert.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AltitudeAngle = -0.01).Message);
+        Assert.Contains("AltitudeAngle value must be between 0 and 1.5707963267948966 (pi / 2) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AltitudeAngle = 1.58).Message);
+        Assert.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AzimuthAngle = -0.01).Message);
+        Assert.Contains("AzimuthAngle value must be between 0 and 6.283185307179586 (2 * pi) inclusive", Assert.ThrowsAny<ArgumentOutOfRangeException>(() => properties.AzimuthAngle = 6.29).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PointerSourceActionsTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PointerSourceActionsTests.cs
@@ -3,30 +3,37 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PointerSourceActionsTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PointerSourceActions properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointer"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointer", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalMousePointerType()
     {
         PointerSourceActions properties = new()
@@ -38,31 +45,43 @@ public class PointerSourceActionsTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointer"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("parameters"));
-            Assert.That(serialized["parameters"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject parametersObject = (JObject)serialized["parameters"]!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parametersObject, Has.Count.EqualTo(1));
-            Assert.That(parametersObject, Contains.Key("pointerType"));
-            Assert.That(parametersObject["pointerType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parametersObject["pointerType"]!.Value<string>(), Is.EqualTo("mouse"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointer", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
+
+        Assert.True(serialized.ContainsKey("parameters"));
+        JToken? parametersToken = serialized["parameters"];
+        Assert.NotNull(parametersToken);
+        Assert.Equal(JTokenType.Object, parametersToken.Type);
+
+        JObject parametersObject = (JObject)parametersToken;
+        Assert.Single(parametersObject);
+        Assert.True(parametersObject.ContainsKey("pointerType"));
+
+        JToken? pointerType = parametersObject["pointerType"];
+        Assert.NotNull(pointerType);
+        Assert.Equal(JTokenType.String, pointerType.Type);
+        Assert.Equal("mouse", pointerType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalPenPointerType()
     {
         PointerSourceActions properties = new()
@@ -74,31 +93,43 @@ public class PointerSourceActionsTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointer"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("parameters"));
-            Assert.That(serialized["parameters"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject parametersObject = (JObject)serialized["parameters"]!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parametersObject, Has.Count.EqualTo(1));
-            Assert.That(parametersObject, Contains.Key("pointerType"));
-            Assert.That(parametersObject["pointerType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parametersObject["pointerType"]!.Value<string>(), Is.EqualTo("pen"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointer", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
+
+        Assert.True(serialized.ContainsKey("parameters"));
+        JToken? parametersToken = serialized["parameters"];
+        Assert.NotNull(parametersToken);
+        Assert.Equal(JTokenType.Object, parametersToken.Type);
+
+        JObject parametersObject = (JObject)parametersToken;
+        Assert.Single(parametersObject);
+        Assert.True(parametersObject.ContainsKey("pointerType"));
+
+        JToken? pointerType = parametersObject["pointerType"];
+        Assert.NotNull(pointerType);
+        Assert.Equal(JTokenType.String, pointerType.Type);
+        Assert.Equal("pen", pointerType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalTouchPointerType()
     {
         PointerSourceActions properties = new()
@@ -110,31 +141,43 @@ public class PointerSourceActionsTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointer"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("parameters"));
-            Assert.That(serialized["parameters"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject parametersObject = (JObject)serialized["parameters"]!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parametersObject, Has.Count.EqualTo(1));
-            Assert.That(parametersObject, Contains.Key("pointerType"));
-            Assert.That(parametersObject["pointerType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parametersObject["pointerType"]!.Value<string>(), Is.EqualTo("touch"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointer", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
+
+        Assert.True(serialized.ContainsKey("parameters"));
+        JToken? parametersToken = serialized["parameters"];
+        Assert.NotNull(parametersToken);
+        Assert.Equal(JTokenType.Object, parametersToken.Type);
+
+        JObject parametersObject = (JObject)parametersToken;
+        Assert.Single(parametersObject);
+        Assert.True(parametersObject.ContainsKey("pointerType"));
+
+        JToken? pointerType = parametersObject["pointerType"];
+        Assert.NotNull(pointerType);
+        Assert.Equal(JTokenType.String, pointerType.Type);
+        Assert.Equal("touch", pointerType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalUnspecifiedPointerType()
     {
         PointerSourceActions properties = new()
@@ -143,60 +186,82 @@ public class PointerSourceActionsTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointer"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("parameters"));
-            Assert.That(serialized["parameters"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject parametersObject = (JObject)serialized["parameters"]!;
-        Assert.That(parametersObject, Is.Empty);
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointer", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
+
+        Assert.True(serialized.ContainsKey("parameters"));
+        JToken? parametersToken = serialized["parameters"];
+        Assert.NotNull(parametersToken);
+        Assert.Equal(JTokenType.Object, parametersToken.Type);
+
+        JObject parametersObject = (JObject)parametersToken;
+        Assert.Empty(parametersObject);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithActions()
     {
         PointerSourceActions properties = new();
         properties.Actions.Add(new PointerDownAction(0));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"], Is.Not.Null);
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointer"));
-            Assert.That(serialized["actions"], Is.Not.Null);
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["actions"]![0], Is.Not.Null);
-            Assert.That(serialized["actions"]![0]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? action = serialized["actions"]![0]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(action, Is.Not.Null);
-            Assert.That(action, Has.Count.EqualTo(2));
-            Assert.That(action, Contains.Key("type"));
-            Assert.That(action!["type"], Is.Not.Null);
-            Assert.That(action!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(action!["type"]!.Value<string>(), Is.EqualTo("pointerDown"));
-            Assert.That(action, Contains.Key("button"));
-            Assert.That(action!["button"], Is.Not.Null);
-            Assert.That(action!["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(action!["button"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointer", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Single(actionsArray);
+
+        JToken? actionToken = actionsArray[0];
+        Assert.NotNull(actionToken);
+        Assert.Equal(JTokenType.Object, actionToken.Type);
+
+        JObject? action = actionToken.Value<JObject>();
+        Assert.NotNull(action);
+        Assert.Equal(2, action.Count);
+
+        Assert.True(action.ContainsKey("type"));
+        JToken? actionType = action["type"];
+        Assert.NotNull(actionType);
+        Assert.Equal(JTokenType.String, actionType.Type);
+        Assert.Equal("pointerDown", actionType.Value<string>());
+
+        Assert.True(action.ContainsKey("button"));
+        JToken? button = action["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0, button.Value<long>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/PointerUpActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/PointerUpActionTests.cs
@@ -3,24 +3,26 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PointerUpActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         PointerUpAction properties = new(0);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pointerUp"));
-            Assert.That(serialized, Contains.Key("button"));
-            Assert.That(serialized["button"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["button"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pointerUp", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("button"));
+        JToken? button = serialized["button"];
+        Assert.NotNull(button);
+        Assert.Equal(JTokenType.Integer, button.Type);
+        Assert.Equal(0L, button.Value<long>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/ReleaseActionsCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/ReleaseActionsCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ReleaseActionsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ReleaseActionsCommandParameters properties = new("myContextId");
-        Assert.That(properties.MethodName, Is.EqualTo("input.releaseActions"));
+        Assert.Equal("input.releaseActions", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ReleaseActionsCommandParameters properties = new("myContextId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/ReleaseActionsCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/ReleaseActionsCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Input;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ReleaseActionsCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         ReleaseActionsCommandResult? result = JsonSerializer.Deserialize<ReleaseActionsCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ReleaseActionsCommandResult? result = JsonSerializer.Deserialize<ReleaseActionsCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ReleaseActionsCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/SetFilesCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/SetFilesCommandParametersTests.cs
@@ -4,45 +4,52 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class SetFilesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SharedReference element = new("mySharedId");
         SetFilesCommandParameters properties = new("myContextId", element);
-        Assert.That(properties.MethodName, Is.EqualTo("input.setFiles"));
+        Assert.Equal("input.setFiles", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SharedReference element = new("mySharedId");
         SetFilesCommandParameters properties = new("myContextId", element);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("element"));
-            Assert.That(serialized["element"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["element"]!.Value<JObject>(), Is.Not.Null);
-            JObject elementObject = serialized["element"]!.Value<JObject>()!;
-            Assert.That(elementObject, Has.Count.EqualTo(1));
-            Assert.That(elementObject, Contains.Key("sharedId"));
-            Assert.That(elementObject["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(elementObject["sharedId"]!.Value<string>(), Is.EqualTo("mySharedId"));
-            Assert.That(serialized, Contains.Key("files"));
-            Assert.That(serialized["files"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["files"]!, Is.Empty);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("element"));
+        JToken? elementToken = serialized["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+        JObject? elementObject = elementToken.Value<JObject>();
+        Assert.NotNull(elementObject);
+        Assert.Single(elementObject);
+        Assert.True(elementObject.ContainsKey("sharedId"));
+        JToken? sharedId = elementObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("mySharedId", sharedId.Value<string>());
+
+        Assert.True(serialized.ContainsKey("files"));
+        JToken? filesToken = serialized["files"];
+        Assert.NotNull(filesToken);
+        Assert.Equal(JTokenType.Array, filesToken.Type);
+        Assert.Empty(filesToken);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithFileList()
     {
         SharedReference element = new("mySharedId");
@@ -51,29 +58,37 @@ public class SetFilesCommandParametersTests
         properties.Files.Add("path/to/file2.txt");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myContextId"));
-            Assert.That(serialized, Contains.Key("element"));
-            Assert.That(serialized["element"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized["element"]!.Value<JObject>(), Is.Not.Null);
-            JObject elementObject = serialized["element"]!.Value<JObject>()!;
-            Assert.That(elementObject, Has.Count.EqualTo(1));
-            Assert.That(elementObject, Contains.Key("sharedId"));
-            Assert.That(elementObject["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(elementObject["sharedId"]!.Value<string>(), Is.EqualTo("mySharedId"));
-            Assert.That(serialized, Contains.Key("files"));
-            Assert.That(serialized["files"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["files"]!.Value<JArray>(), Is.Not.Null);
-            JArray filesArray = serialized["files"]!.Value<JArray>()!;
-            Assert.That(filesArray, Has.Count.EqualTo(2));
-            Assert.That(filesArray[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(filesArray[0].Value<string>(), Is.EqualTo("path/to/file1.txt"));
-            Assert.That(filesArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(filesArray[1].Value<string>(), Is.EqualTo("path/to/file2.txt"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myContextId", context.Value<string>());
+
+        Assert.True(serialized.ContainsKey("element"));
+        JToken? elementToken = serialized["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+        JObject? elementObject = elementToken.Value<JObject>();
+        Assert.NotNull(elementObject);
+        Assert.Single(elementObject);
+        Assert.True(elementObject.ContainsKey("sharedId"));
+        JToken? sharedId = elementObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("mySharedId", sharedId.Value<string>());
+
+        Assert.True(serialized.ContainsKey("files"));
+        JToken? filesToken = serialized["files"];
+        Assert.NotNull(filesToken);
+        Assert.Equal(JTokenType.Array, filesToken.Type);
+        JArray? filesArray = filesToken.Value<JArray>();
+        Assert.NotNull(filesArray);
+        Assert.Equal(2, filesArray.Count);
+        Assert.Equal(JTokenType.String, filesArray[0].Type);
+        Assert.Equal("path/to/file1.txt", filesArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, filesArray[1].Type);
+        Assert.Equal("path/to/file2.txt", filesArray[1].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/SetFilesCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/SetFilesCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Input;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetFilesCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetFilesCommandResult? result = JsonSerializer.Deserialize<SetFilesCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetFilesCommandResult? result = JsonSerializer.Deserialize<SetFilesCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetFilesCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/WheelScrollActionTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/WheelScrollActionTests.cs
@@ -5,37 +5,48 @@ using Newtonsoft.Json.Linq;
 
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class WheelScrollActionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         WheelScrollAction properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(5));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("scroll"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaX"));
-            Assert.That(serialized["deltaX"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaX"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaY"));
-            Assert.That(serialized["deltaY"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaY"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(5, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("scroll", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaX"));
+        JToken? deltaX = serialized["deltaX"];
+        Assert.NotNull(deltaX);
+        Assert.Equal(JTokenType.Integer, deltaX.Type);
+        Assert.Equal(0L, deltaX.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaY"));
+        JToken? deltaY = serialized["deltaY"];
+        Assert.NotNull(deltaY);
+        Assert.Equal(JTokenType.Integer, deltaY.Type);
+        Assert.Equal(0L, deltaY.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalDuration()
     {
         WheelScrollAction properties = new()
@@ -44,31 +55,46 @@ public class WheelScrollActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("scroll"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaX"));
-            Assert.That(serialized["deltaX"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaX"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaY"));
-            Assert.That(serialized["deltaY"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaY"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("duration"));
-            Assert.That(serialized["duration"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["duration"]!.Value<long>(), Is.EqualTo(1));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("scroll", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaX"));
+        JToken? deltaX = serialized["deltaX"];
+        Assert.NotNull(deltaX);
+        Assert.Equal(JTokenType.Integer, deltaX.Type);
+        Assert.Equal(0L, deltaX.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaY"));
+        JToken? deltaY = serialized["deltaY"];
+        Assert.NotNull(deltaY);
+        Assert.Equal(JTokenType.Integer, deltaY.Type);
+        Assert.Equal(0L, deltaY.Value<long>());
+
+        Assert.True(serialized.ContainsKey("duration"));
+        JToken? duration = serialized["duration"];
+        Assert.NotNull(duration);
+        Assert.Equal(JTokenType.Integer, duration.Type);
+        Assert.Equal(1L, duration.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalViewportOrigin()
     {
         WheelScrollAction properties = new()
@@ -77,31 +103,46 @@ public class WheelScrollActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("scroll"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaX"));
-            Assert.That(serialized["deltaX"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaX"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaY"));
-            Assert.That(serialized["deltaY"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaY"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("viewport"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("scroll", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaX"));
+        JToken? deltaX = serialized["deltaX"];
+        Assert.NotNull(deltaX);
+        Assert.Equal(JTokenType.Integer, deltaX.Type);
+        Assert.Equal(0L, deltaX.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaY"));
+        JToken? deltaY = serialized["deltaY"];
+        Assert.NotNull(deltaY);
+        Assert.Equal(JTokenType.Integer, deltaY.Type);
+        Assert.Equal(0L, deltaY.Value<long>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("viewport", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalPointerOrigin()
     {
         WheelScrollAction properties = new()
@@ -110,31 +151,46 @@ public class WheelScrollActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("scroll"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaX"));
-            Assert.That(serialized["deltaX"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaX"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaY"));
-            Assert.That(serialized["deltaY"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaY"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("pointer"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("scroll", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaX"));
+        JToken? deltaX = serialized["deltaX"];
+        Assert.NotNull(deltaX);
+        Assert.Equal(JTokenType.Integer, deltaX.Type);
+        Assert.Equal(0L, deltaX.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaY"));
+        JToken? deltaY = serialized["deltaY"];
+        Assert.NotNull(deltaY);
+        Assert.Equal(JTokenType.Integer, deltaY.Type);
+        Assert.Equal(0L, deltaY.Value<long>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("pointer", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalElementOrigin()
     {
         string nodeJson = """
@@ -142,14 +198,14 @@ public class WheelScrollActionTests
                             "type": "node",
                             "value": {
                               "nodeType": 1,
-                              "childNodeCount": 0 
+                              "childNodeCount": 0
                             },
                             "sharedId": "testSharedId"
                           }
                           """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(nodeJson);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         SharedReference node = ((NodeRemoteValue)remoteValue).ToSharedReference();
         WheelScrollAction properties = new()
         {
@@ -157,41 +213,64 @@ public class WheelScrollActionTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("scroll"));
-            Assert.That(serialized, Contains.Key("x"));
-            Assert.That(serialized["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("y"));
-            Assert.That(serialized["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaX"));
-            Assert.That(serialized["deltaX"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaX"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("deltaY"));
-            Assert.That(serialized["deltaY"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["deltaY"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject originObject = (JObject)serialized["origin"]!;
-        Assert.That(originObject, Has.Count.EqualTo(2));
-        Assert.That(originObject, Contains.Key("type"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(originObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(originObject["type"]!.Value<string>(), Is.EqualTo("element"));
-            Assert.That(originObject, Contains.Key("element"));
-            Assert.That(originObject["element"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject elementObject = (JObject)originObject["element"]!;
-            Assert.That(elementObject, Has.Count.EqualTo(1));
-            Assert.That(elementObject, Contains.Key("sharedId"));
-            Assert.That(elementObject["sharedId"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(elementObject["sharedId"]!.Value<string>(), Is.EqualTo("testSharedId"));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("scroll", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("x"));
+        JToken? x = serialized["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0L, x.Value<long>());
+
+        Assert.True(serialized.ContainsKey("y"));
+        JToken? y = serialized["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaX"));
+        JToken? deltaX = serialized["deltaX"];
+        Assert.NotNull(deltaX);
+        Assert.Equal(JTokenType.Integer, deltaX.Type);
+        Assert.Equal(0L, deltaX.Value<long>());
+
+        Assert.True(serialized.ContainsKey("deltaY"));
+        JToken? deltaY = serialized["deltaY"];
+        Assert.NotNull(deltaY);
+        Assert.Equal(JTokenType.Integer, deltaY.Type);
+        Assert.Equal(0L, deltaY.Value<long>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? originToken = serialized["origin"];
+        Assert.NotNull(originToken);
+        Assert.Equal(JTokenType.Object, originToken.Type);
+
+        JObject originObject = (JObject)originToken;
+        Assert.Equal(2, originObject.Count);
+        Assert.True(originObject.ContainsKey("type"));
+
+        JToken? originType = originObject["type"];
+        Assert.NotNull(originType);
+        Assert.Equal(JTokenType.String, originType.Type);
+        Assert.Equal("element", originType.Value<string>());
+
+        Assert.True(originObject.ContainsKey("element"));
+        JToken? elementToken = originObject["element"];
+        Assert.NotNull(elementToken);
+        Assert.Equal(JTokenType.Object, elementToken.Type);
+
+        JObject elementObject = (JObject)elementToken;
+        Assert.Single(elementObject);
+        Assert.True(elementObject.ContainsKey("sharedId"));
+
+        JToken? sharedId = elementObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal(JTokenType.String, sharedId.Type);
+        Assert.Equal("testSharedId", sharedId.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Input/WheelSourceActionsTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/WheelSourceActionsTests.cs
@@ -3,77 +3,100 @@ namespace WebDriverBiDi.Input;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class WheelSourceActionsTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         WheelSourceActions properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("wheel"));
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Is.Empty);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("wheel", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Empty(actionsArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithActions()
     {
         WheelSourceActions properties = new();
         properties.Actions.Add(new WheelScrollAction());
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("id"));
-            Assert.That(serialized["id"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"], Is.Not.Null);
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("wheel"));
-            Assert.That(serialized["actions"], Is.Not.Null);
-            Assert.That(serialized, Contains.Key("actions"));
-            Assert.That(serialized["actions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["actions"]!.Value<JArray>(), Has.Count.EqualTo(1));
-            Assert.That(serialized["actions"]![0], Is.Not.Null);
-            Assert.That(serialized["actions"]![0]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? action = serialized["actions"]![0]!.Value<JObject>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(action, Is.Not.Null);
-            Assert.That(action, Has.Count.EqualTo(5));
-            Assert.That(action, Contains.Key("type"));
-            Assert.That(action!["type"], Is.Not.Null);
-            Assert.That(action!["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(action!["type"]!.Value<string>(), Is.EqualTo("scroll"));
-            Assert.That(action, Contains.Key("x"));
-            Assert.That(action!["x"], Is.Not.Null);
-            Assert.That(action!["x"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(action!["x"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(action, Contains.Key("y"));
-            Assert.That(action!["y"], Is.Not.Null);
-            Assert.That(action!["y"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(action!["y"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(action, Contains.Key("deltaX"));
-            Assert.That(action!["deltaX"], Is.Not.Null);
-            Assert.That(action!["deltaX"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(action!["deltaX"]!.Value<long>(), Is.EqualTo(0));
-            Assert.That(action, Contains.Key("deltaY"));
-            Assert.That(action!["deltaY"], Is.Not.Null);
-            Assert.That(action!["deltaY"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(action!["deltaY"]!.Value<long>(), Is.EqualTo(0));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("id"));
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(JTokenType.String, id.Type);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("wheel", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("actions"));
+        JToken? actionsToken = serialized["actions"];
+        Assert.NotNull(actionsToken);
+        Assert.Equal(JTokenType.Array, actionsToken.Type);
+        JArray? actionsArray = actionsToken.Value<JArray>();
+        Assert.NotNull(actionsArray);
+        Assert.Single(actionsArray);
+
+        JToken? actionToken = actionsArray[0];
+        Assert.NotNull(actionToken);
+        Assert.Equal(JTokenType.Object, actionToken.Type);
+
+        JObject? action = actionToken.Value<JObject>();
+        Assert.NotNull(action);
+        Assert.Equal(5, action.Count);
+
+        Assert.True(action.ContainsKey("type"));
+        JToken? actionType = action["type"];
+        Assert.NotNull(actionType);
+        Assert.Equal(JTokenType.String, actionType.Type);
+        Assert.Equal("scroll", actionType.Value<string>());
+
+        Assert.True(action.ContainsKey("x"));
+        JToken? x = action["x"];
+        Assert.NotNull(x);
+        Assert.Equal(JTokenType.Integer, x.Type);
+        Assert.Equal(0, x.Value<long>());
+
+        Assert.True(action.ContainsKey("y"));
+        JToken? y = action["y"];
+        Assert.NotNull(y);
+        Assert.Equal(JTokenType.Integer, y.Type);
+        Assert.Equal(0L, y.Value<long>());
+
+        Assert.True(action.ContainsKey("deltaX"));
+        JToken? deltaX = action["deltaX"];
+        Assert.NotNull(deltaX);
+        Assert.Equal(JTokenType.Integer, deltaX.Type);
+        Assert.Equal(0L, deltaX.Value<long>());
+
+        Assert.True(action.ContainsKey("deltaY"));
+        JToken? deltaY = action["deltaY"];
+        Assert.NotNull(deltaY);
+        Assert.Equal(JTokenType.Integer, deltaY.Type);
+        Assert.Equal(0, deltaY.Value<long>());
     }
 }

--- a/test/WebDriverBiDi.Tests/JsonConverters/BigIntegerJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/BigIntegerJsonConverterTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.JsonConverters;
 using System.Numerics;
 using System.Text.Json;
 
-[TestFixture]
 public class BigIntegerJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestDeserializingValidBigInteger()
     {
         string json = "\"123456789012345678901234567890\"";
         BigInteger? result = JsonSerializer.Deserialize<BigInteger>(json, new JsonSerializerOptions { Converters = { new BigIntegerJsonConverter() } });
-        Assert.That(result, Is.EqualTo(BigInteger.Parse("123456789012345678901234567890")));
+        Assert.Equal(BigInteger.Parse("123456789012345678901234567890"), result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidBigIntegerThrows()
     {
         string json = "\"not-a-big-integer\"";
-        Assert.That(() => JsonSerializer.Deserialize<BigInteger>(json, new JsonSerializerOptions { Converters = { new BigIntegerJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.EqualTo($"Cannot parse invalid value 'not-a-big-integer' for bigint"));
+        Assert.Equal($"Cannot parse invalid value 'not-a-big-integer' for bigint", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BigInteger>(json, new JsonSerializerOptions { Converters = { new BigIntegerJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestSerializationThrows()
     {
         BigInteger value = BigInteger.Parse("123456789012345678901234567890");
-        Assert.That(() => JsonSerializer.Serialize(value, new JsonSerializerOptions { Converters = { new BigIntegerJsonConverter() } }), Throws.InstanceOf<NotSupportedException>());
+        Assert.ThrowsAny<NotSupportedException>(() => JsonSerializer.Serialize(value, new JsonSerializerOptions { Converters = { new BigIntegerJsonConverter() } }));
     }
 }

--- a/test/WebDriverBiDi.Tests/JsonConverters/CommandJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/CommandJsonConverterTests.cs
@@ -5,10 +5,9 @@ using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Protocol;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class CommandJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestReadThrowsNotImplementedException()
     {
         string json = """
@@ -18,23 +17,34 @@ public class CommandJsonConverterTests
                         "params": { "parameterName": "parameterValue" }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Command>(json), Throws.InstanceOf<NotImplementedException>());
+        Assert.ThrowsAny<NotImplementedException>(() => JsonSerializer.Deserialize<Command>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestWriteSerializesCommandWithIdMethodAndParams()
     {
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
         Command command = new(1, commandParams);
         string json = JsonSerializer.Serialize(command);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized["id"]!.Value<long>(), Is.EqualTo(1));
-        Assert.That(serialized["method"]!.Value<string>(), Is.EqualTo("module.command"));
-        Assert.That(serialized["params"], Is.Not.Null);
-        Assert.That(serialized["params"]!["parameterName"]!.Value<string>(), Is.EqualTo("parameterValue"));
+
+        JToken? id = serialized["id"];
+        Assert.NotNull(id);
+        Assert.Equal(1L, id.Value<long>());
+
+        JToken? method = serialized["method"];
+        Assert.NotNull(method);
+        Assert.Equal("module.command", method.Value<string>());
+
+        Assert.NotNull(serialized["params"]);
+        JToken? paramsToken = serialized["params"];
+        Assert.NotNull(paramsToken);
+        JToken? parameterName = paramsToken["parameterName"];
+        Assert.NotNull(parameterName);
+        Assert.Equal("parameterValue", parameterName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestWriteIncludesAdditionalDataInOutput()
     {
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
@@ -42,16 +52,18 @@ public class CommandJsonConverterTests
         Command command = new(1, commandParams);
         string json = JsonSerializer.Serialize(command);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Contains.Key("extraKey"));
-        Assert.That(serialized["extraKey"]!.Value<string>(), Is.EqualTo("extraValue"));
+        Assert.True(serialized.ContainsKey("extraKey"));
+        JToken? extraKey = serialized["extraKey"];
+        Assert.NotNull(extraKey);
+        Assert.Equal("extraValue", extraKey.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestWriteWithNullValueThrowsArgumentNullException()
     {
         CommandJsonConverter converter = new();
         using MemoryStream stream = new();
         using Utf8JsonWriter writer = new(stream);
-        Assert.That(() => converter.Write(writer, null!, new JsonSerializerOptions()), Throws.InstanceOf<ArgumentNullException>());
+        Assert.ThrowsAny<ArgumentNullException>(() => converter.Write(writer, null!, new JsonSerializerOptions()));
     }
 }

--- a/test/WebDriverBiDi.Tests/JsonConverters/DiscrminiatedUnionJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/DiscrminiatedUnionJsonConverterTests.cs
@@ -1,14 +1,11 @@
 namespace WebDriverBiDi.JsonConverters;
 
-using System.Reflection;
-using System.Security;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-[TestFixture]
 public class DiscriminatedUnionJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeDerivedType()
     {
         string json = """
@@ -17,14 +14,15 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyA": "Value for A"
                       }
                       """;
-        ParentTypeWithChildTypes result = JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json)!;
-        Assert.That(result, Is.TypeOf<DerivedTypeA>());
+        ParentTypeWithChildTypes? result = JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json);
+        Assert.NotNull(result);
+        Assert.IsType<DerivedTypeA>(result);
         DerivedTypeA derivedA = (DerivedTypeA)result;
-        Assert.That(derivedA.Type, Is.EqualTo("typeA"));
-        Assert.That(derivedA.PropertyA, Is.EqualTo("Value for A"));
+        Assert.Equal("typeA", derivedA.Type);
+        Assert.Equal("Value for A", derivedA.PropertyA);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDerivedTypeWithInvalidDiscriminatorValueThrows()
     {
         string json = """
@@ -33,10 +31,10 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyC": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'ParentTypeWithChildTypes' type property contains unknown value 'typeC'"));
+        Assert.Contains("JSON for 'ParentTypeWithChildTypes' type property contains unknown value 'typeC'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDerivedTypeWithMissingDiscriminatorPropertyThrows()
     {
         string json = """
@@ -44,10 +42,10 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyC": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'ParentTypeWithChildTypes' must contain a 'type' property"));
+        Assert.Contains("JSON for 'ParentTypeWithChildTypes' must contain a 'type' property", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBaseTypeWithInvalidJsonSchemaThrows()
     {
         string json = """
@@ -56,10 +54,10 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyC"
                       ]
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'ParentTypeWithChildTypes' must be an object, but starting token was StartArray"));
+        Assert.Contains("JSON for 'ParentTypeWithChildTypes' must be an object, but starting token was StartArray", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDerivedTypeWithInvalidDiscriminatorValueTypeThrows()
     {
         string json = """
@@ -68,10 +66,10 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyC": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON 'type' property must be a string"));
+        Assert.Contains("JSON 'type' property must be a string", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ParentTypeWithChildTypes>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithEmptyDiscriminatorValueThrows()
     {
         string json = """
@@ -80,10 +78,10 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyC": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<EmptyDiscriminator>(json), Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("must have a non-empty Discriminator"));
+        Assert.Contains("must have a non-empty Discriminator", Assert.ThrowsAny<InvalidOperationException>(() => JsonSerializer.Deserialize<EmptyDiscriminator>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDiscriminatorValueReturnsNullForAttributeValue()
     {
         string json = """
@@ -92,10 +90,10 @@ public class DiscriminatedUnionJsonConverterTests
                       }
                       """;
         NullForEmptyDiscriminator? result = JsonSerializer.Deserialize<NullForEmptyDiscriminator>(json);
-        Assert.That(result, Is.Null);
+        Assert.Null(result);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeFallbackDerivedType()
     {
         string json = """
@@ -104,14 +102,15 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyA": "Value for A"
                       }
                       """;
-        ParentTypeWithFallback result = JsonSerializer.Deserialize<ParentTypeWithFallback>(json)!;
-        Assert.That(result, Is.TypeOf<FallbackDerivedType>());
+        ParentTypeWithFallback? result = JsonSerializer.Deserialize<ParentTypeWithFallback>(json);
+        Assert.NotNull(result);
+        Assert.IsType<FallbackDerivedType>(result);
         FallbackDerivedType fallbackResult = (FallbackDerivedType)result;
-        Assert.That(fallbackResult.Type, Is.EqualTo("someUnknownType"));
-        Assert.That(fallbackResult.PropertyA, Is.EqualTo("Value for A"));
+        Assert.Equal("someUnknownType", fallbackResult.Type);
+        Assert.Equal("Value for A", fallbackResult.PropertyA);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeBasedOnPropertyPresence()
     {
         string jsonA = """
@@ -119,23 +118,25 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyA": "Value for A"
                       }
                       """;
-        PropertyPresence resultA = JsonSerializer.Deserialize<PropertyPresence>(jsonA)!;
-        Assert.That(resultA, Is.TypeOf<PropertyPresenceChildA>());
+        PropertyPresence? resultA = JsonSerializer.Deserialize<PropertyPresence>(jsonA);
+        Assert.NotNull(resultA);
+        Assert.IsType<PropertyPresenceChildA>(resultA);
         PropertyPresenceChildA childAResult = (PropertyPresenceChildA)resultA;
-        Assert.That(childAResult.PropertyA, Is.EqualTo("Value for A"));
+        Assert.Equal("Value for A", childAResult.PropertyA);
 
         string jsonB = """
                       {
                         "propertyB": 123
                       }
                       """;
-        PropertyPresence resultB = JsonSerializer.Deserialize<PropertyPresence>(jsonB)!;
-        Assert.That(resultB, Is.TypeOf<PropertyPresenceChildB>());
+        PropertyPresence? resultB = JsonSerializer.Deserialize<PropertyPresence>(jsonB);
+        Assert.NotNull(resultB);
+        Assert.IsType<PropertyPresenceChildB>(resultB);
         PropertyPresenceChildB childBResult = (PropertyPresenceChildB)resultB;
-        Assert.That(childBResult.PropertyB, Is.EqualTo(123));
+        Assert.Equal(123, childBResult.PropertyB);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBasedOnPropertyPresenceWithInvalidValueThrows()
     {
         string jsonA = """
@@ -143,10 +144,10 @@ public class DiscriminatedUnionJsonConverterTests
                         "propertyC": "Value for C"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PropertyPresence>(jsonA), Throws.InstanceOf<JsonException>().With.Message.Contains("one of the following properties"));
+        Assert.Contains("one of the following properties", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PropertyPresence>(jsonA)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeDerivedType()
     {
         ParentTypeWithChildTypes derivedB = new DerivedTypeB
@@ -155,10 +156,11 @@ public class DiscriminatedUnionJsonConverterTests
             PropertyB = 42
         };
         string json = JsonSerializer.Serialize(derivedB);
-        Assert.That(json, Is.Not.Null.And.Not.Empty);
+        Assert.NotNull(json);
+        Assert.NotEmpty(json);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingTypeWithMissingDiscriminatedTypePropertyAttributeThrows()
     {
         string json = """
@@ -166,7 +168,7 @@ public class DiscriminatedUnionJsonConverterTests
                         "type": "child"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MissingDiscriminatorAttribute>(json), Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("must have a [DiscriminatedTypeProperty] or [DiscriminatedTypePresence] attribute"));
+        Assert.Contains("must have a [DiscriminatedTypeProperty] or [DiscriminatedTypePresence] attribute", Assert.ThrowsAny<InvalidOperationException>(() => JsonSerializer.Deserialize<MissingDiscriminatorAttribute>(json)).Message);
     }
 
     [JsonConverter(typeof(DiscriminatedUnionJsonConverter<ParentTypeWithChildTypes>))]

--- a/test/WebDriverBiDi.Tests/JsonConverters/EnumValueJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/EnumValueJsonConverterTests.cs
@@ -3,60 +3,59 @@ namespace WebDriverBiDi.JsonConverters;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-[TestFixture]
 public class EnumValueJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void ShouldSerializeValue()
     {
         string json = JsonSerializer.Serialize(BasicEnum.FirstValue);
-        Assert.That(json, Is.EqualTo("\"firstvalue\""));
+        Assert.Equal("\"firstvalue\"", json);
     }
 
-    [Test]
+    [Fact]
     public void ShouldSerializeValueWithCustomSerializedValue()
     {
         string json = JsonSerializer.Serialize(BasicEnum.SecondValue);
-        Assert.That(json, Is.EqualTo("\"second-value\""));
+        Assert.Equal("\"second-value\"", json);
     }
 
-    [Test]
+    [Fact]
     public void ShouldDeserializeBasicValue()
     {
         BasicEnum? value = JsonSerializer.Deserialize<BasicEnum>("\"firstvalue\"");
-        Assert.That(value, Is.EqualTo(BasicEnum.FirstValue));
+        Assert.Equal(BasicEnum.FirstValue, value);
     }
 
-    [Test]
+    [Fact]
     public void ShouldDeserializeCustomValue()
     {
         BasicEnum? value = JsonSerializer.Deserialize<BasicEnum>("\"second-value\"");
-        Assert.That(value, Is.EqualTo(BasicEnum.SecondValue));
+        Assert.Equal(BasicEnum.SecondValue, value);
     }
 
-    [Test]
+    [Fact]
     public void ShouldDeserializeInvalidValueWhenAttributeSet()
     {
         EnumWithDefault? value = JsonSerializer.Deserialize<EnumWithDefault>("\"invalid\"");
-        Assert.That(value, Is.EqualTo(EnumWithDefault.DefaultValue));
+        Assert.Equal(EnumWithDefault.DefaultValue, value);
     }
 
-    [Test]
+    [Fact]
     public void DeserializeNonStringValueThrows()
     {
-        Assert.That(() => JsonSerializer.Deserialize<BasicEnum>("1"), Throws.InstanceOf<JsonException>().With.Message.EqualTo($"Deserialization error reading enumerated string value"));
+        Assert.Equal($"Deserialization error reading enumerated string value", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BasicEnum>("1")).Message);
     }
 
-    [Test]
+    [Fact]
     public void DeserializeInvalidValueThrows()
     {
-        Assert.That(() => JsonSerializer.Deserialize<BasicEnum>("\"invalid\""), Throws.InstanceOf<JsonException>().With.Message.EqualTo($"Deserialization error: value 'invalid' is not valid for enum type BasicEnum"));
+        Assert.Equal($"Deserialization error: value 'invalid' is not valid for enum type BasicEnum", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BasicEnum>("\"invalid\"")).Message);
     }
 
-    [Test]
+    [Fact]
     public void SerializeInvalidValueThrows()
     {
-        Assert.That(() => JsonSerializer.Serialize(FlagEnum.FirstValue | FlagEnum.SecondValue), Throws.InstanceOf<JsonException>().With.Message.StartsWith("Serialization error: value"));
+        Assert.StartsWith("Serialization error: value", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Serialize(FlagEnum.FirstValue | FlagEnum.SecondValue)).Message);
     }
 
     [JsonConverter(typeof(EnumValueJsonConverter<BasicEnum>))]

--- a/test/WebDriverBiDi.Tests/JsonConverters/FixedDoubleJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/FixedDoubleJsonConverterTests.cs
@@ -3,53 +3,52 @@ namespace WebDriverBiDi.JsonConverters;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-[TestFixture]
 public class FixedDoubleJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestReadIntegerJsonNumberReturnsDouble()
     {
         string json = """{ "value": 42 }""";
         TestWrapper? result = JsonSerializer.Deserialize<TestWrapper>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result!.Value, Is.EqualTo(42.0));
+        Assert.NotNull(result);
+        Assert.Equal(42.0, result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestReadDecimalJsonNumberReturnsDouble()
     {
         string json = """{ "value": 3.14 }""";
         TestWrapper? result = JsonSerializer.Deserialize<TestWrapper>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result!.Value, Is.EqualTo(3.14));
+        Assert.NotNull(result);
+        Assert.Equal(3.14, result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestWriteIntegerDoubleOutputsWithDecimal()
     {
         TestWrapper wrapper = new() { Value = 42.0 };
         string json = JsonSerializer.Serialize(wrapper);
-        Assert.That(json, Does.Contain("42.0"));
+        Assert.Contains("42.0", json);
     }
 
-    [Test]
+    [Fact]
     public void TestWriteDecimalDoubleOutputsCorrectly()
     {
         TestWrapper wrapper = new() { Value = 3.14 };
         string json = JsonSerializer.Serialize(wrapper);
-        Assert.That(json, Does.Contain("3.14"));
+        Assert.Contains("3.14", json);
     }
 
-    [Test]
+    [Fact]
     public void TestWriteVeryPreciseDoublePreservesPrecision()
     {
         double preciseValue = 1.23456789012345;
         TestWrapper wrapper = new() { Value = preciseValue };
         string json = JsonSerializer.Serialize(wrapper);
-        Assert.That(json, Does.Contain("1.23456789012345"));
+        Assert.Contains("1.23456789012345", json);
         TestWrapper? deserialized = JsonSerializer.Deserialize<TestWrapper>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        Assert.That(deserialized!.Value, Is.EqualTo(preciseValue));
+        Assert.NotNull(deserialized);
+        Assert.Equal(preciseValue, deserialized.Value);
     }
 
     private class TestWrapper

--- a/test/WebDriverBiDi.Tests/JsonConverters/NumberJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/NumberJsonConverterTests.cs
@@ -2,75 +2,74 @@ namespace WebDriverBiDi.JsonConverters;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NumberJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestDeserializingValidFloatingPointNumber()
     {
         string json = "3.14159";
         double? result = JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } });
-        Assert.That(result, Is.EqualTo(3.14159));
+        Assert.Equal(3.14159, result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInteger()
     {
         string json = "12345";
         double result = JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } });
-        Assert.That(result, Is.EqualTo(12345));
+        Assert.Equal(12345, result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInfinity()
     {
         string json = "\"Infinity\"";
         double result = JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } });
-        Assert.That(result, Is.EqualTo(double.PositiveInfinity));
+        Assert.Equal(double.PositiveInfinity, result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNegativeInfinity()
     {
         string json = "\"-Infinity\"";
         double result = JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } });
-        Assert.That(result, Is.EqualTo(double.NegativeInfinity));
+        Assert.Equal(double.NegativeInfinity, result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNaN()
     {
         string json = "\"NaN\"";
         double result = JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } });
-        Assert.That(result, Is.EqualTo(double.NaN));
+        Assert.Equal(double.NaN, result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNegativeZero()
     {
         string json = "\"-0\"";
         double result = JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } });
-        Assert.That(result, Is.EqualTo(-0.0));
+        Assert.Equal(-0.0, result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidStringThrows()
     {
         string json = "\"not-a-number\"";
-        Assert.That(() => JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.EqualTo($"Invalid value 'not-a-number' for 'value' property of number"));
+        Assert.Equal($"Invalid value 'not-a-number' for 'value' property of number", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidDataTypeThrows()
     {
         string json = "false";
-        Assert.That(() => JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"Unexpected token parsing number."));
+        Assert.Contains($"Unexpected token parsing number.", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<double>(json, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestSerializationThrows()
     {
         double value = 3.14159;
-        Assert.That(() => JsonSerializer.Serialize(value, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } }), Throws.InstanceOf<NotSupportedException>());
+        Assert.ThrowsAny<NotSupportedException>(() => JsonSerializer.Serialize(value, new JsonSerializerOptions { Converters = { new NumberJsonConverter() } }));
     }
 }

--- a/test/WebDriverBiDi.Tests/JsonConverters/RemoteValueDictionaryJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/RemoteValueDictionaryJsonConverterTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.JsonConverters;
 using System.Text.Json;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class RemoteValueDictionaryJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestDeserializingValidMapRepresentation()
     {
         string json = """
@@ -38,10 +37,11 @@ public class RemoteValueDictionaryJsonConverterTests
 
         // Assertions that the elements of the list are deserialized correctly
         // are performed elsewhere.
-        Assert.That(result, Has.Count.EqualTo(3));
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingValidMapWithNonStringKeys()
     {
         string json = """
@@ -82,32 +82,34 @@ public class RemoteValueDictionaryJsonConverterTests
 
         // Assertions that the elements of the list are deserialized correctly
         // are performed elsewhere.
-        Assert.That(result, Has.Count.EqualTo(3));
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingValidEmptyMapRepresentation()
     {
         string json = "[]";
         RemoteValueDictionary? result = JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } });
-        Assert.That(result, Has.Count.EqualTo(0));
+        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNonArrayThrows()
     {
         string json = "\"not-an-array\"";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"JSON value could not be converted"));
+        Assert.Contains($"JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidMapArrayElementThrows()
     {
         string json = "[\"not-a-remote-value\"]";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"RemoteValue array element for dictionary must be an array"));
+        Assert.Contains($"RemoteValue array element for dictionary must be an array", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapArrayWithTooLongElementLengthThrows()
     {
         string json = """
@@ -125,10 +127,10 @@ public class RemoteValueDictionaryJsonConverterTests
                         ]
                       ]
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"RemoteValue array element for dictionary must be an array with exactly two elements"));
+        Assert.Contains($"RemoteValue array element for dictionary must be an array with exactly two elements", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapArrayWithTooShortElementLengthThrows()
     {
         string json = """
@@ -141,10 +143,10 @@ public class RemoteValueDictionaryJsonConverterTests
                         ]
                       ]
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"RemoteValue array element for dictionary must be an array with exactly two elements"));
+        Assert.Contains($"RemoteValue array element for dictionary must be an array with exactly two elements", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapArrayWithInvalidKeyElementTypeThrows()
     {
         string json = """
@@ -158,10 +160,10 @@ public class RemoteValueDictionaryJsonConverterTests
                         ]
                       ]
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"RemoteValue array element for dictionary must have a first element (key) that is either a string or an object"));
+        Assert.Contains($"RemoteValue array element for dictionary must have a first element (key) that is either a string or an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapArrayWithInvalidValueElementTypeThrows()
     {
         string json = """
@@ -172,14 +174,14 @@ public class RemoteValueDictionaryJsonConverterTests
                         ]
                       ]
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"RemoteValue array element for dictionary must have a second element (value) that is an object"));
+        Assert.Contains($"RemoteValue array element for dictionary must have a second element (value) that is an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestSerializationThrows()
     {
         string json = "[]";
         RemoteValueDictionary? result = JsonSerializer.Deserialize<RemoteValueDictionary>(json, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } });
-        Assert.That(() => JsonSerializer.Serialize(result, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }), Throws.InstanceOf<NotSupportedException>());
+        Assert.ThrowsAny<NotSupportedException>(() => JsonSerializer.Serialize(result, new JsonSerializerOptions { Converters = { new RemoteValueDictionaryJsonConverter() } }));
     }
 }

--- a/test/WebDriverBiDi.Tests/JsonConverters/RemoteValueListJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/RemoteValueListJsonConverterTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.JsonConverters;
 using System.Text.Json;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class RemoteValueListJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestDeserializingValidArray()
     {
         string json = """
@@ -29,36 +28,38 @@ public class RemoteValueListJsonConverterTests
 
         // Assertions that the elements of the list are deserialized correctly
         // are performed elsewhere.
-        Assert.That(result, Has.Count.EqualTo(3));
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingValidEmptyArray()
     {
         string json = "[]";
         RemoteValueList? result = JsonSerializer.Deserialize<RemoteValueList>(json, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } });
-        Assert.That(result, Has.Count.EqualTo(0));
+        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidArrayThrows()
     {
         string json = "\"not-an-array\"";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueList>(json, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"JSON value could not be converted"));
+        Assert.Contains($"JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueList>(json, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidArrayElementThrows()
     {
         string json = "[\"not-a-remote-value\"]";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValueList>(json, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } }), Throws.InstanceOf<JsonException>().With.Message.Contains($"JSON for 'RemoteValue' must be an object"));
+        Assert.Contains($"JSON for 'RemoteValue' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValueList>(json, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } })).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestSerializationThrows()
     {
         string json = "[]";
         RemoteValueList? result = JsonSerializer.Deserialize<RemoteValueList>(json, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } });
-        Assert.That(() => JsonSerializer.Serialize(result, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } }), Throws.InstanceOf<NotSupportedException>());
+        Assert.ThrowsAny<NotSupportedException>(() => JsonSerializer.Serialize(result, new JsonSerializerOptions { Converters = { new RemoteValueListJsonConverter() } }));
     }
 }

--- a/test/WebDriverBiDi.Tests/JsonConverters/SentinelNullJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/SentinelNullJsonConverterTests.cs
@@ -6,19 +6,18 @@ using System.Text.Json.Serialization;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.BrowsingContext;
 
-[TestFixture]
 public class SentinelNullJsonConverterTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         TestClass instance = new();
         string json = JsonSerializer.Serialize(instance);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.Zero);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithViewportProperty()
     {
         TestClass instance = new()
@@ -27,12 +26,12 @@ public class SentinelNullJsonConverterTests
         };
         string json = JsonSerializer.Serialize(instance);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        Assert.That(serialized, Contains.Key("viewport"));
-        Assert.That(serialized["viewport"], Is.Not.Null);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("viewport"));
+        Assert.NotNull(serialized["viewport"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithViewportNullProperty()
     {
         TestClass instance = new()
@@ -41,12 +40,14 @@ public class SentinelNullJsonConverterTests
         };
         string json = JsonSerializer.Serialize(instance);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        Assert.That(serialized, Contains.Key("viewport"));
-        Assert.That(serialized["viewport"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("viewport"));
+        JToken? viewport = serialized["viewport"];
+        Assert.NotNull(viewport);
+        Assert.Equal(JTokenType.Null, viewport.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithDoubleProperty()
     {
         TestClass instance = new()
@@ -55,12 +56,14 @@ public class SentinelNullJsonConverterTests
         };
         string json = JsonSerializer.Serialize(instance);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        Assert.That(serialized, Contains.Key("double"));
-        Assert.That(serialized["double"]!.Value<double>(), Is.EqualTo(2));
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("double"));
+        JToken? doubleToken = serialized["double"];
+        Assert.NotNull(doubleToken);
+        Assert.Equal(2, doubleToken.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithDoubleNullProperty()
     {
         TestClass instance = new()
@@ -69,19 +72,21 @@ public class SentinelNullJsonConverterTests
         };
         string json = JsonSerializer.Serialize(instance);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        Assert.That(serialized, Contains.Key("double"));
-        Assert.That(serialized["double"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("double"));
+        JToken? doubleToken = serialized["double"];
+        Assert.NotNull(doubleToken);
+        Assert.Equal(JTokenType.Null, doubleToken.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCannotDeserialize()
     {
         string json = """{ "double": 3 }""";
-        Assert.That(() => JsonSerializer.Deserialize<TestClass>(json), Throws.InstanceOf<NotSupportedException>());
+        Assert.ThrowsAny<NotSupportedException>(() => JsonSerializer.Deserialize<TestClass>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestWriteWithNullValueWritesNothing()
     {
         SentinelNullJsonConverter<Viewport, ViewportSentinelChecker> converter = new();
@@ -92,7 +97,7 @@ public class SentinelNullJsonConverterTests
         writer.WriteEndObject();
         writer.Flush();
         string json = Encoding.UTF8.GetString(stream.ToArray());
-        Assert.That(json, Is.EqualTo("{}"));
+        Assert.Equal("{}", json);
     }
 
     private class TestClass

--- a/test/WebDriverBiDi.Tests/JsonConverters/WebDriverBiDiJsonSerializerContextTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/WebDriverBiDiJsonSerializerContextTests.cs
@@ -6,10 +6,9 @@ using System.Text.Json.Serialization;
 using TestUtilities;
 using WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class WebDriverBiDiJsonSerializerContextTests
 {
-    [Test]
+    [Fact]
     public void TestAllCommandParametersAreIncludedInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext
@@ -35,10 +34,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("CommandParameters", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
-    [Test]
+    [Fact]
     public void TestAllCommandResultsHaveResponseMessageInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext.
@@ -80,10 +79,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("CommandResponseMessage<T>", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
-    [Test]
+    [Fact]
     public void TestAllEventMessagesAreIncludedInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext.
@@ -101,9 +100,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         _ = new BiDiDriver(TimeSpan.FromSeconds(1), transport);
 
         FieldInfo? field = transport.GetType().GetField("eventMessageTypes", BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.That(field, Is.Not.Null, "Could not find eventMessageTypes field on Transport");
+        Assert.NotNull(field);
 
-        ConcurrentDictionary<string, Type> eventMessageTypes = (ConcurrentDictionary<string, Type>)field!.GetValue(transport)!;
+        ConcurrentDictionary<string, Type>? eventMessageTypes = field.GetValue(transport) as ConcurrentDictionary<string, Type>;
+        Assert.NotNull(eventMessageTypes);
 
         // Add any of the EventMessage<T> types that are not in the list of types registered with
         // the custom JsonSerializerContext to the list of missing types. 
@@ -117,10 +117,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("EventMessage<T>", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
-    [Test]
+    [Fact]
     public void TestAllSerializableEnumsAreIncludedInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext.
@@ -145,10 +145,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("Enum", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
-    [Test]
+    [Fact]
     public void TestAllTypesWithCustomConvertersAreIncludedInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext.
@@ -174,10 +174,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("[JsonConverter]", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
-    [Test]
+    [Fact]
     public void TestAllDerivedTypesAreIncludedInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext.
@@ -207,10 +207,10 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("[JsonDerivedType]", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
-    [Test]
+    [Fact]
     public void TestAllReferencedPropertyTypesAreIncludedInSerializationContext()
     {
         // Get all types registered with the custom JsonSerializerContext.
@@ -264,7 +264,7 @@ public class WebDriverBiDiJsonSerializerContextTests
         }
 
         // There should be no missing types.
-        Assert.That(missingTypes, Is.Empty, FormatMissingMessage("PropertyType", missingTypes));
+        Assert.Empty(missingTypes);
     }
 
     private static HashSet<Type> GetRegisteredSerializableTypes()
@@ -279,7 +279,11 @@ public class WebDriverBiDiJsonSerializerContextTests
         {
             if (customAttributeDataObject.AttributeType == typeof(JsonSerializableAttribute))
             {
-                set.Add((Type)customAttributeDataObject.ConstructorArguments[0].Value!);
+                Type? registeredType = customAttributeDataObject.ConstructorArguments[0].Value as Type;
+                if (registeredType is not null)
+                {
+                    set.Add(registeredType);
+                }
             }
         }
 
@@ -294,7 +298,12 @@ public class WebDriverBiDiJsonSerializerContextTests
         {
             if (customAttributeDataObject.AttributeType == typeof(JsonSerializableAttribute))
             {
-                Type registeredType = (Type)customAttributeDataObject.ConstructorArguments[0].Value!;
+                Type? registeredType = customAttributeDataObject.ConstructorArguments[0].Value as Type;
+                if (registeredType is null)
+                {
+                    continue;
+                }
+
                 coveredTypes.Add(registeredType);
                 if (registeredType.IsGenericType)
                 {
@@ -400,7 +409,12 @@ public class WebDriverBiDiJsonSerializerContextTests
 
         if (underlying.IsArray)
         {
-            CollectLibraryTypes(underlying.GetElementType()!, result);
+            Type? elementType = underlying.GetElementType();
+            if (elementType is not null)
+            {
+                CollectLibraryTypes(elementType, result);
+            }
+
             return;
         }
 

--- a/test/WebDriverBiDi.Tests/Log/EntryAddedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/EntryAddedEventArgsTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Log;
 using System.Text.Json;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class EntryAddedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullText()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -22,21 +21,20 @@ public class EntryAddedEventArgsTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        EntryAddedEventArgs eventArgs = new(entry!);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(eventArgs.Text, Is.Null);
-            Assert.That(eventArgs.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.Type, Is.EqualTo("generic"));
-            Assert.That(eventArgs.Method, Is.Null);
-            Assert.That(eventArgs.Arguments, Is.Null);
-            Assert.That(eventArgs.StackTrace, Is.Null);
-        }
+        Assert.NotNull(entry);
+        EntryAddedEventArgs eventArgs = new(entry);
+
+        Assert.Equal("realmId", eventArgs.Source.RealmId);
+        Assert.Null(eventArgs.Text);
+        Assert.Equal(LogLevel.Debug, eventArgs.Level);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("generic", eventArgs.Type);
+        Assert.Null(eventArgs.Method);
+        Assert.Null(eventArgs.Arguments);
+        Assert.Null(eventArgs.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeConsoleLogEntry()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -45,7 +43,7 @@ public class EntryAddedEventArgsTests
                         "type": "console",
                         "level": "debug",
                         "source": {
-                          "realm": "realmId" 
+                          "realm": "realmId"
                         },
                         "text": "my log message",
                         "timestamp": {{epochTimestamp}},
@@ -57,22 +55,21 @@ public class EntryAddedEventArgsTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
+        Assert.NotNull(entry);
         EntryAddedEventArgs eventArgs = new(entry);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(eventArgs.Text, Is.EqualTo("my log message"));
-            Assert.That(eventArgs.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.Type, Is.EqualTo("console"));
-            Assert.That(eventArgs.Method, Is.EqualTo("myMethod"));
-            Assert.That(eventArgs.Arguments, Is.Empty);
-            Assert.That(eventArgs.StackTrace, Is.Not.Null);
-        }
+
+        Assert.Equal("realmId", eventArgs.Source.RealmId);
+        Assert.Equal("my log message", eventArgs.Text);
+        Assert.Equal(LogLevel.Debug, eventArgs.Level);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("console", eventArgs.Type);
+        Assert.Equal("myMethod", eventArgs.Method);
+        Assert.NotNull(eventArgs.Arguments);
+        Assert.Empty(eventArgs.Arguments);
+        Assert.NotNull(eventArgs.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeConsoleLogEntryWithArgs()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -89,7 +86,7 @@ public class EntryAddedEventArgsTests
                         "args": [
                           {
                             "type": "string",
-                            "value": "argValue" 
+                            "value": "argValue"
                           }
                         ], "stackTrace": {
                           "callFrames": []
@@ -97,24 +94,23 @@ public class EntryAddedEventArgsTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
+        Assert.NotNull(entry);
         EntryAddedEventArgs eventArgs = new(entry);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(eventArgs.Text, Is.EqualTo("my log message"));
-            Assert.That(eventArgs.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(eventArgs.Type, Is.EqualTo("console"));
-            Assert.That(eventArgs.Method, Is.EqualTo("myMethod"));
-            Assert.That(eventArgs.Arguments, Has.Count.EqualTo(1));
-            Assert.That(eventArgs.Arguments![0].Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(eventArgs.Arguments![0].ConvertTo<StringRemoteValue>().Value, Is.EqualTo("argValue"));
-            Assert.That(eventArgs.StackTrace, Is.Not.Null);
-        }
+
+        Assert.Equal("realmId", eventArgs.Source.RealmId);
+        Assert.Equal("my log message", eventArgs.Text);
+        Assert.Equal(LogLevel.Debug, eventArgs.Level);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), eventArgs.Timestamp);
+        Assert.Equal("console", eventArgs.Type);
+        Assert.Equal("myMethod", eventArgs.Method);
+        Assert.NotNull(eventArgs.Arguments);
+        Assert.Single(eventArgs.Arguments);
+        Assert.Equal(RemoteValueType.String, eventArgs.Arguments[0].Type);
+        Assert.Equal("argValue", eventArgs.Arguments[0].ConvertTo<StringRemoteValue>().Value);
+        Assert.NotNull(eventArgs.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -130,9 +126,9 @@ public class EntryAddedEventArgsTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        EntryAddedEventArgs eventArgs = new(entry!);
-        Assert.That(entry, Is.Not.Null);
+        Assert.NotNull(entry);
+        EntryAddedEventArgs eventArgs = new(entry);
         EntryAddedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Log/LogEntryTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/LogEntryTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Log;
 using System.Text.Json;
 using WebDriverBiDi.Script;
 
-[TestFixture]
 public class LogEntryTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullText()
     {
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -22,22 +21,20 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<LogEntry>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(entry.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(entry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(entry.Text, Is.Null);
-            Assert.That(entry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(entry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-        }
+        Assert.NotNull(entry);
+        Assert.IsType<GenericLogEntry>(entry);
+
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.Equal("realmId", entry.Source.RealmId);
+        Assert.Null(entry.Text);
+        Assert.Equal((ulong)((ulong)(epochTimestamp)), entry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), entry.Timestamp);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeConsoleLogEntry()
     {
-        long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
+        ulong epochTimestamp = Convert.ToUInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         string json = $$"""
                       {
                         "type": "console",
@@ -55,29 +52,27 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<ConsoleLogEntry>());
+        Assert.NotNull(entry);
+        Assert.IsType<ConsoleLogEntry>(entry);
         ConsoleLogEntry? consoleEntry = entry as ConsoleLogEntry;
-        Assert.That(consoleEntry, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(consoleEntry.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(consoleEntry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(consoleEntry.Text, Is.Not.Null);
-            Assert.That(consoleEntry.Text, Is.EqualTo("my log message"));
-            Assert.That(consoleEntry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(consoleEntry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(consoleEntry.Method, Is.EqualTo("myMethod"));
-            Assert.That(consoleEntry.Args, Is.Empty);
-            Assert.That(consoleEntry.StackTrace, Is.Not.Null);
-            Assert.That(consoleEntry.StackTrace!.CallFrames, Is.Empty);
-        }
+        Assert.NotNull(consoleEntry);
+
+        Assert.Equal(LogLevel.Debug, consoleEntry.Level);
+        Assert.Equal("realmId", consoleEntry.Source.RealmId);
+        Assert.NotNull(consoleEntry.Text);
+        Assert.Equal("my log message", consoleEntry.Text);
+        Assert.Equal(epochTimestamp, consoleEntry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), consoleEntry.Timestamp);
+        Assert.Equal("myMethod", consoleEntry.Method);
+        Assert.Empty(consoleEntry.Args);
+        Assert.NotNull(consoleEntry.StackTrace);
+        Assert.Empty(consoleEntry.StackTrace.CallFrames);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeConsoleLogEntryWithArgs()
     {
-        long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
+        ulong epochTimestamp = Convert.ToUInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         string json = $$"""
                       {
                         "type": "console",
@@ -97,29 +92,27 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<ConsoleLogEntry>());
+        Assert.NotNull(entry);
+        Assert.IsType<ConsoleLogEntry>(entry);
         ConsoleLogEntry? consoleEntry = entry as ConsoleLogEntry;
-        Assert.That(consoleEntry, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(consoleEntry.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(consoleEntry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(consoleEntry.Text, Is.Not.Null);
-            Assert.That(consoleEntry.Text, Is.EqualTo("my log message"));
-            Assert.That(consoleEntry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(consoleEntry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-            Assert.That(consoleEntry.Method, Is.EqualTo("myMethod"));
-            Assert.That(consoleEntry.Args, Has.Count.EqualTo(1));
-            Assert.That(consoleEntry.Args[0].Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(consoleEntry.Args[0].ConvertTo<StringRemoteValue>().Value, Is.EqualTo("argValue"));
-        }
+        Assert.NotNull(consoleEntry);
+
+        Assert.Equal(LogLevel.Debug, consoleEntry.Level);
+        Assert.Equal("realmId", consoleEntry.Source.RealmId);
+        Assert.NotNull(consoleEntry.Text);
+        Assert.Equal("my log message", consoleEntry.Text);
+        Assert.Equal(epochTimestamp, consoleEntry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), consoleEntry.Timestamp);
+        Assert.Equal("myMethod", consoleEntry.Method);
+        Assert.Single(consoleEntry.Args);
+        Assert.Equal(RemoteValueType.String, consoleEntry.Args[0].Type);
+        Assert.Equal("argValue", consoleEntry.Args[0].ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithDebugLogLevel()
     {
-        long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
+        ulong epochTimestamp = Convert.ToUInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         string json = $$"""
                       {
                         "type": "generic",
@@ -132,23 +125,21 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<LogEntry>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(entry.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(entry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(entry.Text, Is.Not.Null);
-            Assert.That(entry.Text, Is.EqualTo("my log message"));
-            Assert.That(entry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(entry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-        }
+        Assert.NotNull(entry);
+        Assert.IsType<GenericLogEntry>(entry);
+
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.Equal("realmId", entry.Source.RealmId);
+        Assert.NotNull(entry.Text);
+        Assert.Equal("my log message", entry.Text);
+        Assert.Equal(epochTimestamp, entry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), entry.Timestamp);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInfoLogLevel()
     {
-        long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
+        ulong epochTimestamp = Convert.ToUInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         string json = $$"""
                       {
                         "type": "generic",
@@ -161,23 +152,21 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<LogEntry>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(entry.Level, Is.EqualTo(LogLevel.Info));
-            Assert.That(entry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(entry.Text, Is.Not.Null);
-            Assert.That(entry.Text, Is.EqualTo("my log message"));
-            Assert.That(entry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(entry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-        }
+        Assert.NotNull(entry);
+        Assert.IsType<GenericLogEntry>(entry);
+
+        Assert.Equal(LogLevel.Info, entry.Level);
+        Assert.Equal("realmId", entry.Source.RealmId);
+        Assert.NotNull(entry.Text);
+        Assert.Equal("my log message", entry.Text);
+        Assert.Equal(epochTimestamp, entry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), entry.Timestamp);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithWarnLogLevel()
     {
-        long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
+        ulong epochTimestamp = Convert.ToUInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         string json = $$"""
                       {
                         "type": "generic",
@@ -190,23 +179,21 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<LogEntry>());
-        Assert.That(entry.Level, Is.EqualTo(LogLevel.Warn));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(entry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(entry.Text, Is.Not.Null);
-            Assert.That(entry.Text, Is.EqualTo("my log message"));
-            Assert.That(entry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(entry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-        }
+        Assert.NotNull(entry);
+        Assert.IsType<GenericLogEntry>(entry);
+        Assert.Equal(LogLevel.Warn, entry.Level);
+
+        Assert.Equal("realmId", entry.Source.RealmId);
+        Assert.NotNull(entry.Text);
+        Assert.Equal("my log message", entry.Text);
+        Assert.Equal(epochTimestamp, entry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), entry.Timestamp);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithErrorLogLevel()
     {
-        long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
+        ulong epochTimestamp = Convert.ToUInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         string json = $$"""
                       {
                         "type": "generic",
@@ -219,20 +206,18 @@ public class LogEntryTests
                       }
                       """;
         LogEntry? entry = JsonSerializer.Deserialize<LogEntry>(json);
-        Assert.That(entry, Is.Not.Null);
-        Assert.That(entry, Is.InstanceOf<LogEntry>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(entry.Level, Is.EqualTo(LogLevel.Error));
-            Assert.That(entry.Source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(entry.Text, Is.Not.Null);
-            Assert.That(entry.Text, Is.EqualTo("my log message"));
-            Assert.That(entry.EpochTimestamp, Is.EqualTo(epochTimestamp));
-            Assert.That(entry.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-        }
+        Assert.NotNull(entry);
+        Assert.IsType<GenericLogEntry>(entry);
+
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Equal("realmId", entry.Source.RealmId);
+        Assert.NotNull(entry.Text);
+        Assert.Equal("my log message", entry.Text);
+        Assert.Equal(epochTimestamp, entry.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), entry.Timestamp);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidLevelValueThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -248,10 +233,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingLevelThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -266,10 +251,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidLevelTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -285,10 +270,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -303,10 +288,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithNullTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -322,10 +307,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -341,10 +326,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingSourceThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -357,10 +342,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidSourceTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -374,10 +359,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTextThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -392,10 +377,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTextThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -411,10 +396,10 @@ public class LogEntryTests
                         "timestamp": {{epochTimestamp}}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTimestampThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -429,10 +414,10 @@ public class LogEntryTests
                         "text": "my log message"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTimestampTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -448,10 +433,10 @@ public class LogEntryTests
                         "timestamp": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingConsoleLogEntryWithMissingMethodThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -468,10 +453,10 @@ public class LogEntryTests
                         "args": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingConsoleLogEntryWithInvalidMethodThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -489,10 +474,10 @@ public class LogEntryTests
                         "args": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingConsoleLogEntryWithMissingArgsThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -509,10 +494,10 @@ public class LogEntryTests
                         "method": "myMethod"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingConsoleLogEntryWithInvalidArgsThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -530,10 +515,10 @@ public class LogEntryTests
                         "args": "invalidArgs"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingConsoleLogEntryWithInvalidArgTypeThrows()
     {
         DateTime timestamp = DateTime.Now;
@@ -551,13 +536,13 @@ public class LogEntryTests
                         "args": [ "invalidArgs" ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingLogEntryWithAsNonObjectThrows()
     {
         string json = @"[ ""invalid log entry"" ]";
-        Assert.That(() => JsonSerializer.Deserialize<LogEntry>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<LogEntry>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
@@ -8,7 +8,7 @@ public class LogModuleTests
     public async Task TestCanReceiveEntryAddedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 
@@ -53,7 +53,7 @@ public class LogModuleTests
     public async Task TestCanReceiveEntryAddedEventForConsoleLogType()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 

--- a/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
@@ -2,29 +2,27 @@ namespace WebDriverBiDi.Log;
 
 using TestUtilities;
 
-[TestFixture]
 public class LogModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestCanReceiveEntryAddedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 
         ManualResetEvent syncEvent = new(false);
         module.OnEntryAdded.AddObserver((EntryAddedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.Type, Is.EqualTo("javascript"));
-                Assert.That(e.Text, Is.EqualTo("my log message"));
-                Assert.That(e.Method, Is.Null);
-                Assert.That(e.Arguments, Is.Null);
-                Assert.That(e.StackTrace, Is.Not.Null);
-                Assert.That(e.StackTrace!.CallFrames, Is.Empty);
-            }
+
+            Assert.Equal("javascript", e.Type);
+            Assert.Equal("my log message", e.Text);
+            Assert.Null(e.Method);
+            Assert.Null(e.Arguments);
+            Assert.NotNull(e.StackTrace);
+            Assert.Empty(e.StackTrace.CallFrames);
+
             syncEvent.Set();
         });
 
@@ -50,32 +48,31 @@ public class LogModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveEntryAddedEventForConsoleLogType()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 
         ManualResetEvent syncEvent = new(false);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnEntryAdded.AddObserver((EntryAddedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.Type, Is.EqualTo("console"));
-                Assert.That(e.Text, Is.EqualTo("my log message"));
-                Assert.That(e.Method, Is.Not.Null);
-                Assert.That(e.Arguments, Is.Not.Null);
-                Assert.That(e.Source, Is.Not.Null);
-                Assert.That(e.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp)));
-                Assert.That(e.StackTrace, Is.Not.Null);
-                Assert.That(e.StackTrace!.CallFrames, Is.Empty);
-            }
+
+            Assert.Equal("console", e.Type);
+            Assert.Equal("my log message", e.Text);
+            Assert.NotNull(e.Method);
+            Assert.NotNull(e.Arguments);
+            Assert.NotNull(e.Source);
+            Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(epochTimestamp), e.Timestamp);
+            Assert.NotNull(e.StackTrace);
+            Assert.Empty(e.StackTrace.CallFrames);
+
             syncEvent.Set();
         });
 
@@ -102,6 +99,6 @@ public class LogModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 }

--- a/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
@@ -9,13 +9,12 @@ public class LogModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnEntryAdded.AddObserver((EntryAddedEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnEntryAdded.AddObserver(e =>
         {
-
             Assert.Equal("javascript", e.Type);
             Assert.Equal("my log message", e.Text);
             Assert.Null(e.Method);
@@ -23,7 +22,7 @@ public class LogModuleTests
             Assert.NotNull(e.StackTrace);
             Assert.Empty(e.StackTrace.CallFrames);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
@@ -47,8 +46,7 @@ public class LogModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -56,14 +54,13 @@ public class LogModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
         module.OnEntryAdded.AddObserver((EntryAddedEventArgs e) =>
         {
-
             Assert.Equal("console", e.Type);
             Assert.Equal("my log message", e.Text);
             Assert.NotNull(e.Method);
@@ -73,7 +70,7 @@ public class LogModuleTests
             Assert.NotNull(e.StackTrace);
             Assert.Empty(e.StackTrace.CallFrames);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -98,7 +95,6 @@ public class LogModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
@@ -59,7 +59,7 @@ public class LogModuleTests
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         long epochTimestamp = Convert.ToInt64((DateTime.Now - DateTime.UnixEpoch).TotalMilliseconds);
-        module.OnEntryAdded.AddObserver((EntryAddedEventArgs e) =>
+        module.OnEntryAdded.AddObserver(e =>
         {
             Assert.Equal("console", e.Type);
             Assert.Equal("my log message", e.Text);

--- a/test/WebDriverBiDi.Tests/LogMessageEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/LogMessageEventArgsTests.cs
@@ -1,25 +1,24 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class LogMessageEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateConnectionDataReceivedEventArgs()
     {
         DateTime testTime = DateTime.Now;
         LogMessageEventArgs eventArgs = new("log message", WebDriverBiDiLogLevel.Info, "test component");
-        Assert.That(eventArgs.Message, Is.EqualTo("log message"));
-        Assert.That(eventArgs.Level, Is.EqualTo(WebDriverBiDiLogLevel.Info));
-        Assert.That(eventArgs.ComponentName, Is.EqualTo("test component"));
-        Assert.That(eventArgs.Timestamp, Is.GreaterThanOrEqualTo(testTime));
-        Assert.That(eventArgs.AdditionalData, Is.Empty);
+        Assert.Equal("log message", eventArgs.Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Info, eventArgs.Level);
+        Assert.Equal("test component", eventArgs.ComponentName);
+        Assert.True(eventArgs.Timestamp >= testTime);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         LogMessageEventArgs eventArgs = new("log message", WebDriverBiDiLogLevel.Info, "test component");
         LogMessageEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/ModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/ModuleTests.cs
@@ -3,6 +3,7 @@ namespace WebDriverBiDi;
 using TestUtilities;
 using WebDriverBiDi.Protocol;
 
+[Collection("EventSourceTests")]
 public class ModuleTests
 {
     [Fact]
@@ -17,7 +18,7 @@ public class ModuleTests
         {
         });
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         List<string> driverLog = [];
         transport.OnLogMessage.AddObserver((e) =>
         {
@@ -31,10 +32,10 @@ public class ModuleTests
         transport.OnUnknownMessageReceived.AddObserver((e) =>
         {
             unknownMessage = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -45,7 +46,7 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        syncEvent.WaitOne(TimeSpan.FromMilliseconds(10000));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Single(driverLog);
         Assert.Contains("Unexpected error parsing event JSON", driverLog[0]);
@@ -60,13 +61,14 @@ public class ModuleTests
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
 
-        ManualResetEvent syncEvent = new(false);
+        // Use a ManualResetEventSlim because we want to reset the event.
+        ManualResetEventSlim syncEvent = new(false);
         EventObserver<TestEventArgs> handler = module.OnEventInvoked.AddObserver((TestEventArgs e) =>
         {
             syncEvent.Set();
         });
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -77,13 +79,13 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventSet = syncEvent.WaitOne(TimeSpan.FromMilliseconds(50));
+        bool eventSet = syncEvent.Wait(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         Assert.True(eventSet);
 
         handler.Unobserve();
         syncEvent.Reset();
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        eventSet = syncEvent.WaitOne(TimeSpan.FromMilliseconds(50));
+        eventSet = syncEvent.Wait(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         Assert.False(eventSet);
     }
 
@@ -95,17 +97,13 @@ public class ModuleTests
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
 
-        Task? eventTask = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         EventObserver<TestEventArgs> handler = module.OnEventInvoked.AddObserver((TestEventArgs e) =>
         {
-            TaskCompletionSource taskCompletionSource = new();
-            eventTask = taskCompletionSource.Task;
-            taskCompletionSource.SetResult();
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -116,11 +114,7 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventSet = syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        Assert.True(eventSet);
-        Assert.NotNull(eventTask);
-        await eventTask;
-        Assert.True(eventTask.IsCompletedSuccessfully);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -148,7 +142,7 @@ public class ModuleTests
             }
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -162,7 +156,7 @@ public class ModuleTests
         await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Collect);
         Assert.True(errorPropagated);
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await driver.StopAsync(TestContext.Current.CancellationToken));
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.Contains("Async module handler exception", exception.InnerException.Message);
@@ -187,7 +181,7 @@ public class ModuleTests
 
         observer.StartCapturingTasks();
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -199,10 +193,10 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
 
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         _ = Assert.Single(tasks);
         Assert.Contains("Async module handler exception", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await Task.WhenAll(tasks))).Message);
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -239,7 +233,7 @@ public class ModuleTests
             return Task.WhenAll(firstTaskCompletionSource.Task, secondTaskCompletionSource.Task);
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -254,7 +248,7 @@ public class ModuleTests
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Collect);
         Assert.True(errorPropagated);
 
-        AggregateException exception = await Assert.ThrowsAsync<AggregateException>(async () => await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken));
+        AggregateException exception = await Assert.ThrowsAsync<AggregateException>(async () => await driver.StopAsync(TestContext.Current.CancellationToken));
         Assert.IsType<AggregateException>(exception.InnerException);
 
         AggregateException innerAggregateException = (AggregateException)exception.InnerException;
@@ -289,7 +283,7 @@ public class ModuleTests
             }
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -328,7 +322,7 @@ public class ModuleTests
 
         observer.StartCapturingTasks();
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -340,10 +334,10 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
 
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         _ = Assert.Single(tasks);
         Assert.Contains("Async module handler exception", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await Task.WhenAll(tasks))).Message);
-        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -380,7 +374,7 @@ public class ModuleTests
             return Task.WhenAll(firstTaskCompletionSource.Task, secondTaskCompletionSource.Task);
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",

--- a/test/WebDriverBiDi.Tests/ModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/ModuleTests.cs
@@ -79,7 +79,7 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventSet = syncEvent.Wait(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
+        bool eventSet = syncEvent.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(eventSet);
 
         handler.Unobserve();

--- a/test/WebDriverBiDi.Tests/ModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/ModuleTests.cs
@@ -14,13 +14,13 @@ public class ModuleTests
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
 
-        module.OnEventInvoked.AddObserver((TestEventArgs e) =>
+        module.OnEventInvoked.AddObserver(e =>
         {
         });
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         List<string> driverLog = [];
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level >= WebDriverBiDiLogLevel.Error)
             {
@@ -29,7 +29,7 @@ public class ModuleTests
         });
 
         string unknownMessage = string.Empty;
-        transport.OnUnknownMessageReceived.AddObserver((e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             unknownMessage = e.Message;
             taskCompletionSource.TrySetResult();
@@ -63,7 +63,7 @@ public class ModuleTests
 
         // Use a ManualResetEventSlim because we want to reset the event.
         ManualResetEventSlim syncEvent = new(false);
-        EventObserver<TestEventArgs> handler = module.OnEventInvoked.AddObserver((TestEventArgs e) =>
+        EventObserver<TestEventArgs> handler = module.OnEventInvoked.AddObserver(e =>
         {
             syncEvent.Set();
         });
@@ -98,7 +98,7 @@ public class ModuleTests
         TestProtocolModule module = new(driver);
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        EventObserver<TestEventArgs> handler = module.OnEventInvoked.AddObserver((TestEventArgs e) =>
+        EventObserver<TestEventArgs> handler = module.OnEventInvoked.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -129,7 +129,7 @@ public class ModuleTests
         TestProtocolModule module = new(driver);
         TaskCompletionSource<bool> handlerCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        module.OnEventInvoked.AddObserver(async (TestEventArgs e) =>
+        module.OnEventInvoked.AddObserver(async e =>
         {
             try
             {
@@ -173,7 +173,7 @@ public class ModuleTests
         };
         TestProtocolModule module = new(driver);
 
-        EventObserver<TestEventArgs> observer = module.OnEventInvoked.AddObserver(async (TestEventArgs e) =>
+        EventObserver<TestEventArgs> observer = module.OnEventInvoked.AddObserver(async e =>
         {
             await Task.Yield();
             throw new WebDriverBiDiException("Async module handler exception");
@@ -211,24 +211,25 @@ public class ModuleTests
         TestProtocolModule module = new(driver);
         TaskCompletionSource<bool> handlerCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        module.OnEventInvoked.AddObserver((TestEventArgs e) =>
+        module.OnEventInvoked.AddObserver(e =>
         {
             TaskCompletionSource firstTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource secondTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            _ = Task.Run(async () =>
-            {
-                try
+            _ = Task.Run(
+                async () =>
                 {
-                    await Task.Yield();
-                    firstTaskCompletionSource.SetException(new InvalidOperationException("First aggregate failure"));
-                    secondTaskCompletionSource.SetException(new WebDriverBiDiException("Second aggregate failure"));
-                }
-                finally
-                {
-                    handlerCompleted.TrySetResult(true);
-                }
-            });
+                    try
+                    {
+                        await Task.Yield();
+                        firstTaskCompletionSource.SetException(new InvalidOperationException("First aggregate failure"));
+                        secondTaskCompletionSource.SetException(new WebDriverBiDiException("Second aggregate failure"));
+                    }
+                    finally
+                    {
+                        handlerCompleted.TrySetResult(true);
+                    }
+                });
 
             return Task.WhenAll(firstTaskCompletionSource.Task, secondTaskCompletionSource.Task);
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -270,7 +271,7 @@ public class ModuleTests
         TestProtocolModule module = new(driver);
         TaskCompletionSource<bool> handlerCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        module.OnEventInvoked.AddObserver(async (TestEventArgs e) =>
+        module.OnEventInvoked.AddObserver(async e =>
         {
             try
             {
@@ -314,7 +315,7 @@ public class ModuleTests
         };
         TestProtocolModule module = new(driver);
 
-        EventObserver<TestEventArgs> observer = module.OnEventInvoked.AddObserver(async (TestEventArgs e) =>
+        EventObserver<TestEventArgs> observer = module.OnEventInvoked.AddObserver(async e =>
         {
             await Task.Yield();
             throw new WebDriverBiDiException("Async module handler exception");
@@ -352,24 +353,25 @@ public class ModuleTests
         TestProtocolModule module = new(driver);
         TaskCompletionSource<bool> handlerCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        module.OnEventInvoked.AddObserver((TestEventArgs e) =>
+        module.OnEventInvoked.AddObserver(e =>
         {
             TaskCompletionSource firstTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource secondTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            _ = Task.Run(async () =>
-            {
-                try
+            _ = Task.Run(
+                async () =>
                 {
-                    await Task.Yield();
-                    firstTaskCompletionSource.SetException(new InvalidOperationException("First aggregate failure"));
-                    secondTaskCompletionSource.SetException(new WebDriverBiDiException("Second aggregate failure"));
-                }
-                finally
-                {
-                    handlerCompleted.TrySetResult(true);
-                }
-            });
+                    try
+                    {
+                        await Task.Yield();
+                        firstTaskCompletionSource.SetException(new InvalidOperationException("First aggregate failure"));
+                        secondTaskCompletionSource.SetException(new WebDriverBiDiException("Second aggregate failure"));
+                    }
+                    finally
+                    {
+                        handlerCompleted.TrySetResult(true);
+                    }
+                });
 
             return Task.WhenAll(firstTaskCompletionSource.Task, secondTaskCompletionSource.Task);
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
@@ -428,11 +430,11 @@ public class ModuleTests
         await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver, 1);
 
-        module.OnEventInvoked.AddObserver((TestEventArgs e) =>
+        module.OnEventInvoked.AddObserver(e =>
         {
         });
 
-        Assert.ThrowsAny<WebDriverBiDiException>(() => module.OnEventInvoked.AddObserver((e) => { }));
+        Assert.ThrowsAny<WebDriverBiDiException>(() => module.OnEventInvoked.AddObserver(e => { }));
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/ModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/ModuleTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi;
 using TestUtilities;
 using WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class ModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestEventWithInvalidEventArgsThrows()
     {
         TestWebSocketConnection connection = new();
@@ -35,7 +34,7 @@ public class ModuleTests
             syncEvent.Set();
         });
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -47,15 +46,13 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         syncEvent.WaitOne(TimeSpan.FromMilliseconds(10000));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(driverLog, Has.Count.EqualTo(1));
-            Assert.That(driverLog[0], Contains.Substring("Unexpected error parsing event JSON"));
-            Assert.That(unknownMessage, Is.Not.Empty);
-        }
+
+        Assert.Single(driverLog);
+        Assert.Contains("Unexpected error parsing event JSON", driverLog[0]);
+        Assert.NotEmpty(unknownMessage);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanRemoveEventHandler()
     {
         TestWebSocketConnection connection = new();
@@ -69,7 +66,7 @@ public class ModuleTests
             syncEvent.Set();
         });
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -81,16 +78,16 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventSet = syncEvent.WaitOne(TimeSpan.FromMilliseconds(50));
-        Assert.That(eventSet, Is.True);
+        Assert.True(eventSet);
 
         handler.Unobserve();
         syncEvent.Reset();
         await connection.RaiseDataReceivedEventAsync(eventJson);
         eventSet = syncEvent.WaitOne(TimeSpan.FromMilliseconds(50));
-        Assert.That(eventSet, Is.False);
+        Assert.False(eventSet);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanExecuteEventHandlersAsynchronously()
     {
         TestWebSocketConnection connection = new();
@@ -108,7 +105,7 @@ public class ModuleTests
             syncEvent.Set();
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -120,12 +117,13 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventSet = syncEvent.WaitOne(TimeSpan.FromMilliseconds(100));
-        Assert.That(eventSet, Is.True);
-        await eventTask!;
-        Assert.That(eventTask!.IsCompletedSuccessfully, Is.True);
+        Assert.True(eventSet);
+        Assert.NotNull(eventTask);
+        await eventTask;
+        Assert.True(eventTask.IsCompletedSuccessfully);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncExceptionInModuleEventHandlerCanCollect()
     {
         TestWebSocketConnection connection = new();
@@ -150,7 +148,7 @@ public class ModuleTests
             }
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -161,13 +159,16 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Collect);
-        Assert.That(errorPropagated, Is.True, "The transport should collect the late async handler failure before shutdown.");
-        Assert.That(async () => await driver.StopAsync(), Throws.InstanceOf<AggregateException>().With.InnerException.InstanceOf<WebDriverBiDiException>().And.Message.Contains("Normal shutdown").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("Async module handler exception"));
+        Assert.True(errorPropagated);
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.Contains("Async module handler exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncExceptionInModuleEventHandlerCapturedByCheckpointDoesNotCollect()
     {
         TestWebSocketConnection connection = new();
@@ -186,7 +187,7 @@ public class ModuleTests
 
         observer.StartCapturingTasks();
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -198,13 +199,13 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
 
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1));
-        Assert.That(tasks, Has.Length.EqualTo(1));
-        Assert.That(async () => await Task.WhenAll(tasks), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("Async module handler exception"));
-        Assert.That(async () => await driver.StopAsync(), Throws.Nothing);
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        _ = Assert.Single(tasks);
+        Assert.Contains("Async module handler exception", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await Task.WhenAll(tasks))).Message);
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncAggregateExceptionInModuleEventHandlerCanCollect()
     {
         TestWebSocketConnection connection = new();
@@ -238,7 +239,7 @@ public class ModuleTests
             return Task.WhenAll(firstTaskCompletionSource.Task, secondTaskCompletionSource.Task);
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -249,23 +250,21 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Collect);
-        Assert.That(errorPropagated, Is.True, "The transport should collect the late async aggregate handler failure before shutdown.");
+        Assert.True(errorPropagated);
 
-        AggregateException exception = Assert.ThrowsAsync<AggregateException>(async () => await driver.StopAsync())!;
-        Assert.That(exception.InnerException, Is.InstanceOf<AggregateException>());
+        AggregateException exception = await Assert.ThrowsAsync<AggregateException>(async () => await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.IsType<AggregateException>(exception.InnerException);
 
-        AggregateException innerAggregateException = (AggregateException)exception.InnerException!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(innerAggregateException.InnerExceptions, Has.Count.EqualTo(2));
-            Assert.That(innerAggregateException.InnerExceptions, Has.One.InstanceOf<InvalidOperationException>().With.Message.EqualTo("First aggregate failure"));
-            Assert.That(innerAggregateException.InnerExceptions, Has.One.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Second aggregate failure"));
-        }
+        AggregateException innerAggregateException = (AggregateException)exception.InnerException;
+
+        Assert.Equal(2, innerAggregateException.InnerExceptions.Count);
+        Assert.Single(innerAggregateException.InnerExceptions.OfType<InvalidOperationException>(), e => e.Message == "First aggregate failure");
+        Assert.Single(innerAggregateException.InnerExceptions.OfType<WebDriverBiDiException>(), e => e.Message == "Second aggregate failure");
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncExceptionInModuleEventHandlerCanTerminate()
     {
         TestWebSocketConnection connection = new();
@@ -290,7 +289,7 @@ public class ModuleTests
             }
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -301,13 +300,16 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Terminate);
-        Assert.That(errorPropagated, Is.True, "The transport should collect the late async handler failure before shutdown.");
-        Assert.That(async () => await driver.Session.StatusAsync(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("Unhandled exception in user event handler").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("Async module handler exception"));
+        Assert.True(errorPropagated);
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await driver.Session.StatusAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Unhandled exception in user event handler", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("Async module handler exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncExceptionInModuleEventHandlerCapturedByCheckpointDoesNotTerminate()
     {
         TestWebSocketConnection connection = new();
@@ -326,7 +328,7 @@ public class ModuleTests
 
         observer.StartCapturingTasks();
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -338,13 +340,13 @@ public class ModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
 
-        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1));
-        Assert.That(tasks, Has.Length.EqualTo(1));
-        Assert.That(async () => await Task.WhenAll(tasks), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("Async module handler exception"));
-        Assert.That(async () => await driver.StopAsync(), Throws.Nothing);
+        Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        _ = Assert.Single(tasks);
+        Assert.Contains("Async module handler exception", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await Task.WhenAll(tasks))).Message);
+        await driver.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncAggregateExceptionInModuleEventHandlerCanTerminate()
     {
         TestWebSocketConnection connection = new();
@@ -378,7 +380,7 @@ public class ModuleTests
             return Task.WhenAll(firstTaskCompletionSource.Task, secondTaskCompletionSource.Task);
         }, ObservableEventHandlerOptions.RunHandlerAsynchronously);
 
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string eventJson = """
                            {
                              "type": "event",
@@ -389,45 +391,43 @@ public class ModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Terminate);
-        Assert.That(errorPropagated, Is.True, "The transport should collect the late async aggregate handler failure before shutdown.");
+        Assert.True(errorPropagated);
 
-        WebDriverBiDiException exception = Assert.ThrowsAsync<WebDriverBiDiException>(async () => await driver.Session.StatusAsync())!;
-        Assert.That(exception.InnerException, Is.InstanceOf<AggregateException>());
+        WebDriverBiDiException exception = await Assert.ThrowsAsync<WebDriverBiDiException>(async () => await driver.Session.StatusAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.IsType<AggregateException>(exception.InnerException);
 
-        AggregateException innerAggregateException = (AggregateException)exception.InnerException!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(innerAggregateException.InnerExceptions, Has.Count.EqualTo(2));
-            Assert.That(innerAggregateException.InnerExceptions, Has.One.InstanceOf<InvalidOperationException>().With.Message.EqualTo("First aggregate failure"));
-            Assert.That(innerAggregateException.InnerExceptions, Has.One.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Second aggregate failure"));
-        }
+        AggregateException innerAggregateException = (AggregateException)exception.InnerException;
+
+        Assert.Equal(2, innerAggregateException.InnerExceptions.Count);
+        Assert.Single(innerAggregateException.InnerExceptions.OfType<InvalidOperationException>(), e => e.Message == "First aggregate failure");
+        Assert.Single(innerAggregateException.InnerExceptions.OfType<WebDriverBiDiException>(), e => e.Message == "Second aggregate failure");
     }
 
-    [Test]
-    public void TestCanGetMaxObserverCount()
+    [Fact]
+    public async Task TestCanGetMaxObserverCount()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
-        Assert.That(module.OnEventInvoked.MaxObserverCount, Is.EqualTo(0));
+        Assert.Equal(0u, module.OnEventInvoked.MaxObserverCount);
     }
 
-    [Test]
-    public void TestSubclassCanGetAccessDriver()
+    [Fact]
+    public async Task TestSubclassCanGetAccessDriver()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
-        Assert.That(module.ModuleName, Is.EqualTo("protocol"));
-        Assert.That(module.HostingDriver, Is.EqualTo(driver));
+        Assert.Equal("protocol", module.ModuleName);
+        Assert.Equal(driver, module.HostingDriver);
     }
 
-    [Test]
-    public void TestExceedingMaxObserverCountThrows()
+    [Fact]
+    public async Task TestExceedingMaxObserverCountThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -438,18 +438,18 @@ public class ModuleTests
         {
         });
 
-        Assert.That(() => module.OnEventInvoked.AddObserver((e) => { }), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.ThrowsAny<WebDriverBiDiException>(() => module.OnEventInvoked.AddObserver((e) => { }));
     }
 
-    [Test]
-    public void TestModuleWithNonReporterDriverDoesNotSetErrorReporter()
+    [Fact]
+    public async Task TestModuleWithNonReporterDriverDoesNotSetErrorReporter()
     {
         NonReporterDriver driver = new();
         TestProtocolModule module = new(driver);
 
         // Verify the module was constructed without throwing; observer error reporting
         // is silently skipped when the driver does not implement IEventObserverErrorReporter.
-        Assert.That(module.OnEventInvoked.CurrentObserverCount, Is.EqualTo(0));
+        Assert.Equal(0, module.OnEventInvoked.CurrentObserverCount);
     }
 
     private sealed class NonReporterDriver : IBiDiCommandExecutor

--- a/test/WebDriverBiDi.Tests/ModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/ModuleTests.cs
@@ -11,7 +11,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
 
         module.OnEventInvoked.AddObserver((TestEventArgs e) =>
@@ -58,7 +58,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
 
         // Use a ManualResetEventSlim because we want to reset the event.
@@ -94,7 +94,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -122,7 +122,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
@@ -167,7 +167,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
@@ -204,7 +204,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
@@ -263,7 +263,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
@@ -308,7 +308,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
@@ -345,7 +345,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
@@ -404,7 +404,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
         Assert.Equal(0u, module.OnEventInvoked.MaxObserverCount);
     }
@@ -414,7 +414,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver);
         Assert.Equal("protocol", module.ModuleName);
         Assert.Equal(driver, module.HostingDriver);
@@ -425,7 +425,7 @@ public class ModuleTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), transport);
         TestProtocolModule module = new(driver, 1);
 
         module.OnEventInvoked.AddObserver((TestEventArgs e) =>

--- a/test/WebDriverBiDi.Tests/Network/AddDataCollectorCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/AddDataCollectorCommandParametersTests.cs
@@ -3,182 +3,210 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class AddDataCollectorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         AddDataCollectorCommandParameters properties = new(1024);
-        Assert.That(properties.MethodName, Is.EqualTo("network.addDataCollector"));
+        Assert.Equal("network.addDataCollector", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         AddDataCollectorCommandParameters properties = new(1024);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(1));
-            Assert.That(dataTypesArray![0].Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(1024));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Single(dataTypesArray);
+        Assert.Equal("response", dataTypesArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(1024u, maxEncodedDataSize.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersSpecifyingResponseCollection()
     {
         AddDataCollectorCommandParameters properties = new(1024, DataType.Response);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(1));
-            Assert.That(dataTypesArray![0].Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(1024));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Single(dataTypesArray);
+        Assert.Equal("response", dataTypesArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(1024u, maxEncodedDataSize.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersSpecifyingRequestAndResponseCollection()
     {
         AddDataCollectorCommandParameters properties = new(1024, DataType.Response, DataType.Request);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(2));
-            List<string> dataTypesValues = dataTypesArray!.ToObject<List<string>>()!;
-            Assert.That(dataTypesValues, Contains.Item("request"));
-            Assert.That(dataTypesValues, Contains.Item("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(1024));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Equal(2, dataTypesArray.Count);
+        List<string>? dataTypesValues = dataTypesArray.ToObject<List<string>>();
+        Assert.NotNull(dataTypesValues);
+        Assert.Contains("request", dataTypesValues);
+        Assert.Contains("response", dataTypesValues);
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(1024u, maxEncodedDataSize.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersSpecifyingDuplicateCollection()
     {
         AddDataCollectorCommandParameters properties = new(1024, DataType.Request, DataType.Request, DataType.Response);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(2));
-            List<string> dataTypesValues = dataTypesArray!.ToObject<List<string>>()!;
-            Assert.That(dataTypesValues, Contains.Item("request"));
-            Assert.That(dataTypesValues, Contains.Item("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(1024));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Equal(2, dataTypesArray.Count);
+        List<string>? dataTypesValues = dataTypesArray.ToObject<List<string>>();
+        Assert.NotNull(dataTypesValues);
+        Assert.Contains("request", dataTypesValues);
+        Assert.Contains("response", dataTypesValues);
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(1024u, maxEncodedDataSize.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersSpecifyingRequestCollection()
     {
         AddDataCollectorCommandParameters properties = new(100, DataType.Request);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(1));
-            Assert.That(dataTypesArray![0].Value<string>(), Is.EqualTo("request"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(100));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Single(dataTypesArray);
+        Assert.Equal("request", dataTypesArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(100u, maxEncodedDataSize.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBrowsingContexts()
     {
         AddDataCollectorCommandParameters properties = new(100);
         properties.BrowsingContexts.Add("myContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(1));
-            Assert.That(dataTypesArray![0].Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(100));
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"] as JArray;
-            Assert.That(contextsArray, Is.Not.Null);
-            Assert.That(contextsArray, Has.Count.EqualTo(1));
-            Assert.That(contextsArray![0].Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Single(dataTypesArray);
+        Assert.Equal("response", dataTypesArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(100UL, maxEncodedDataSize.Value<ulong>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken as JArray;
+        Assert.NotNull(contextsArray);
+        Assert.Single(contextsArray);
+        Assert.Equal("myContext", contextsArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUserContexts()
     {
         AddDataCollectorCommandParameters properties = new(100);
         properties.UserContexts.Add("myUserContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(1));
-            Assert.That(dataTypesArray![0].Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(100));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"] as JArray;
-            Assert.That(userContextsArray, Is.Not.Null);
-            Assert.That(userContextsArray, Has.Count.EqualTo(1));
-            Assert.That(userContextsArray![0].Value<string>(), Is.EqualTo("myUserContext"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Single(dataTypesArray);
+        Assert.Equal("response", dataTypesArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(100UL, maxEncodedDataSize.Value<ulong>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken as JArray;
+        Assert.NotNull(userContextsArray);
+        Assert.Single(userContextsArray);
+        Assert.Equal("myUserContext", userContextsArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCollectorType()
     {
         AddDataCollectorCommandParameters properties = new(100)
@@ -187,21 +215,27 @@ public class AddDataCollectorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("dataTypes"));
-            Assert.That(serialized["dataTypes"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? dataTypesArray = serialized["dataTypes"] as JArray;
-            Assert.That(dataTypesArray, Is.Not.Null);
-            Assert.That(dataTypesArray, Has.Count.EqualTo(1));
-            Assert.That(dataTypesArray![0].Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("maxEncodedDataSize"));
-            Assert.That(serialized["maxEncodedDataSize"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxEncodedDataSize"]!.Value<ulong>(), Is.EqualTo(100));
-            Assert.That(serialized, Contains.Key("collectorType"));
-            Assert.That(serialized["collectorType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized!["collectorType"]!.Value<string>(), Is.EqualTo("blob"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("dataTypes"));
+        JToken? dataTypesToken = serialized["dataTypes"];
+        Assert.NotNull(dataTypesToken);
+        Assert.Equal(JTokenType.Array, dataTypesToken.Type);
+        JArray? dataTypesArray = dataTypesToken as JArray;
+        Assert.NotNull(dataTypesArray);
+        Assert.Single(dataTypesArray);
+        Assert.Equal("response", dataTypesArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxEncodedDataSize"));
+        JToken? maxEncodedDataSize = serialized["maxEncodedDataSize"];
+        Assert.NotNull(maxEncodedDataSize);
+        Assert.Equal(JTokenType.Integer, maxEncodedDataSize.Type);
+        Assert.Equal(100UL, maxEncodedDataSize.Value<ulong>());
+
+        Assert.True(serialized.ContainsKey("collectorType"));
+        JToken? collectorType = serialized["collectorType"];
+        Assert.NotNull(collectorType);
+        Assert.Equal(JTokenType.String, collectorType.Type);
+        Assert.Equal("blob", collectorType.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/AddDataCollectorCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/AddDataCollectorCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class AddDataCollectorCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class AddDataCollectorCommandResultTests
                       }
                       """;
         AddDataCollectorCommandResult? result = JsonSerializer.Deserialize<AddDataCollectorCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.CollectorId, Is.EqualTo("myCollectorId"));
+        Assert.NotNull(result);
+        Assert.Equal("myCollectorId", result.CollectorId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class AddDataCollectorCommandResultTests
                       }
                       """;
         AddDataCollectorCommandResult? result = JsonSerializer.Deserialize<AddDataCollectorCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         AddDataCollectorCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<AddDataCollectorCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AddDataCollectorCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class AddDataCollectorCommandResultTests
                         "collector": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<AddDataCollectorCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AddDataCollectorCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/AddInterceptCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/AddInterceptCommandParametersTests.cs
@@ -3,76 +3,78 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class AddInterceptCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         AddInterceptCommandParameters properties = new(InterceptPhase.BeforeRequestSent);
-        Assert.That(properties.MethodName, Is.EqualTo("network.addIntercept"));
+        Assert.Equal("network.addIntercept", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         AddInterceptCommandParameters properties = new(InterceptPhase.BeforeRequestSent);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("phases"));
-            Assert.That(serialized["phases"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray interceptArray = (JArray)serialized["phases"]!;
-            Assert.That(interceptArray, Has.Count.EqualTo(1));
-            Assert.That(interceptArray[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(interceptArray[0].Value<string>(), Is.EqualTo("beforeRequestSent"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("phases"));
+        JToken? phasesToken = serialized["phases"];
+        Assert.NotNull(phasesToken);
+        Assert.Equal(JTokenType.Array, phasesToken.Type);
+        JArray? interceptArray = phasesToken as JArray;
+        Assert.NotNull(interceptArray);
+        Assert.Single(interceptArray);
+        Assert.Equal(JTokenType.String, interceptArray[0].Type);
+        Assert.Equal("beforeRequestSent", interceptArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanConstructWithMultiplePhases()
     {
         AddInterceptCommandParameters properties = new(InterceptPhase.BeforeRequestSent, InterceptPhase.ResponseStarted);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("phases"));
-            Assert.That(serialized["phases"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray interceptArray = (JArray)serialized["phases"]!;
-            Assert.That(interceptArray, Has.Count.EqualTo(2));
-            Assert.That(interceptArray[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(interceptArray[0].Value<string>(), Is.EqualTo("beforeRequestSent"));
-            Assert.That(interceptArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(interceptArray[1].Value<string>(), Is.EqualTo("responseStarted"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("phases"));
+        JToken? phasesToken = serialized["phases"];
+        Assert.NotNull(phasesToken);
+        Assert.Equal(JTokenType.Array, phasesToken.Type);
+        JArray? interceptArray = phasesToken as JArray;
+        Assert.NotNull(interceptArray);
+        Assert.Equal(2, interceptArray.Count);
+        Assert.Equal(JTokenType.String, interceptArray[0].Type);
+        Assert.Equal("beforeRequestSent", interceptArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, interceptArray[1].Type);
+        Assert.Equal("responseStarted", interceptArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestDuplicatePhaseArgumentOnlySerializesOnce()
     {
         AddInterceptCommandParameters properties = new(InterceptPhase.BeforeRequestSent, InterceptPhase.BeforeRequestSent);
         properties.Phases.Add(InterceptPhase.AuthRequired);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("phases"));
-            Assert.That(serialized["phases"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray phases = (JArray)serialized["phases"]!;
-            Assert.That(phases, Has.Count.EqualTo(2));
-            Assert.That(phases[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(phases[0].Value<string>(), Is.EqualTo("beforeRequestSent"));
-            Assert.That(phases[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(phases[1].Value<string>(), Is.EqualTo("authRequired"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("phases"));
+        JToken? phasesToken = serialized["phases"];
+        Assert.NotNull(phasesToken);
+        Assert.Equal(JTokenType.Array, phasesToken.Type);
+        JArray? phases = phasesToken as JArray;
+        Assert.NotNull(phases);
+        Assert.Equal(2, phases.Count);
+        Assert.Equal(JTokenType.String, phases[0].Type);
+        Assert.Equal("beforeRequestSent", phases[0].Value<string>());
+        Assert.Equal(JTokenType.String, phases[1].Type);
+        Assert.Equal("authRequired", phases[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAllProperties()
     {
         AddInterceptCommandParameters properties = new(InterceptPhase.BeforeRequestSent)
@@ -82,39 +84,53 @@ public class AddInterceptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("phases"));
-            Assert.That(serialized["phases"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray phases = (JArray)serialized["phases"]!;
-            Assert.That(phases, Has.Count.EqualTo(1));
-            Assert.That(phases[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(phases[0].Value<string>(), Is.EqualTo("beforeRequestSent"));
-            Assert.That(serialized, Contains.Key("contexts"));
-            JArray contexts = (JArray)serialized["contexts"]!;
-            Assert.That(contexts, Has.Count.EqualTo(1));
-            Assert.That(contexts[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contexts[0].Value<string>(), Is.EqualTo("myContext"));
-            Assert.That(serialized, Contains.Key("urlPatterns"));
-            Assert.That(serialized["urlPatterns"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray patterns = (JArray)serialized["urlPatterns"]!;
-            Assert.That(patterns, Has.Count.EqualTo(1));
-            Assert.That(patterns[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject urlPatternObject = (JObject)patterns[0];
-            Assert.That(urlPatternObject, Has.Count.EqualTo(2));
-            Assert.That(urlPatternObject, Contains.Key("type"));
-            Assert.That(urlPatternObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(urlPatternObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(urlPatternObject, Contains.Key("pattern"));
-            Assert.That(urlPatternObject["pattern"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(urlPatternObject["pattern"]!.Value<string>(), Is.EqualTo("https://example.com/*"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("phases"));
+        JToken? phasesToken = serialized["phases"];
+        Assert.NotNull(phasesToken);
+        Assert.Equal(JTokenType.Array, phasesToken.Type);
+        JArray? phases = phasesToken as JArray;
+        Assert.NotNull(phases);
+        Assert.Single(phases);
+        Assert.Equal(JTokenType.String, phases[0].Type);
+        Assert.Equal("beforeRequestSent", phases[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        JArray? contexts = contextsToken as JArray;
+        Assert.NotNull(contexts);
+        Assert.Single(contexts);
+        Assert.Equal(JTokenType.String, contexts[0].Type);
+        Assert.Equal("myContext", contexts[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("urlPatterns"));
+        JToken? urlPatternsToken = serialized["urlPatterns"];
+        Assert.NotNull(urlPatternsToken);
+        Assert.Equal(JTokenType.Array, urlPatternsToken.Type);
+        JArray? patterns = urlPatternsToken as JArray;
+        Assert.NotNull(patterns);
+        Assert.Single(patterns);
+        Assert.Equal(JTokenType.Object, patterns[0].Type);
+        JObject? urlPatternObject = patterns[0] as JObject;
+        Assert.NotNull(urlPatternObject);
+        Assert.Equal(2, urlPatternObject.Count);
+        Assert.True(urlPatternObject.ContainsKey("type"));
+        JToken? patternType = urlPatternObject["type"];
+        Assert.NotNull(patternType);
+        Assert.Equal(JTokenType.String, patternType.Type);
+        Assert.Equal("string", patternType.Value<string>());
+        Assert.True(urlPatternObject.ContainsKey("pattern"));
+        JToken? pattern = urlPatternObject["pattern"];
+        Assert.NotNull(pattern);
+        Assert.Equal(JTokenType.String, pattern.Type);
+        Assert.Equal("https://example.com/*", pattern.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestOmittingPhaseInConstructorThrows()
     {
-        Assert.That(() => new AddInterceptCommandParameters(), Throws.InstanceOf<ArgumentException>().With.Message.StartsWith("You must supply at least one phase for the intercept"));
+        Assert.StartsWith("You must supply at least one phase for the intercept", Assert.ThrowsAny<ArgumentException>(() => new AddInterceptCommandParameters()).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/AddInterceptCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/AddInterceptCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class AddInterceptCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class AddInterceptCommandResultTests
                       }
                       """;
         AddInterceptCommandResult? result = JsonSerializer.Deserialize<AddInterceptCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.InterceptId, Is.EqualTo("myInterceptId"));
+        Assert.NotNull(result);
+        Assert.Equal("myInterceptId", result.InterceptId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class AddInterceptCommandResultTests
                       }
                       """;
         AddInterceptCommandResult? result = JsonSerializer.Deserialize<AddInterceptCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         AddInterceptCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<AddInterceptCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AddInterceptCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class AddInterceptCommandResultTests
                         "intercept": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<AddInterceptCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AddInterceptCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/AuthChallengeTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/AuthChallengeTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class AuthChallengeTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeAuthChallenge()
     {
         string json = """
@@ -15,15 +14,13 @@ public class AuthChallengeTests
                       }
                       """;
         AuthChallenge? challenge = JsonSerializer.Deserialize<AuthChallenge>(json);
-        Assert.That(challenge, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(challenge.Scheme, Is.EqualTo("basic"));
-            Assert.That(challenge.Realm, Is.EqualTo("example.com"));
-        }
+        Assert.NotNull(challenge);
+
+        Assert.Equal("basic", challenge.Scheme);
+        Assert.Equal("example.com", challenge.Realm);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -33,12 +30,12 @@ public class AuthChallengeTests
                       }
                       """;
         AuthChallenge? challenge = JsonSerializer.Deserialize<AuthChallenge>(json);
-        Assert.That(challenge, Is.Not.Null);
+        Assert.NotNull(challenge);
         AuthChallenge copy = challenge with { };
-        Assert.That(copy, Is.EqualTo(challenge));
+        Assert.Equal(challenge, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingSchemeThrows()
     {
         string json = """
@@ -46,10 +43,10 @@ public class AuthChallengeTests
                         "realm": "example.com"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<AuthChallenge>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AuthChallenge>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidSchemeTypeThrows()
     {
         string json = """
@@ -58,10 +55,10 @@ public class AuthChallengeTests
                         "realm": "example.com"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<AuthChallenge>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AuthChallenge>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRealmThrows()
     {
         string json = """
@@ -69,10 +66,10 @@ public class AuthChallengeTests
                         "scheme": "basic"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<AuthChallenge>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AuthChallenge>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidRealmTypeThrows()
     {
         string json = """
@@ -81,6 +78,6 @@ public class AuthChallengeTests
                         "realm": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<AuthChallenge>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AuthChallenge>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/AuthRequiredEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/AuthRequiredEventArgsTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class AuthRequiredEventArgsTests
 {
     private readonly string requestDataJson = """
@@ -34,7 +33,7 @@ public class AuthRequiredEventArgsTests
                                               }
                                               """;
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -74,16 +73,14 @@ public class AuthRequiredEventArgsTests
                            }
                            """;
         AuthRequiredEventArgs? eventArgs = JsonSerializer.Deserialize<AuthRequiredEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            // Note that proper deserialization of base class properties is tested in BaseNetworkEventArgsTests.
-            // Also proper deserialization of the ResponseData object is handled in InitiatorTests.
-            Assert.That(eventArgs.Response, Is.Not.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        // Note that proper deserialization of base class properties is tested in BaseNetworkEventArgsTests.
+        // Also proper deserialization of the ResponseData object is handled in InitiatorTests.
+        Assert.NotNull(eventArgs.Response);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -123,12 +120,12 @@ public class AuthRequiredEventArgsTests
                            }
                            """;
         AuthRequiredEventArgs? eventArgs = JsonSerializer.Deserialize<AuthRequiredEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         AuthRequiredEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingResponseThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -144,6 +141,6 @@ public class AuthRequiredEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<AuthRequiredEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<AuthRequiredEventArgs>(eventJson));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/BaseNetworkEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/BaseNetworkEventArgsTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class BaseNetworkEventArgsTests
 {
     private readonly string requestDataJson = """
@@ -34,7 +33,7 @@ public class BaseNetworkEventArgsTests
                                               }
                                               """;
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -51,23 +50,21 @@ public class BaseNetworkEventArgsTests
                            }
                            """;
         BaseNetworkEventArgs? eventArgs = JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal(milliseconds, eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithIntercepts()
     {
         DateTime now = DateTime.UtcNow;
@@ -85,25 +82,23 @@ public class BaseNetworkEventArgsTests
                            }
                            """;
         BaseNetworkEventArgs? eventArgs = JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.True);
-            Assert.That(eventArgs.Intercepts, Is.Not.Null);
-            Assert.That(eventArgs.Intercepts, Has.Count.EqualTo(1));
-            Assert.That(eventArgs.Intercepts![0], Is.EqualTo("myInterceptId"));
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.True(eventArgs.IsBlocked);
+        Assert.NotNull(eventArgs.Intercepts);
+        Assert.Single(eventArgs.Intercepts);
+        Assert.Equal("myInterceptId", eventArgs.Intercepts[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullContextId()
     {
         DateTime now = DateTime.UtcNow;
@@ -120,23 +115,21 @@ public class BaseNetworkEventArgsTests
                            }
                            """;
         BaseNetworkEventArgs? eventArgs = JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.Null);
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-        }
+        Assert.Null(eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -153,12 +146,12 @@ public class BaseNetworkEventArgsTests
                            }
                            """;
         BaseNetworkEventArgs? eventArgs = JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         BaseNetworkEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextIdThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -173,10 +166,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextIdTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -192,10 +185,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullNavigationId()
     {
         DateTime now = DateTime.UtcNow;
@@ -212,23 +205,21 @@ public class BaseNetworkEventArgsTests
                            }
                            """;
         BaseNetworkEventArgs? eventArgs = JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.Null);
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Null(eventArgs.NavigationId);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingNavigationIdThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -243,10 +234,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidNavigationIdTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -262,10 +253,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingIsBlockedThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -280,10 +271,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidIsBlockedTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -299,10 +290,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRedirectCountThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -317,10 +308,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidRedirectCountTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -336,10 +327,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTimestampThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -354,10 +345,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidTimestampTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -373,10 +364,10 @@ public class BaseNetworkEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRequestDataThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -391,10 +382,10 @@ public class BaseNetworkEventArgsTests
                              "timestamp": {{milliseconds}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidRequestDataTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -410,6 +401,6 @@ public class BaseNetworkEventArgsTests
                              "request": "requestData"
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BaseNetworkEventArgs>(eventJson));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/BeforeRequestSentEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/BeforeRequestSentEventArgsTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class BeforeRequestSentEventArgsTests
 {
     private readonly string requestDataJson = """
@@ -34,7 +33,7 @@ public class BeforeRequestSentEventArgsTests
                                               }
                                               """;
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -51,15 +50,13 @@ public class BeforeRequestSentEventArgsTests
                            }
                            """;
         BeforeRequestSentEventArgs? eventArgs = JsonSerializer.Deserialize<BeforeRequestSentEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            // Note that proper deserialization of base class properties is tested in BaseNetworkEventArgsTests.
-            Assert.That(eventArgs.Initiator, Is.Null);
-        }
+        Assert.NotNull(eventArgs);
+
+        // Note that proper deserialization of base class properties is tested in BaseNetworkEventArgsTests.
+        Assert.Null(eventArgs.Initiator);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalValues()
     {
         DateTime now = DateTime.UtcNow;
@@ -79,17 +76,15 @@ public class BeforeRequestSentEventArgsTests
                            }
                            """;
         BeforeRequestSentEventArgs? eventArgs = JsonSerializer.Deserialize<BeforeRequestSentEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            // Note that proper deserialization of base class properties is tested in BaseNetworkEventArgsTests.
-            // Also proper deserialization of the Initiator object is handled in InitiatorTests.
-            Assert.That(eventArgs.Initiator, Is.Not.Null);
-            Assert.That(eventArgs.Initiator!.Type, Is.EqualTo(InitiatorType.Parser));
-        }
+        Assert.NotNull(eventArgs);
+
+        // Note that proper deserialization of base class properties is tested in BaseNetworkEventArgsTests.
+        // Also proper deserialization of the Initiator object is handled in InitiatorTests.
+        Assert.NotNull(eventArgs.Initiator);
+        Assert.Equal(InitiatorType.Parser, eventArgs.Initiator.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -106,12 +101,12 @@ public class BeforeRequestSentEventArgsTests
                            }
                            """;
         BeforeRequestSentEventArgs? eventArgs = JsonSerializer.Deserialize<BeforeRequestSentEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         BeforeRequestSentEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidInitiatorTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -128,6 +123,6 @@ public class BeforeRequestSentEventArgsTests
                             "initiator": []
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<BeforeRequestSentEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BeforeRequestSentEventArgs>(eventJson));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/BytesValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/BytesValueTests.cs
@@ -4,48 +4,54 @@ using System.Text;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-
-[TestFixture]
 public class BytesValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeStringValue()
     {
         BytesValue value = BytesValue.FromString("this is my string");
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["value"]!.Value<string>(), Is.EqualTo("this is my string"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("string", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.String, valueToken.Type);
+        Assert.Equal("this is my string", valueToken.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeBase64Value()
     {
         string base64String = Convert.ToBase64String(Encoding.UTF8.GetBytes("this is my string"));
         BytesValue value = BytesValue.FromBase64String(base64String);
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["value"]!.Value<string>(), Is.EqualTo(base64String));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("base64", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.String, valueToken.Type);
+        Assert.Equal(base64String, valueToken.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeBase64ValueFromByteArray()
     {
         byte[] byteArray = Encoding.UTF8.GetBytes("this is my string");
@@ -53,19 +59,23 @@ public class BytesValueTests
         BytesValue value = BytesValue.FromByteArray(byteArray);
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["value"]!.Value<string>(), Is.EqualTo(base64String));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("base64", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.String, valueToken.Type);
+        Assert.Equal(base64String, valueToken.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeStringValue()
     {
         string stringValue = "this is my string";
@@ -77,16 +87,14 @@ public class BytesValueTests
                       }
                       """;
         BytesValue? value = JsonSerializer.Deserialize<BytesValue>(json);
-        Assert.That(value, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(value.Value, Is.EqualTo("this is my string"));
-            Assert.That(value.ValueAsByteArray, Is.EqualTo(valueArray));
-        }
+        Assert.NotNull(value);
+
+        Assert.Equal(BytesValueType.String, value.Type);
+        Assert.Equal("this is my string", value.Value);
+        Assert.Equal(valueArray, value.ValueAsByteArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeBase64Value()
     {
         // Disable spell checking only for the base64-encoded value.
@@ -100,19 +108,17 @@ public class BytesValueTests
                       }
                       """;
         BytesValue? value = JsonSerializer.Deserialize<BytesValue>(json);
-        Assert.That(value, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(value.Type, Is.EqualTo(BytesValueType.Base64));
+        Assert.NotNull(value);
 
-            // Disable spell checking only for the base64-encoded value.
-            // cspell: disable-next
-            Assert.That(value.Value, Is.EqualTo("dGhpcyBpcyBteSBzdHJpbmc="));
-            Assert.That(value.ValueAsByteArray, Is.EqualTo(valueArray));
-        }
+        Assert.Equal(BytesValueType.Base64, value.Type);
+
+        // Disable spell checking only for the base64-encoded value.
+        // cspell: disable-next
+        Assert.Equal("dGhpcyBpcyBteSBzdHJpbmc=", value.Value);
+        Assert.Equal(valueArray, value.ValueAsByteArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string stringValue = "this is my string";
@@ -124,12 +130,12 @@ public class BytesValueTests
                       }
                       """;
         BytesValue? value = JsonSerializer.Deserialize<BytesValue>(json);
-        Assert.That(value, Is.Not.Null);
+        Assert.NotNull(value);
         BytesValue copy = value with { };
-        Assert.That(copy, Is.EqualTo(value));
+        Assert.Equal(value, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingTypeThrows()
     {
         string json = """
@@ -137,10 +143,10 @@ public class BytesValueTests
                         "value": "this is my string"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BytesValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BytesValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidTypeValueThrows()
     {
         string json = $$"""
@@ -149,10 +155,10 @@ public class BytesValueTests
                         "value": "this is my string"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BytesValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BytesValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidTypeThrows()
     {
         string json = $$"""
@@ -161,10 +167,10 @@ public class BytesValueTests
                         "value": "this is my string"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BytesValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BytesValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingValueThrows()
     {
         string json = $$"""
@@ -172,10 +178,10 @@ public class BytesValueTests
                         "type": "string"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BytesValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BytesValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidValueThrows()
     {
         string json = $$"""
@@ -184,6 +190,6 @@ public class BytesValueTests
                         "value": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<BytesValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BytesValue>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ContinueRequestCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ContinueRequestCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ContinueRequestCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ContinueRequestCommandParameters properties = new("myRequestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.continueRequest"));
+        Assert.Equal("network.continueRequest", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ContinueRequestCommandParameters properties = new("myRequestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithBody()
     {
         ContinueRequestCommandParameters properties = new("myRequestId")
@@ -37,26 +36,34 @@ public class ContinueRequestCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("body"));
-            Assert.That(serialized["body"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject bodyObject = (JObject)serialized["body"]!;
-            Assert.That(bodyObject, Has.Count.EqualTo(2));
-            Assert.That(bodyObject, Contains.Key("type"));
-            Assert.That(bodyObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(bodyObject, Contains.Key("value"));
-            Assert.That(bodyObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["value"]!.Value<string>(), Is.EqualTo("test body"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("body"));
+        JToken? bodyToken = serialized["body"];
+        Assert.NotNull(bodyToken);
+        Assert.Equal(JTokenType.Object, bodyToken.Type);
+        JObject? bodyObject = bodyToken as JObject;
+        Assert.NotNull(bodyObject);
+        Assert.Equal(2, bodyObject.Count);
+        Assert.True(bodyObject.ContainsKey("type"));
+        JToken? bodyType = bodyObject["type"];
+        Assert.NotNull(bodyType);
+        Assert.Equal(JTokenType.String, bodyType.Type);
+        Assert.Equal("string", bodyType.Value<string>());
+        Assert.True(bodyObject.ContainsKey("value"));
+        JToken? bodyValue = bodyObject["value"];
+        Assert.NotNull(bodyValue);
+        Assert.Equal(JTokenType.String, bodyValue.Type);
+        Assert.Equal("test body", bodyValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithCookies()
     {
         ContinueRequestCommandParameters properties = new("myRequestId")
@@ -65,36 +72,50 @@ public class ContinueRequestCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("cookies"));
-            Assert.That(serialized["cookies"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray cookieHeaderArray = (JArray)serialized["cookies"]!;
-            Assert.That(cookieHeaderArray, Has.Count.EqualTo(1));
-            Assert.That(cookieHeaderArray[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieHeaderObject = (JObject)cookieHeaderArray[0];
-            Assert.That(cookieHeaderObject, Has.Count.EqualTo(2));
-            Assert.That(cookieHeaderObject, Contains.Key("name"));
-            Assert.That(cookieHeaderObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieHeaderObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(cookieHeaderObject, Contains.Key("value"));
-            Assert.That(cookieHeaderObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieValueObject = (JObject)cookieHeaderObject["value"]!;
-            Assert.That(cookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(cookieValueObject, Contains.Key("type"));
-            Assert.That(cookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(cookieValueObject, Contains.Key("value"));
-            Assert.That(cookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("cookies"));
+        JToken? cookiesToken = serialized["cookies"];
+        Assert.NotNull(cookiesToken);
+        Assert.Equal(JTokenType.Array, cookiesToken.Type);
+        JArray? cookieHeaderArray = cookiesToken as JArray;
+        Assert.NotNull(cookieHeaderArray);
+        Assert.Single(cookieHeaderArray);
+        Assert.Equal(JTokenType.Object, cookieHeaderArray[0].Type);
+        JObject? cookieHeaderObject = cookieHeaderArray[0] as JObject;
+        Assert.NotNull(cookieHeaderObject);
+        Assert.Equal(2, cookieHeaderObject.Count);
+        Assert.True(cookieHeaderObject.ContainsKey("name"));
+        JToken? cookieName = cookieHeaderObject["name"];
+        Assert.NotNull(cookieName);
+        Assert.Equal(JTokenType.String, cookieName.Type);
+        Assert.Equal("cookieName", cookieName.Value<string>());
+        Assert.True(cookieHeaderObject.ContainsKey("value"));
+        JToken? cookieValueToken = cookieHeaderObject["value"];
+        Assert.NotNull(cookieValueToken);
+        Assert.Equal(JTokenType.Object, cookieValueToken.Type);
+        JObject? cookieValueObject = cookieValueToken as JObject;
+        Assert.NotNull(cookieValueObject);
+        Assert.Equal(2, cookieValueObject.Count);
+        Assert.True(cookieValueObject.ContainsKey("type"));
+        JToken? cookieValueType = cookieValueObject["type"];
+        Assert.NotNull(cookieValueType);
+        Assert.Equal(JTokenType.String, cookieValueType.Type);
+        Assert.Equal("string", cookieValueType.Value<string>());
+        Assert.True(cookieValueObject.ContainsKey("value"));
+        JToken? cookieValueValue = cookieValueObject["value"];
+        Assert.NotNull(cookieValueValue);
+        Assert.Equal(JTokenType.String, cookieValueValue.Type);
+        Assert.Equal("cookieValue", cookieValueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithHeaders()
     {
         ContinueRequestCommandParameters properties = new("myRequestId")
@@ -103,36 +124,50 @@ public class ContinueRequestCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray headerArray = (JArray)serialized["headers"]!;
-            Assert.That(headerArray, Has.Count.EqualTo(1));
-            Assert.That(headerArray[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject headerObject = (JObject)headerArray[0];
-            Assert.That(headerObject, Has.Count.EqualTo(2));
-            Assert.That(headerObject, Contains.Key("name"));
-            Assert.That(headerObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerObject["name"]!.Value<string>(), Is.EqualTo("headerName"));
-            Assert.That(headerObject, Contains.Key("value"));
-            Assert.That(headerObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject headerValueObject = (JObject)headerObject["value"]!;
-            Assert.That(headerValueObject, Has.Count.EqualTo(2));
-            Assert.That(headerValueObject, Contains.Key("type"));
-            Assert.That(headerValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(headerValueObject, Contains.Key("value"));
-            Assert.That(headerValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerValueObject["value"]!.Value<string>(), Is.EqualTo("headerValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headerArray = headersToken as JArray;
+        Assert.NotNull(headerArray);
+        Assert.Single(headerArray);
+        Assert.Equal(JTokenType.Object, headerArray[0].Type);
+        JObject? headerObject = headerArray[0] as JObject;
+        Assert.NotNull(headerObject);
+        Assert.Equal(2, headerObject.Count);
+        Assert.True(headerObject.ContainsKey("name"));
+        JToken? headerName = headerObject["name"];
+        Assert.NotNull(headerName);
+        Assert.Equal(JTokenType.String, headerName.Type);
+        Assert.Equal("headerName", headerName.Value<string>());
+        Assert.True(headerObject.ContainsKey("value"));
+        JToken? headerValueToken = headerObject["value"];
+        Assert.NotNull(headerValueToken);
+        Assert.Equal(JTokenType.Object, headerValueToken.Type);
+        JObject? headerValueObject = headerValueToken as JObject;
+        Assert.NotNull(headerValueObject);
+        Assert.Equal(2, headerValueObject.Count);
+        Assert.True(headerValueObject.ContainsKey("type"));
+        JToken? headerValueType = headerValueObject["type"];
+        Assert.NotNull(headerValueType);
+        Assert.Equal(JTokenType.String, headerValueType.Type);
+        Assert.Equal("string", headerValueType.Value<string>());
+        Assert.True(headerValueObject.ContainsKey("value"));
+        JToken? headerValueValue = headerValueObject["value"];
+        Assert.NotNull(headerValueValue);
+        Assert.Equal(JTokenType.String, headerValueValue.Type);
+        Assert.Equal("headerValue", headerValueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithMethod()
     {
         ContinueRequestCommandParameters properties = new("myRequestId")
@@ -141,19 +176,22 @@ public class ContinueRequestCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("method"));
-            Assert.That(serialized["method"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["method"]!.Value<string>(), Is.EqualTo("get"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("method"));
+        JToken? method = serialized["method"];
+        Assert.NotNull(method);
+        Assert.Equal(JTokenType.String, method.Type);
+        Assert.Equal("get", method.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithUrl()
     {
         ContinueRequestCommandParameters properties = new("myRequestId")
@@ -162,15 +200,18 @@ public class ContinueRequestCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("url"));
-            Assert.That(serialized["url"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["url"]!.Value<string>(), Is.EqualTo("https://example.com"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("url"));
+        JToken? url = serialized["url"];
+        Assert.NotNull(url);
+        Assert.Equal(JTokenType.String, url.Type);
+        Assert.Equal("https://example.com", url.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ContinueRequestCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ContinueRequestCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ContinueRequestCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         ContinueRequestCommandResult? result = JsonSerializer.Deserialize<ContinueRequestCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ContinueRequestCommandResult? result = JsonSerializer.Deserialize<ContinueRequestCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ContinueRequestCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ContinueResponseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ContinueResponseCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ContinueResponseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ContinueResponseCommandParameters properties = new("myRequestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.continueResponse"));
+        Assert.Equal("network.continueResponse", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ContinueResponseCommandParameters properties = new("myRequestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAuthCredentials()
     {
         ContinueResponseCommandParameters properties = new("myRequestId")
@@ -37,29 +36,39 @@ public class ContinueResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("credentials"));
-            Assert.That(serialized["credentials"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject bodyObject = (JObject)serialized["credentials"]!;
-            Assert.That(bodyObject, Has.Count.EqualTo(3));
-            Assert.That(bodyObject, Contains.Key("type"));
-            Assert.That(bodyObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["type"]!.Value<string>(), Is.EqualTo("password"));
-            Assert.That(bodyObject, Contains.Key("username"));
-            Assert.That(bodyObject["username"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["username"]!.Value<string>(), Is.EqualTo("myUserName"));
-            Assert.That(bodyObject, Contains.Key("password"));
-            Assert.That(bodyObject["password"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["password"]!.Value<string>(), Is.EqualTo("myPassword"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("credentials"));
+        JToken? credentialsToken = serialized["credentials"];
+        Assert.NotNull(credentialsToken);
+        Assert.Equal(JTokenType.Object, credentialsToken.Type);
+        JObject? bodyObject = credentialsToken as JObject;
+        Assert.NotNull(bodyObject);
+        Assert.Equal(3, bodyObject.Count);
+        Assert.True(bodyObject.ContainsKey("type"));
+        JToken? credType = bodyObject["type"];
+        Assert.NotNull(credType);
+        Assert.Equal(JTokenType.String, credType.Type);
+        Assert.Equal("password", credType.Value<string>());
+        Assert.True(bodyObject.ContainsKey("username"));
+        JToken? username = bodyObject["username"];
+        Assert.NotNull(username);
+        Assert.Equal(JTokenType.String, username.Type);
+        Assert.Equal("myUserName", username.Value<string>());
+        Assert.True(bodyObject.ContainsKey("password"));
+        JToken? password = bodyObject["password"];
+        Assert.NotNull(password);
+        Assert.Equal(JTokenType.String, password.Type);
+        Assert.Equal("myPassword", password.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithCookies()
     {
         ContinueResponseCommandParameters properties = new("myRequestId")
@@ -68,36 +77,50 @@ public class ContinueResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("cookies"));
-            Assert.That(serialized["cookies"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray cookieHeaderArray = (JArray)serialized["cookies"]!;
-            Assert.That(cookieHeaderArray, Has.Count.EqualTo(1));
-            Assert.That(cookieHeaderArray[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieHeaderObject = (JObject)cookieHeaderArray[0];
-            Assert.That(cookieHeaderObject, Has.Count.EqualTo(2));
-            Assert.That(cookieHeaderObject, Contains.Key("name"));
-            Assert.That(cookieHeaderObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieHeaderObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(cookieHeaderObject, Contains.Key("value"));
-            Assert.That(cookieHeaderObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieValueObject = (JObject)cookieHeaderObject["value"]!;
-            Assert.That(cookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(cookieValueObject, Contains.Key("type"));
-            Assert.That(cookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(cookieValueObject, Contains.Key("value"));
-            Assert.That(cookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("cookies"));
+        JToken? cookiesToken = serialized["cookies"];
+        Assert.NotNull(cookiesToken);
+        Assert.Equal(JTokenType.Array, cookiesToken.Type);
+        JArray? cookieHeaderArray = cookiesToken as JArray;
+        Assert.NotNull(cookieHeaderArray);
+        Assert.Single(cookieHeaderArray);
+        Assert.Equal(JTokenType.Object, cookieHeaderArray[0].Type);
+        JObject? cookieHeaderObject = cookieHeaderArray[0] as JObject;
+        Assert.NotNull(cookieHeaderObject);
+        Assert.Equal(2, cookieHeaderObject.Count);
+        Assert.True(cookieHeaderObject.ContainsKey("name"));
+        JToken? cookieName = cookieHeaderObject["name"];
+        Assert.NotNull(cookieName);
+        Assert.Equal(JTokenType.String, cookieName.Type);
+        Assert.Equal("cookieName", cookieName.Value<string>());
+        Assert.True(cookieHeaderObject.ContainsKey("value"));
+        JToken? cookieValueToken = cookieHeaderObject["value"];
+        Assert.NotNull(cookieValueToken);
+        Assert.Equal(JTokenType.Object, cookieValueToken.Type);
+        JObject? cookieValueObject = cookieValueToken as JObject;
+        Assert.NotNull(cookieValueObject);
+        Assert.Equal(2, cookieValueObject.Count);
+        Assert.True(cookieValueObject.ContainsKey("type"));
+        JToken? cookieValueType = cookieValueObject["type"];
+        Assert.NotNull(cookieValueType);
+        Assert.Equal(JTokenType.String, cookieValueType.Type);
+        Assert.Equal("string", cookieValueType.Value<string>());
+        Assert.True(cookieValueObject.ContainsKey("value"));
+        JToken? cookieValueValue = cookieValueObject["value"];
+        Assert.NotNull(cookieValueValue);
+        Assert.Equal(JTokenType.String, cookieValueValue.Type);
+        Assert.Equal("cookieValue", cookieValueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithHeaders()
     {
         ContinueResponseCommandParameters properties = new("myRequestId")
@@ -106,36 +129,50 @@ public class ContinueResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray headerArray = (JArray)serialized["headers"]!;
-            Assert.That(headerArray, Has.Count.EqualTo(1));
-            Assert.That(headerArray[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject headerObject = (JObject)headerArray[0];
-            Assert.That(headerObject, Has.Count.EqualTo(2));
-            Assert.That(headerObject, Contains.Key("name"));
-            Assert.That(headerObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerObject["name"]!.Value<string>(), Is.EqualTo("headerName"));
-            Assert.That(headerObject, Contains.Key("value"));
-            Assert.That(headerObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject headerValueObject = (JObject)headerObject["value"]!;
-            Assert.That(headerValueObject, Has.Count.EqualTo(2));
-            Assert.That(headerValueObject, Contains.Key("type"));
-            Assert.That(headerValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(headerValueObject, Contains.Key("value"));
-            Assert.That(headerValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerValueObject["value"]!.Value<string>(), Is.EqualTo("headerValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headerArray = headersToken as JArray;
+        Assert.NotNull(headerArray);
+        Assert.Single(headerArray);
+        Assert.Equal(JTokenType.Object, headerArray[0].Type);
+        JObject? headerObject = headerArray[0] as JObject;
+        Assert.NotNull(headerObject);
+        Assert.Equal(2, headerObject.Count);
+        Assert.True(headerObject.ContainsKey("name"));
+        JToken? headerName = headerObject["name"];
+        Assert.NotNull(headerName);
+        Assert.Equal(JTokenType.String, headerName.Type);
+        Assert.Equal("headerName", headerName.Value<string>());
+        Assert.True(headerObject.ContainsKey("value"));
+        JToken? headerValueToken = headerObject["value"];
+        Assert.NotNull(headerValueToken);
+        Assert.Equal(JTokenType.Object, headerValueToken.Type);
+        JObject? headerValueObject = headerValueToken as JObject;
+        Assert.NotNull(headerValueObject);
+        Assert.Equal(2, headerValueObject.Count);
+        Assert.True(headerValueObject.ContainsKey("type"));
+        JToken? headerValueType = headerValueObject["type"];
+        Assert.NotNull(headerValueType);
+        Assert.Equal(JTokenType.String, headerValueType.Type);
+        Assert.Equal("string", headerValueType.Value<string>());
+        Assert.True(headerValueObject.ContainsKey("value"));
+        JToken? headerValueValue = headerValueObject["value"];
+        Assert.NotNull(headerValueValue);
+        Assert.Equal(JTokenType.String, headerValueValue.Type);
+        Assert.Equal("headerValue", headerValueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithReasonPhrase()
     {
         ContinueResponseCommandParameters properties = new("myRequestId")
@@ -144,19 +181,22 @@ public class ContinueResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("reasonPhrase"));
-            Assert.That(serialized["reasonPhrase"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["reasonPhrase"]!.Value<string>(), Is.EqualTo("Not Found"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("reasonPhrase"));
+        JToken? reasonPhrase = serialized["reasonPhrase"];
+        Assert.NotNull(reasonPhrase);
+        Assert.Equal(JTokenType.String, reasonPhrase.Type);
+        Assert.Equal("Not Found", reasonPhrase.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithStatusCode()
     {
         ContinueResponseCommandParameters properties = new("myRequestId")
@@ -165,15 +205,18 @@ public class ContinueResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("statusCode"));
-            Assert.That(serialized["statusCode"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["statusCode"]!.Value<ulong>(), Is.EqualTo(404));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("statusCode"));
+        JToken? statusCode = serialized["statusCode"];
+        Assert.NotNull(statusCode);
+        Assert.Equal(JTokenType.Integer, statusCode.Type);
+        Assert.Equal(404UL, statusCode.Value<ulong>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ContinueResponseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ContinueResponseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ContinueResponseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         ContinueResponseCommandResult? result = JsonSerializer.Deserialize<ContinueResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ContinueResponseCommandResult? result = JsonSerializer.Deserialize<ContinueResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ContinueResponseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ContinueWithAuthCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ContinueWithAuthCommandParametersTests.cs
@@ -3,35 +3,37 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ContinueWithAuthCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ContinueWithAuthCommandParameters properties = new("requestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.continueWithAuth"));
+        Assert.Equal("network.continueWithAuth", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ContinueWithAuthCommandParameters properties = new("requestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("requestId"));
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("default"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("requestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("default", action.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCancelAction()
     {
         ContinueWithAuthCommandParameters properties = new("requestId")
@@ -40,19 +42,22 @@ public class ContinueWithAuthCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("requestId"));
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("cancel"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("requestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("cancel", action.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithProvideCredentialsAction()
     {
         ContinueWithAuthCommandParameters properties = new("requestId")
@@ -61,32 +66,45 @@ public class ContinueWithAuthCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("requestId"));
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("provideCredentials"));
-            Assert.That(serialized, Contains.Key("credentials"));
-            Assert.That(serialized["credentials"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject credentialsObject = (JObject)serialized["credentials"]!;
-            Assert.That(credentialsObject, Has.Count.EqualTo(3));
-            Assert.That(credentialsObject, Contains.Key("type"));
-            Assert.That(credentialsObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(credentialsObject["type"]!.Value<string>(), Is.EqualTo("password"));
-            Assert.That(credentialsObject, Contains.Key("username"));
-            Assert.That(credentialsObject["username"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(credentialsObject["username"]!.Value<string>(), Is.Empty);
-            Assert.That(credentialsObject, Contains.Key("password"));
-            Assert.That(credentialsObject["password"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(credentialsObject["password"]!.Value<string>(), Is.Empty);
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("requestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("provideCredentials", action.Value<string>());
+
+        Assert.True(serialized.ContainsKey("credentials"));
+        JToken? credentialsToken = serialized["credentials"];
+        Assert.NotNull(credentialsToken);
+        Assert.Equal(JTokenType.Object, credentialsToken.Type);
+        JObject? credentialsObject = credentialsToken as JObject;
+        Assert.NotNull(credentialsObject);
+        Assert.Equal(3, credentialsObject.Count);
+        Assert.True(credentialsObject.ContainsKey("type"));
+        JToken? credType = credentialsObject["type"];
+        Assert.NotNull(credType);
+        Assert.Equal(JTokenType.String, credType.Type);
+        Assert.Equal("password", credType.Value<string>());
+        Assert.True(credentialsObject.ContainsKey("username"));
+        JToken? username = credentialsObject["username"];
+        Assert.NotNull(username);
+        Assert.Equal(JTokenType.String, username.Type);
+        Assert.Equal(string.Empty, username.Value<string>());
+        Assert.True(credentialsObject.ContainsKey("password"));
+        JToken? password = credentialsObject["password"];
+        Assert.NotNull(password);
+        Assert.Equal(JTokenType.String, password.Type);
+        Assert.Equal(string.Empty, password.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithProvideCredentialsActionAndCredentials()
     {
         ContinueWithAuthCommandParameters properties = new("requestId")
@@ -96,28 +114,41 @@ public class ContinueWithAuthCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("requestId"));
-            Assert.That(serialized, Contains.Key("action"));
-            Assert.That(serialized["action"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["action"]!.Value<string>(), Is.EqualTo("provideCredentials"));
-            Assert.That(serialized, Contains.Key("credentials"));
-            Assert.That(serialized["credentials"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject credentialsObject = (JObject)serialized["credentials"]!;
-            Assert.That(credentialsObject, Has.Count.EqualTo(3));
-            Assert.That(credentialsObject, Contains.Key("type"));
-            Assert.That(credentialsObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(credentialsObject["type"]!.Value<string>(), Is.EqualTo("password"));
-            Assert.That(credentialsObject, Contains.Key("username"));
-            Assert.That(credentialsObject["username"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(credentialsObject["username"]!.Value<string>(), Is.EqualTo("myUserName"));
-            Assert.That(credentialsObject, Contains.Key("password"));
-            Assert.That(credentialsObject["password"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(credentialsObject["password"]!.Value<string>(), Is.EqualTo("myPassword"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("requestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("action"));
+        JToken? action = serialized["action"];
+        Assert.NotNull(action);
+        Assert.Equal(JTokenType.String, action.Type);
+        Assert.Equal("provideCredentials", action.Value<string>());
+
+        Assert.True(serialized.ContainsKey("credentials"));
+        JToken? credentialsToken = serialized["credentials"];
+        Assert.NotNull(credentialsToken);
+        Assert.Equal(JTokenType.Object, credentialsToken.Type);
+        JObject? credentialsObject = credentialsToken as JObject;
+        Assert.NotNull(credentialsObject);
+        Assert.Equal(3, credentialsObject.Count);
+        Assert.True(credentialsObject.ContainsKey("type"));
+        JToken? credType = credentialsObject["type"];
+        Assert.NotNull(credType);
+        Assert.Equal(JTokenType.String, credType.Type);
+        Assert.Equal("password", credType.Value<string>());
+        Assert.True(credentialsObject.ContainsKey("username"));
+        JToken? username = credentialsObject["username"];
+        Assert.NotNull(username);
+        Assert.Equal(JTokenType.String, username.Type);
+        Assert.Equal("myUserName", username.Value<string>());
+        Assert.True(credentialsObject.ContainsKey("password"));
+        JToken? password = credentialsObject["password"];
+        Assert.NotNull(password);
+        Assert.Equal(JTokenType.String, password.Type);
+        Assert.Equal("myPassword", password.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ContinueWithAuthCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ContinueWithAuthCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ContinueWithAuthCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         ContinueWithAuthCommandResult? result = JsonSerializer.Deserialize<ContinueWithAuthCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ContinueWithAuthCommandResult? result = JsonSerializer.Deserialize<ContinueWithAuthCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ContinueWithAuthCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/CookieHeaderTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/CookieHeaderTests.cs
@@ -3,60 +3,81 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CookieHeaderTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         CookieHeader cookieHeader = new();
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.Empty);
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal(string.Empty, name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal(string.Empty, valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithConstructorValues()
     {
         CookieHeader cookieHeader = new("cookieName", "cookieValue");
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithPropertySetValues()
     {
         CookieHeader cookieHeader = new()
@@ -66,26 +87,37 @@ public class CookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithPropertySetAndBynaryValue()
     {
         byte[] cookieValue = new byte[] { 0x41, 0x42, 0x43 };
@@ -97,22 +129,33 @@ public class CookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo(base64Value));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("base64", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal(base64Value, valueValue.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/CookieTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/CookieTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CookieTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeCookie()
     {
         string json = """
@@ -24,25 +23,23 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.Name, Is.EqualTo("cookieName"));
-            Assert.That(cookie.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(cookie.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(cookie.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(cookie.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(cookie.Secure, Is.False);
-            Assert.That(cookie.HttpOnly, Is.False);
-            Assert.That(cookie.SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-            Assert.That(cookie.Size, Is.EqualTo(100));
-            Assert.That(cookie.Expires, Is.Null);
-            Assert.That(cookie.EpochExpires, Is.Null);
-            Assert.That(cookie.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Equal("cookieName", cookie.Name);
+        Assert.Equal(BytesValueType.String, cookie.Value.Type);
+        Assert.Equal("cookieValue", cookie.Value.Value);
+        Assert.Equal("cookieDomain", cookie.Domain);
+        Assert.Equal("/cookiePath", cookie.Path);
+        Assert.False(cookie.Secure);
+        Assert.False(cookie.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Strict, cookie.SameSite);
+        Assert.Equal(100, cookie.Size);
+        Assert.Null(cookie.Expires);
+        Assert.Null(cookie.EpochExpires);
+        Assert.Empty(cookie.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCookieWithSameSiteLax()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -64,25 +61,23 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.Name, Is.EqualTo("cookieName"));
-            Assert.That(cookie.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(cookie.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(cookie.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(cookie.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(cookie.Secure, Is.False);
-            Assert.That(cookie.HttpOnly, Is.False);
-            Assert.That(cookie.SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(cookie.Size, Is.EqualTo(100));
-            Assert.That(cookie.Expires, Is.Null);
-            Assert.That(cookie.EpochExpires, Is.Null);
-            Assert.That(cookie.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Equal("cookieName", cookie.Name);
+        Assert.Equal(BytesValueType.String, cookie.Value.Type);
+        Assert.Equal("cookieValue", cookie.Value.Value);
+        Assert.Equal("cookieDomain", cookie.Domain);
+        Assert.Equal("/cookiePath", cookie.Path);
+        Assert.False(cookie.Secure);
+        Assert.False(cookie.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, cookie.SameSite);
+        Assert.Equal(100, cookie.Size);
+        Assert.Null(cookie.Expires);
+        Assert.Null(cookie.EpochExpires);
+        Assert.Empty(cookie.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCookieWithSameSiteNone()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -104,25 +99,23 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.Name, Is.EqualTo("cookieName"));
-            Assert.That(cookie.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(cookie.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(cookie.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(cookie.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(cookie.Secure, Is.False);
-            Assert.That(cookie.HttpOnly, Is.False);
-            Assert.That(cookie.SameSite, Is.EqualTo(CookieSameSiteValue.None));
-            Assert.That(cookie.Size, Is.EqualTo(100));
-            Assert.That(cookie.Expires, Is.Null);
-            Assert.That(cookie.EpochExpires, Is.Null);
-            Assert.That(cookie.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Equal("cookieName", cookie.Name);
+        Assert.Equal(BytesValueType.String, cookie.Value.Type);
+        Assert.Equal("cookieValue", cookie.Value.Value);
+        Assert.Equal("cookieDomain", cookie.Domain);
+        Assert.Equal("/cookiePath", cookie.Path);
+        Assert.False(cookie.Secure);
+        Assert.False(cookie.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.None, cookie.SameSite);
+        Assert.Equal(100, cookie.Size);
+        Assert.Null(cookie.Expires);
+        Assert.Null(cookie.EpochExpires);
+        Assert.Empty(cookie.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCookieWithBinaryValue()
     {
         byte[] byteArray = new byte[] { 0x41, 0x42, 0x43 };
@@ -143,25 +136,23 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.Name, Is.EqualTo("cookieName"));
-            Assert.That(cookie.Value.Type, Is.EqualTo(BytesValueType.Base64));
-            Assert.That(cookie.Value.Value, Is.EqualTo(base64Value));
-            Assert.That(cookie.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(cookie.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(cookie.Secure, Is.False);
-            Assert.That(cookie.HttpOnly, Is.False);
-            Assert.That(cookie.SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(cookie.Size, Is.EqualTo(100));
-            Assert.That(cookie.Expires, Is.Null);
-            Assert.That(cookie.EpochExpires, Is.Null);
-            Assert.That(cookie.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Equal("cookieName", cookie.Name);
+        Assert.Equal(BytesValueType.Base64, cookie.Value.Type);
+        Assert.Equal(base64Value, cookie.Value.Value);
+        Assert.Equal("cookieDomain", cookie.Domain);
+        Assert.Equal("/cookiePath", cookie.Path);
+        Assert.False(cookie.Secure);
+        Assert.False(cookie.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, cookie.SameSite);
+        Assert.Equal(100, cookie.Size);
+        Assert.Null(cookie.Expires);
+        Assert.Null(cookie.EpochExpires);
+        Assert.Empty(cookie.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCookieWithExpiration()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -184,25 +175,23 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.Name, Is.EqualTo("cookieName"));
-            Assert.That(cookie.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(cookie.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(cookie.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(cookie.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(cookie.Secure, Is.False);
-            Assert.That(cookie.HttpOnly, Is.False);
-            Assert.That(cookie.SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(cookie.Size, Is.EqualTo(100));
-            Assert.That(cookie.Expires, Is.EqualTo(expireTime));
-            Assert.That(cookie.EpochExpires, Is.EqualTo(milliseconds));
-            Assert.That(cookie.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Equal("cookieName", cookie.Name);
+        Assert.Equal(BytesValueType.String, cookie.Value.Type);
+        Assert.Equal("cookieValue", cookie.Value.Value);
+        Assert.Equal("cookieDomain", cookie.Domain);
+        Assert.Equal("/cookiePath", cookie.Path);
+        Assert.False(cookie.Secure);
+        Assert.False(cookie.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, cookie.SameSite);
+        Assert.Equal(100, cookie.Size);
+        Assert.Equal(expireTime, cookie.Expires);
+        Assert.Equal(milliseconds, cookie.EpochExpires);
+        Assert.Empty(cookie.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCookieWithAdditionalData()
     {
         string json = """
@@ -222,28 +211,28 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.Name, Is.EqualTo("cookieName"));
-            Assert.That(cookie.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(cookie.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(cookie.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(cookie.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(cookie.Secure, Is.False);
-            Assert.That(cookie.HttpOnly, Is.False);
-            Assert.That(cookie.SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-            Assert.That(cookie.Size, Is.EqualTo(100));
-            Assert.That(cookie.Expires, Is.Null);
-            Assert.That(cookie.EpochExpires, Is.Null);
-            Assert.That(cookie.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(cookie.AdditionalData, Contains.Key("extraData"));
-            Assert.That(cookie.AdditionalData["extraData"]!.GetType, Is.EqualTo(typeof(string)));
-            Assert.That(cookie.AdditionalData["extraData"]!, Is.EqualTo("myExtraData"));
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Equal("cookieName", cookie.Name);
+        Assert.Equal(BytesValueType.String, cookie.Value.Type);
+        Assert.Equal("cookieValue", cookie.Value.Value);
+        Assert.Equal("cookieDomain", cookie.Domain);
+        Assert.Equal("/cookiePath", cookie.Path);
+        Assert.False(cookie.Secure);
+        Assert.False(cookie.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Strict, cookie.SameSite);
+        Assert.Equal(100, cookie.Size);
+        Assert.Null(cookie.Expires);
+        Assert.Null(cookie.EpochExpires);
+        Assert.Single(cookie.AdditionalData);
+        Assert.True(cookie.AdditionalData.ContainsKey("extraData"));
+        object? extraData = cookie.AdditionalData["extraData"];
+        Assert.NotNull(extraData);
+        Assert.Equal(typeof(string), extraData.GetType());
+        Assert.Equal("myExtraData", extraData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertDeserializeCookieToSetCookieHeader()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -266,24 +255,22 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
+        Assert.NotNull(cookie);
         SetCookieHeader header = cookie.ToSetCookieHeader();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(header.Name, Is.EqualTo("cookieName"));
-            Assert.That(header.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(header.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(header.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(header.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(header.Secure, Is.False);
-            Assert.That(header.HttpOnly, Is.False);
-            Assert.That(header.SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(header.Expires, Is.EqualTo(expireTime));
-            Assert.That(header.MaxAge, Is.Null);
-        }
+
+        Assert.Equal("cookieName", header.Name);
+        Assert.Equal(BytesValueType.String, header.Value.Type);
+        Assert.Equal("cookieValue", header.Value.Value);
+        Assert.Equal("cookieDomain", header.Domain);
+        Assert.Equal("/cookiePath", header.Path);
+        Assert.False(header.Secure);
+        Assert.False(header.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, header.SameSite);
+        Assert.Equal(expireTime, header.Expires);
+        Assert.Null(header.MaxAge);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -302,12 +289,12 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
+        Assert.NotNull(cookie);
         Cookie copy = cookie with { };
-        Assert.That(copy, Is.EqualTo(cookie));
+        Assert.Equal(cookie, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCookieWithNullExpiryDoesNotSetExpires()
     {
         string json = """
@@ -327,15 +314,13 @@ public class CookieTests
                       }
                       """;
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(cookie.EpochExpires, Is.Null);
-            Assert.That(cookie.Expires, Is.Null);
-        }
+        Assert.NotNull(cookie);
+
+        Assert.Null(cookie.EpochExpires);
+        Assert.Null(cookie.Expires);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingNameThrows()
     {
         string json = """
@@ -352,10 +337,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'name'"));
+        Assert.Contains("missing required properties including: 'name'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingValueThrows()
     {
         string json = """
@@ -369,10 +354,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'value'"));
+        Assert.Contains("missing required properties including: 'value'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingDomainThrows()
     {
         string json = """
@@ -389,10 +374,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'domain'"));
+        Assert.Contains("missing required properties including: 'domain'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingPathThrows()
     {
         string json = """
@@ -409,10 +394,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'path'"));
+        Assert.Contains("missing required properties including: 'path'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingSecureThrows()
     {
         string json = """
@@ -429,10 +414,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'secure'"));
+        Assert.Contains("missing required properties including: 'secure'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingHttpOnlyThrows()
     {
         string json = """
@@ -449,10 +434,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'httpOnly'"));
+        Assert.Contains("missing required properties including: 'httpOnly'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingSameSiteThrows()
     {
         string json = """
@@ -469,10 +454,10 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'sameSite'"));
+        Assert.Contains("missing required properties including: 'sameSite'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingSizeThrows()
     {
         string json = """
@@ -489,10 +474,10 @@ public class CookieTests
                         "sameSite": "lax"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'size'"));
+        Assert.Contains("missing required properties including: 'size'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidSameSiteValueThrows()
     {
         string json = """
@@ -510,6 +495,6 @@ public class CookieTests
                         "size": 100
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Cookie>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value 'invalid' is not valid for enum type"));
+        Assert.Contains("value 'invalid' is not valid for enum type", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Cookie>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/DisownDataCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/DisownDataCommandParametersTests.cs
@@ -3,34 +3,39 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class DisownDataCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         DisownDataCommandParameters properties = new("myCollectorId", "myRequestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.disownData"));
+        Assert.Equal("network.disownData", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         DisownDataCommandParameters properties = new("myCollectorId", "myRequestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("collector"));
-            Assert.That(serialized["collector"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["collector"]!.Value<string>(), Is.EqualTo("myCollectorId"));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("dataType"));
-            Assert.That(serialized["dataType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["dataType"]!.Value<string>(), Is.EqualTo("response"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("collector"));
+        JToken? collector = serialized["collector"];
+        Assert.NotNull(collector);
+        Assert.Equal(JTokenType.String, collector.Type);
+        Assert.Equal("myCollectorId", collector.Value<string>());
+
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("dataType"));
+        JToken? dataType = serialized["dataType"];
+        Assert.NotNull(dataType);
+        Assert.Equal(JTokenType.String, dataType.Type);
+        Assert.Equal("response", dataType.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/DisownDataCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/DisownDataCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DisownDataCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DisownDataCommandResult? result = JsonSerializer.Deserialize<DisownDataCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DisownDataCommandResult? result = JsonSerializer.Deserialize<DisownDataCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         DisownDataCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/FailRequestCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/FailRequestCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class FailRequestCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         FailRequestCommandParameters properties = new("requestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.failRequest"));
+        Assert.Equal("network.failRequest", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         FailRequestCommandParameters properties = new("requestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("requestId"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("requestId", request.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/FailRequestCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/FailRequestCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class FailRequestCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         FailRequestCommandResult? result = JsonSerializer.Deserialize<FailRequestCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         FailRequestCommandResult? result = JsonSerializer.Deserialize<FailRequestCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         FailRequestCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/FetchErrorEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/FetchErrorEventArgsTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class FetchErrorEventArgsTests
 {
     private readonly string requestDataJson = """
@@ -34,7 +33,7 @@ public class FetchErrorEventArgsTests
                                               }
                                               """;
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -52,24 +51,22 @@ public class FetchErrorEventArgsTests
                            }
                            """;
         FetchErrorEventArgs? eventArgs = JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
-            Assert.That(eventArgs.ErrorText, Is.EqualTo("My error"));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal(milliseconds, eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+        Assert.Equal("My error", eventArgs.ErrorText);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithIntercepts()
     {
         DateTime now = DateTime.UtcNow;
@@ -88,26 +85,24 @@ public class FetchErrorEventArgsTests
                            }
                            """;
         FetchErrorEventArgs? eventArgs = JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.True);
-            Assert.That(eventArgs.Intercepts, Is.Not.Null);
-            Assert.That(eventArgs.Intercepts, Has.Count.EqualTo(1));
-            Assert.That(eventArgs.Intercepts![0], Is.EqualTo("myInterceptId"));
-            Assert.That(eventArgs.ErrorText, Is.EqualTo("My error"));
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.True(eventArgs.IsBlocked);
+        Assert.NotNull(eventArgs.Intercepts);
+        Assert.Single(eventArgs.Intercepts);
+        Assert.Equal("myInterceptId", eventArgs.Intercepts[0]);
+        Assert.Equal("My error", eventArgs.ErrorText);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNullContextId()
     {
         DateTime now = DateTime.UtcNow;
@@ -125,24 +120,22 @@ public class FetchErrorEventArgsTests
                            }
                            """;
         FetchErrorEventArgs? eventArgs = JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.Null);
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-            Assert.That(eventArgs.ErrorText, Is.EqualTo("My error"));
-        }
+        Assert.Null(eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal((ulong)((ulong)(milliseconds)), eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
+        Assert.Equal("My error", eventArgs.ErrorText);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -160,12 +153,12 @@ public class FetchErrorEventArgsTests
                            }
                            """;
         FetchErrorEventArgs? eventArgs = JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         FetchErrorEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextIdThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -181,10 +174,10 @@ public class FetchErrorEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidErrorTextTypeThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -201,6 +194,6 @@ public class FetchErrorEventArgsTests
                              "errorText": {}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchErrorEventArgs>(eventJson));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/FetchTimingInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/FetchTimingInfoTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class FetchTimingInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeFetchTimingInfo()
     {
         string json = """
@@ -26,26 +25,24 @@ public class FetchTimingInfoTests
                       }
                       """;
         FetchTimingInfo? info = JsonSerializer.Deserialize<FetchTimingInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.TimeOrigin, Is.EqualTo(1));
-            Assert.That(info.RequestTime, Is.EqualTo(2));
-            Assert.That(info.RedirectStart, Is.EqualTo(3));
-            Assert.That(info.RedirectEnd, Is.EqualTo(4));
-            Assert.That(info.FetchStart, Is.EqualTo(5));
-            Assert.That(info.DnsStart, Is.EqualTo(6));
-            Assert.That(info.DnsEnd, Is.EqualTo(7));
-            Assert.That(info.ConnectStart, Is.EqualTo(8));
-            Assert.That(info.ConnectEnd, Is.EqualTo(9));
-            Assert.That(info.TlsStart, Is.EqualTo(10));
-            Assert.That(info.RequestStart, Is.EqualTo(11));
-            Assert.That(info.ResponseStart, Is.EqualTo(12));
-            Assert.That(info.ResponseEnd, Is.EqualTo(13));
-        }
+        Assert.NotNull(info);
+
+        Assert.Equal(1, info.TimeOrigin);
+        Assert.Equal(2, info.RequestTime);
+        Assert.Equal(3, info.RedirectStart);
+        Assert.Equal(4, info.RedirectEnd);
+        Assert.Equal(5, info.FetchStart);
+        Assert.Equal(6, info.DnsStart);
+        Assert.Equal(7, info.DnsEnd);
+        Assert.Equal(8, info.ConnectStart);
+        Assert.Equal(9, info.ConnectEnd);
+        Assert.Equal(10, info.TlsStart);
+        Assert.Equal(11, info.RequestStart);
+        Assert.Equal(12, info.ResponseStart);
+        Assert.Equal(13, info.ResponseEnd);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -66,12 +63,12 @@ public class FetchTimingInfoTests
                       }
                       """;
         FetchTimingInfo? info = JsonSerializer.Deserialize<FetchTimingInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         FetchTimingInfo copy = info with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTimeOriginThrows()
     {
         string json = """
@@ -90,10 +87,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'timeOrigin"));
+        Assert.Contains("was missing required properties including: 'timeOrigin", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRequestTimeThrows()
     {
         string json = """
@@ -112,10 +109,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'requestTime"));
+        Assert.Contains("was missing required properties including: 'requestTime", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRedirectStartThrows()
     {
         string json = """
@@ -134,10 +131,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'redirectStart"));
+        Assert.Contains("was missing required properties including: 'redirectStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRedirectEndThrows()
     {
         string json = """
@@ -156,10 +153,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'redirectEnd"));
+        Assert.Contains("was missing required properties including: 'redirectEnd", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingFetchStartThrows()
     {
         string json = """
@@ -178,10 +175,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'fetchStart"));
+        Assert.Contains("was missing required properties including: 'fetchStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDnsStartThrows()
     {
         string json = """
@@ -200,10 +197,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'dnsStart"));
+        Assert.Contains("was missing required properties including: 'dnsStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDnsEndThrows()
     {
         string json = """
@@ -222,10 +219,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'dnsEnd"));
+        Assert.Contains("was missing required properties including: 'dnsEnd", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingConnectStartThrows()
     {
         string json = """
@@ -244,10 +241,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'connectStart"));
+        Assert.Contains("was missing required properties including: 'connectStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingConnectEndThrows()
     {
         string json = """
@@ -266,10 +263,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'connectEnd"));
+        Assert.Contains("was missing required properties including: 'connectEnd", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingTlsStartThrows()
     {
         string json = """
@@ -288,10 +285,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'tlsStart"));
+        Assert.Contains("was missing required properties including: 'tlsStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingRequestStartThrows()
     {
         string json = """
@@ -310,10 +307,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'requestStart"));
+        Assert.Contains("was missing required properties including: 'requestStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingResponseStartThrows()
     {
         string json = """
@@ -332,10 +329,10 @@ public class FetchTimingInfoTests
                         "responseEnd": 13
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'responseStart"));
+        Assert.Contains("was missing required properties including: 'responseStart", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingResponseEndThrows()
     {
         string json = """
@@ -354,6 +351,6 @@ public class FetchTimingInfoTests
                         "responseStart": 12
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<FetchTimingInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("was missing required properties including: 'responseEnd"));
+        Assert.Contains("was missing required properties including: 'responseEnd", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<FetchTimingInfo>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/GetDataCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/GetDataCommandParametersTests.cs
@@ -3,35 +3,37 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GetDataCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         GetDataCommandParameters properties = new("myRequestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.getData"));
+        Assert.Equal("network.getData", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         GetDataCommandParameters properties = new("myRequestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("dataType"));
-            Assert.That(serialized["dataType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["dataType"]!.Value<string>(), Is.EqualTo("response"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("dataType"));
+        JToken? dataType = serialized["dataType"];
+        Assert.NotNull(dataType);
+        Assert.Equal(JTokenType.String, dataType.Type);
+        Assert.Equal("response", dataType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCollectorId()
     {
         GetDataCommandParameters properties = new("myRequestId")
@@ -40,22 +42,28 @@ public class GetDataCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("dataType"));
-            Assert.That(serialized["dataType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["dataType"]!.Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("collector"));
-            Assert.That(serialized["collector"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["collector"]!.Value<string>(), Is.EqualTo("myCollectorId"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("dataType"));
+        JToken? dataType = serialized["dataType"];
+        Assert.NotNull(dataType);
+        Assert.Equal(JTokenType.String, dataType.Type);
+        Assert.Equal("response", dataType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("collector"));
+        JToken? collector = serialized["collector"];
+        Assert.NotNull(collector);
+        Assert.Equal(JTokenType.String, collector.Type);
+        Assert.Equal("myCollectorId", collector.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDisownDataTrue()
     {
         GetDataCommandParameters properties = new("myRequestId")
@@ -65,25 +73,34 @@ public class GetDataCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("dataType"));
-            Assert.That(serialized["dataType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["dataType"]!.Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("collector"));
-            Assert.That(serialized["collector"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["collector"]!.Value<string>(), Is.EqualTo("myCollectorId"));
-            Assert.That(serialized, Contains.Key("disown"));
-            Assert.That(serialized["disown"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["disown"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Equal(4, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("dataType"));
+        JToken? dataType = serialized["dataType"];
+        Assert.NotNull(dataType);
+        Assert.Equal(JTokenType.String, dataType.Type);
+        Assert.Equal("response", dataType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("collector"));
+        JToken? collector = serialized["collector"];
+        Assert.NotNull(collector);
+        Assert.Equal(JTokenType.String, collector.Type);
+        Assert.Equal("myCollectorId", collector.Value<string>());
+
+        Assert.True(serialized.ContainsKey("disown"));
+        JToken? disown = serialized["disown"];
+        Assert.NotNull(disown);
+        Assert.Equal(JTokenType.Boolean, disown.Type);
+        Assert.True(disown.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDisownDataFalse()
     {
         GetDataCommandParameters properties = new("myRequestId")
@@ -93,21 +110,30 @@ public class GetDataCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("dataType"));
-            Assert.That(serialized["dataType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["dataType"]!.Value<string>(), Is.EqualTo("response"));
-            Assert.That(serialized, Contains.Key("collector"));
-            Assert.That(serialized["collector"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["collector"]!.Value<string>(), Is.EqualTo("myCollectorId"));
-            Assert.That(serialized, Contains.Key("disown"));
-            Assert.That(serialized["disown"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["disown"]!.Value<bool>(), Is.False);
-        }
+
+        Assert.Equal(4, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("dataType"));
+        JToken? dataType = serialized["dataType"];
+        Assert.NotNull(dataType);
+        Assert.Equal(JTokenType.String, dataType.Type);
+        Assert.Equal("response", dataType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("collector"));
+        JToken? collector = serialized["collector"];
+        Assert.NotNull(collector);
+        Assert.Equal(JTokenType.String, collector.Type);
+        Assert.Equal("myCollectorId", collector.Value<string>());
+
+        Assert.True(serialized.ContainsKey("disown"));
+        JToken? disown = serialized["disown"];
+        Assert.NotNull(disown);
+        Assert.Equal(JTokenType.Boolean, disown.Type);
+        Assert.False(disown.Value<bool>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/GetDataCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/GetDataCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class GetDataCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -17,12 +16,12 @@ public class GetDataCommandResultTests
                       }
                       """;
         GetDataCommandResult? result = JsonSerializer.Deserialize<GetDataCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Bytes.Type, Is.EqualTo(BytesValueType.String));
-        Assert.That(result.Bytes.Value, Is.EqualTo("myNetworkData"));
+        Assert.NotNull(result);
+        Assert.Equal(BytesValueType.String, result.Bytes.Type);
+        Assert.Equal("myNetworkData", result.Bytes.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -34,19 +33,19 @@ public class GetDataCommandResultTests
                       }
                       """;
         GetDataCommandResult? result = JsonSerializer.Deserialize<GetDataCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         GetDataCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingDataThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<GetDataCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetDataCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidDataTypeThrows()
     {
         string json = """
@@ -54,6 +53,6 @@ public class GetDataCommandResultTests
                         "bytes": "invalidValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetDataCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetDataCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/HeaderTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/HeaderTests.cs
@@ -2,18 +2,17 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class HeaderTests
 {
-    [Test]
+    [Fact]
     public void TestCanConstructHeader()
     {
         Header header = new("name", "value");
-        Assert.That(header.Name, Is.EqualTo("name"));
-        Assert.That(header.Value, Is.EqualTo(BytesValue.FromString("value")));
+        Assert.Equal("name", header.Name);
+        Assert.Equal(BytesValue.FromString("value"), header.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeHeader()
     {
         string json = """
@@ -26,16 +25,14 @@ public class HeaderTests
                       }
                       """;
         Header? header = JsonSerializer.Deserialize<Header>(json);
-        Assert.That(header, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(header.Name, Is.EqualTo("headerName"));
-            Assert.That(header.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(header.Value.Value, Is.EqualTo("headerValue"));
-        }
+        Assert.NotNull(header);
+
+        Assert.Equal("headerName", header.Name);
+        Assert.Equal(BytesValueType.String, header.Value.Type);
+        Assert.Equal("headerValue", header.Value.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeHeaderWithBinaryValue()
     {
         byte[] byteArray = new byte[] { 0x41, 0x42, 0x43 };
@@ -50,16 +47,14 @@ public class HeaderTests
                       }
                       """;
         Header? header = JsonSerializer.Deserialize<Header>(json);
-        Assert.That(header, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(header.Name, Is.EqualTo("headerName"));
-            Assert.That(header.Value.Type, Is.EqualTo(BytesValueType.Base64));
-            Assert.That(header.Value.Value, Is.EqualTo(base64Value));
-        }
+        Assert.NotNull(header);
+
+        Assert.Equal("headerName", header.Name);
+        Assert.Equal(BytesValueType.Base64, header.Value.Type);
+        Assert.Equal(base64Value, header.Value.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingNameThrows()
     {
         string json = """
@@ -70,10 +65,10 @@ public class HeaderTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Header>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'name"));
+        Assert.Contains("missing required properties including: 'name", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Header>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingValueThrows()
     {
         string json = """
@@ -81,6 +76,6 @@ public class HeaderTests
                         "name": "headerName"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Header>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'value"));
+        Assert.Contains("missing required properties including: 'value", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Header>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/InitiatorTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/InitiatorTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class InitiatorTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeInitiator()
     {
         string json = """
@@ -13,18 +12,16 @@ public class InitiatorTests
                       }
                       """;
         Initiator? initiator = JsonSerializer.Deserialize<Initiator>(json);
-        Assert.That(initiator, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(initiator.Type, Is.Null);
-            Assert.That(initiator.ColumnNumber, Is.Null);
-            Assert.That(initiator.LineNumber, Is.Null);
-            Assert.That(initiator.StackTrace, Is.Null);
-            Assert.That(initiator.RequestId, Is.Null);
-        }
+        Assert.NotNull(initiator);
+
+        Assert.Null(initiator.Type);
+        Assert.Null(initiator.ColumnNumber);
+        Assert.Null(initiator.LineNumber);
+        Assert.Null(initiator.StackTrace);
+        Assert.Null(initiator.RequestId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeInitiatorWithOptionalValues()
     {
         string json = """
@@ -46,19 +43,17 @@ public class InitiatorTests
                       }
                       """;
         Initiator? initiator = JsonSerializer.Deserialize<Initiator>(json);
-        Assert.That(initiator, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(initiator.Type, Is.EqualTo(InitiatorType.Script));
-            Assert.That(initiator.ColumnNumber, Is.EqualTo(1));
-            Assert.That(initiator.LineNumber, Is.EqualTo(2));
-            Assert.That(initiator.StackTrace, Is.Not.Null);
-            Assert.That(initiator.StackTrace!.CallFrames, Has.Count.EqualTo(1));
-            Assert.That(initiator.RequestId, Is.EqualTo("myRequestId"));
-        }
+        Assert.NotNull(initiator);
+
+        Assert.Equal(InitiatorType.Script, initiator.Type);
+        Assert.Equal(1u, initiator.ColumnNumber);
+        Assert.Equal(2u, initiator.LineNumber);
+        Assert.NotNull(initiator.StackTrace);
+        Assert.Single(initiator.StackTrace.CallFrames);
+        Assert.Equal("myRequestId", initiator.RequestId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -66,12 +61,12 @@ public class InitiatorTests
                       }
                       """;
         Initiator? initiator = JsonSerializer.Deserialize<Initiator>(json);
-        Assert.That(initiator, Is.Not.Null);
+        Assert.NotNull(initiator);
         Initiator copy = initiator with { };
-        Assert.That(copy, Is.EqualTo(initiator));
+        Assert.Equal(initiator, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInitiatorWithInvalidTypeValueThrows()
     {
         string json = """
@@ -79,6 +74,6 @@ public class InitiatorTests
                         "type": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Initiator>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value 'invalid' is not valid for enum type"));
+        Assert.Contains("value 'invalid' is not valid for enum type", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Initiator>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class NetworkModuleTests
 {
     private readonly string requestDataJson = """
@@ -82,7 +81,7 @@ public class NetworkModuleTests
                                                }
                                                """;
 
-    [Test]
+    [Fact]
     public async Task TestExecuteAddInterceptCommand()
     {
         TestWebSocketConnection connection = new();
@@ -101,23 +100,22 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         AddInterceptCommandParameters commandParameters = new(InterceptPhase.BeforeRequestSent)
         {
             UrlPatterns = [new UrlPatternString("https://example.com/*")]
         };
-        Task<AddInterceptCommandResult> task = module.AddInterceptAsync(commandParameters);
+        Task<AddInterceptCommandResult> task = module.AddInterceptAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        AddInterceptCommandResult result = task.Result;
+        AddInterceptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.InterceptId, Is.EqualTo("myInterceptId"));
+        Assert.NotNull(result);
+        Assert.Equal("myInterceptId", result.InterceptId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteAddDataCollectorCommand()
     {
         TestWebSocketConnection connection = new();
@@ -136,20 +134,19 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         AddDataCollectorCommandParameters commandParameters = new(1024 * 1024);
-        Task<AddDataCollectorCommandResult> task = module.AddDataCollectorAsync(commandParameters);
+        Task<AddDataCollectorCommandResult> task = module.AddDataCollectorAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        AddDataCollectorCommandResult result = task.Result;
+        AddDataCollectorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.CollectorId, Is.EqualTo("myCollectorId"));
+        Assert.NotNull(result);
+        Assert.Equal("myCollectorId", result.CollectorId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteContinueRequestCommand()
     {
         TestWebSocketConnection connection = new();
@@ -166,18 +163,17 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        Task<ContinueRequestCommandResult> task = module.ContinueRequestAsync(new ContinueRequestCommandParameters("requestId"));
+        Task<ContinueRequestCommandResult> task = module.ContinueRequestAsync(new ContinueRequestCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        ContinueRequestCommandResult result = task.Result;
+        ContinueRequestCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteContinueResponseCommand()
     {
         TestWebSocketConnection connection = new();
@@ -194,18 +190,17 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        Task<ContinueResponseCommandResult> task = module.ContinueResponseAsync(new ContinueResponseCommandParameters("requestId"));
+        Task<ContinueResponseCommandResult> task = module.ContinueResponseAsync(new ContinueResponseCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        ContinueResponseCommandResult result = task.Result;
+        ContinueResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteContinueWithAuthCommand()
     {
         TestWebSocketConnection connection = new();
@@ -222,22 +217,21 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<ContinueWithAuthCommandResult> task = module.ContinueWithAuthAsync(new ContinueWithAuthCommandParameters("requestId")
         {
             Action = ContinueWithAuthActionType.ProvideCredentials,
             Credentials = new AuthCredentials("username", "password")
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        ContinueWithAuthCommandResult result = task.Result;
+        ContinueWithAuthCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteDisownDataCommand()
     {
         TestWebSocketConnection connection = new();
@@ -254,19 +248,18 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         DisownDataCommandParameters commandParameters = new("myCollectorId", "myRequestId");
-        Task<DisownDataCommandResult> task = module.DisownDataAsync(commandParameters);
+        Task<DisownDataCommandResult> task = module.DisownDataAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        DisownDataCommandResult result = task.Result;
+        DisownDataCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteFailRequestCommand()
     {
         TestWebSocketConnection connection = new();
@@ -283,18 +276,17 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        Task<FailRequestCommandResult> task = module.FailRequestAsync(new FailRequestCommandParameters("requestId"));
+        Task<FailRequestCommandResult> task = module.FailRequestAsync(new FailRequestCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        FailRequestCommandResult result = task.Result;
+        FailRequestCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetDataCommand()
     {
         TestWebSocketConnection connection = new();
@@ -316,21 +308,20 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         GetDataCommandParameters commandParameters = new("myRequestId");
-        Task<GetDataCommandResult> task = module.GetDataAsync(commandParameters);
+        Task<GetDataCommandResult> task = module.GetDataAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetDataCommandResult result = task.Result;
+        GetDataCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Bytes.Type, Is.EqualTo(BytesValueType.String));
-        Assert.That(result.Bytes.Value, Is.EqualTo("myNetworkData"));
+        Assert.NotNull(result);
+        Assert.Equal(BytesValueType.String, result.Bytes.Type);
+        Assert.Equal("myNetworkData", result.Bytes.Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteProvideResponseCommand()
     {
         TestWebSocketConnection connection = new();
@@ -347,18 +338,17 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        Task<ProvideResponseCommandResult> task = module.ProvideResponseAsync(new ProvideResponseCommandParameters("requestId"));
+        Task<ProvideResponseCommandResult> task = module.ProvideResponseAsync(new ProvideResponseCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        ProvideResponseCommandResult result = task.Result;
+        ProvideResponseCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteRemoveDataCollectorCommand()
     {
         TestWebSocketConnection connection = new();
@@ -375,19 +365,18 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         RemoveDataCollectorCommandParameters commandParameters = new("myCollectorId");
-        Task<RemoveDataCollectorCommandResult> task = module.RemoveDataCollectorAsync(commandParameters);
+        Task<RemoveDataCollectorCommandResult> task = module.RemoveDataCollectorAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        RemoveDataCollectorCommandResult result = task.Result;
+        RemoveDataCollectorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteRemoveInterceptCommand()
     {
         TestWebSocketConnection connection = new();
@@ -404,18 +393,17 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        Task<RemoveInterceptCommandResult> task = module.RemoveInterceptAsync(new RemoveInterceptCommandParameters("interceptId"));
+        Task<RemoveInterceptCommandResult> task = module.RemoveInterceptAsync(new RemoveInterceptCommandParameters("interceptId"), cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        RemoveInterceptCommandResult result = task.Result;
+        RemoveInterceptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSetCacheBehaviorCommand()
     {
         TestWebSocketConnection connection = new();
@@ -432,18 +420,17 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        Task<SetCacheBehaviorCommandResult> task = module.SetCacheBehaviorAsync(new SetCacheBehaviorCommandParameters(CacheBehavior.Default));
+        Task<SetCacheBehaviorCommandResult> task = module.SetCacheBehaviorAsync(new SetCacheBehaviorCommandParameters(CacheBehavior.Default), cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetCacheBehaviorCommandResult result = task.Result;
+        SetCacheBehaviorCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSetExtraHeadersCommand()
     {
         TestWebSocketConnection connection = new();
@@ -460,20 +447,19 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         SetExtraHeadersCommandParameters commandParameters = new();
         commandParameters.Headers.Add("X-Extra-Header: headerValue");
-        Task<SetExtraHeadersCommandResult> task = module.SetExtraHeadersAsync(commandParameters);
+        Task<SetExtraHeadersCommandResult> task = module.SetExtraHeadersAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetExtraHeadersCommandResult result = task.Result;
+        SetExtraHeadersCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveAuthRequiredEvent()
     {
         DateTime now = DateTime.UtcNow;
@@ -482,55 +468,54 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         ManualResetEvent syncEvent = new(false);
         module.OnAuthRequired.AddObserver((AuthRequiredEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.RedirectCount, Is.EqualTo(0));
-                Assert.That(e.Timestamp, Is.EqualTo(eventTime));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(milliseconds));
-                Assert.That(e.Request.RequestId, Is.EqualTo("myRequestId"));
-                Assert.That(e.Request.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Request.Method, Is.EqualTo("get"));
-                Assert.That(e.Request.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Request.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Request.Cookies, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Cookies[0].Name, Is.EqualTo("cookieName"));
-                Assert.That(e.Request.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-                Assert.That(e.Request.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-                Assert.That(e.Request.Cookies[0].Path, Is.EqualTo("/cookiePath"));
-                Assert.That(e.Request.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-                Assert.That(e.Request.Cookies[0].Secure, Is.False);
-                Assert.That(e.Request.Cookies[0].HttpOnly, Is.True);
-                Assert.That(e.Request.Cookies[0].Size, Is.EqualTo(10));
-                Assert.That(e.Request.Cookies[0].Expires, Is.Null);
-                Assert.That(e.Request.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Request.BodySize, Is.EqualTo(300));
-                Assert.That(e.Request.Timings, Is.Not.Null);
-                Assert.That(e.Response.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Response.Protocol, Is.EqualTo("https"));
-                Assert.That(e.Response.Status, Is.EqualTo(200));
-                Assert.That(e.Response.StatusText, Is.EqualTo("OK"));
-                Assert.That(e.Response.FromCache, Is.False);
-                Assert.That(e.Response.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Response.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Response.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Response.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Response.MimeType, Is.EqualTo("text/html"));
-                Assert.That(e.Response.BytesReceived, Is.EqualTo(400));
-                Assert.That(e.Response.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Response.BodySize, Is.EqualTo(300));
-                Assert.That(e.Response.Content.Size, Is.EqualTo(300));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal(0u, e.RedirectCount);
+            Assert.Equal(eventTime, e.Timestamp);
+            Assert.Equal((ulong)((ulong)(milliseconds)), e.EpochTimestamp);
+            Assert.Equal("myRequestId", e.Request.RequestId);
+            Assert.Equal("https://example.com", e.Request.Url);
+            Assert.Equal("get", e.Request.Method);
+            Assert.Single(e.Request.Headers);
+            Assert.Equal("headerName", e.Request.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Request.Headers[0].Value.Value);
+            Assert.Single(e.Request.Cookies);
+            Assert.Equal("cookieName", e.Request.Cookies[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Cookies[0].Value.Type);
+            Assert.Equal("cookieValue", e.Request.Cookies[0].Value.Value);
+            Assert.Equal("cookieDomain", e.Request.Cookies[0].Domain);
+            Assert.Equal("/cookiePath", e.Request.Cookies[0].Path);
+            Assert.Equal(CookieSameSiteValue.Strict, e.Request.Cookies[0].SameSite);
+            Assert.False(e.Request.Cookies[0].Secure);
+            Assert.True(e.Request.Cookies[0].HttpOnly);
+            Assert.Equal(10, e.Request.Cookies[0].Size);
+            Assert.Null(e.Request.Cookies[0].Expires);
+            Assert.Equal(100u, e.Request.HeadersSize);
+            Assert.Equal(300u, e.Request.BodySize);
+            Assert.NotNull(e.Request.Timings);
+            Assert.Equal("https://example.com", e.Response.Url);
+            Assert.Equal("https", e.Response.Protocol);
+            Assert.Equal(200u, e.Response.Status);
+            Assert.Equal("OK", e.Response.StatusText);
+            Assert.False(e.Response.FromCache);
+            Assert.Single(e.Response.Headers);
+            Assert.Equal("headerName", e.Response.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Response.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Response.Headers[0].Value.Value);
+            Assert.Equal("text/html", e.Response.MimeType);
+            Assert.Equal(400u, e.Response.BytesReceived);
+            Assert.Equal(100u, e.Response.HeadersSize);
+            Assert.Equal(300u, e.Response.BodySize);
+            Assert.Equal(300u, e.Response.Content.Size);
+
             syncEvent.Set();
         });
 
@@ -551,10 +536,10 @@ public class NetworkModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveBeforeRequestSendEvent()
     {
         DateTime now = DateTime.UtcNow;
@@ -563,42 +548,42 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         ManualResetEvent syncEvent = new(false);
         module.OnBeforeRequestSent.AddObserver((BeforeRequestSentEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.RedirectCount, Is.EqualTo(0));
-                Assert.That(e.Timestamp, Is.EqualTo(eventTime));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(milliseconds));
-                Assert.That(e.Request.RequestId, Is.EqualTo("myRequestId"));
-                Assert.That(e.Request.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Request.Method, Is.EqualTo("get"));
-                Assert.That(e.Request.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Request.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Request.Cookies, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Cookies[0].Name, Is.EqualTo("cookieName"));
-                Assert.That(e.Request.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-                Assert.That(e.Request.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-                Assert.That(e.Request.Cookies[0].Path, Is.EqualTo("/cookiePath"));
-                Assert.That(e.Request.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-                Assert.That(e.Request.Cookies[0].Secure, Is.False);
-                Assert.That(e.Request.Cookies[0].HttpOnly, Is.True);
-                Assert.That(e.Request.Cookies[0].Size, Is.EqualTo(10));
-                Assert.That(e.Request.Cookies[0].Expires, Is.Null);
-                Assert.That(e.Request.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Request.BodySize, Is.EqualTo(300));
-                Assert.That(e.Request.Timings, Is.Not.Null);
-                Assert.That(e.Initiator!.Type, Is.EqualTo(InitiatorType.Parser));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal(0u, e.RedirectCount);
+            Assert.Equal(eventTime, e.Timestamp);
+            Assert.Equal((ulong)((ulong)(milliseconds)), e.EpochTimestamp);
+            Assert.Equal("myRequestId", e.Request.RequestId);
+            Assert.Equal("https://example.com", e.Request.Url);
+            Assert.Equal("get", e.Request.Method);
+            Assert.Single(e.Request.Headers);
+            Assert.Equal("headerName", e.Request.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Request.Headers[0].Value.Value);
+            Assert.Single(e.Request.Cookies);
+            Assert.Equal("cookieName", e.Request.Cookies[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Cookies[0].Value.Type);
+            Assert.Equal("cookieValue", e.Request.Cookies[0].Value.Value);
+            Assert.Equal("cookieDomain", e.Request.Cookies[0].Domain);
+            Assert.Equal("/cookiePath", e.Request.Cookies[0].Path);
+            Assert.Equal(CookieSameSiteValue.Strict, e.Request.Cookies[0].SameSite);
+            Assert.False(e.Request.Cookies[0].Secure);
+            Assert.True(e.Request.Cookies[0].HttpOnly);
+            Assert.Equal(10, e.Request.Cookies[0].Size);
+            Assert.Null(e.Request.Cookies[0].Expires);
+            Assert.Equal(100u, e.Request.HeadersSize);
+            Assert.Equal(300u, e.Request.BodySize);
+            Assert.NotNull(e.Request.Timings);
+            Assert.NotNull(e.Initiator);
+            Assert.Equal(InitiatorType.Parser, e.Initiator.Type);
+
             syncEvent.Set();
         });
 
@@ -621,10 +606,10 @@ public class NetworkModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveFetchErrorEvent()
     {
         DateTime now = DateTime.UtcNow;
@@ -633,42 +618,41 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         ManualResetEvent syncEvent = new(false);
         module.OnFetchError.AddObserver((FetchErrorEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.RedirectCount, Is.EqualTo(0));
-                Assert.That(e.Timestamp, Is.EqualTo(eventTime));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(milliseconds));
-                Assert.That(e.Request.RequestId, Is.EqualTo("myRequestId"));
-                Assert.That(e.Request.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Request.Method, Is.EqualTo("get"));
-                Assert.That(e.Request.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Request.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Request.Cookies, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Cookies[0].Name, Is.EqualTo("cookieName"));
-                Assert.That(e.Request.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-                Assert.That(e.Request.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-                Assert.That(e.Request.Cookies[0].Path, Is.EqualTo("/cookiePath"));
-                Assert.That(e.Request.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-                Assert.That(e.Request.Cookies[0].Secure, Is.False);
-                Assert.That(e.Request.Cookies[0].HttpOnly, Is.True);
-                Assert.That(e.Request.Cookies[0].Size, Is.EqualTo(10));
-                Assert.That(e.Request.Cookies[0].Expires, Is.Null);
-                Assert.That(e.Request.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Request.BodySize, Is.EqualTo(300));
-                Assert.That(e.Request.Timings, Is.Not.Null);
-                Assert.That(e.ErrorText, Is.EqualTo("An error occurred"));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal(0u, e.RedirectCount);
+            Assert.Equal(eventTime, e.Timestamp);
+            Assert.Equal((ulong)((ulong)(milliseconds)), e.EpochTimestamp);
+            Assert.Equal("myRequestId", e.Request.RequestId);
+            Assert.Equal("https://example.com", e.Request.Url);
+            Assert.Equal("get", e.Request.Method);
+            Assert.Single(e.Request.Headers);
+            Assert.Equal("headerName", e.Request.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Request.Headers[0].Value.Value);
+            Assert.Single(e.Request.Cookies);
+            Assert.Equal("cookieName", e.Request.Cookies[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Cookies[0].Value.Type);
+            Assert.Equal("cookieValue", e.Request.Cookies[0].Value.Value);
+            Assert.Equal("cookieDomain", e.Request.Cookies[0].Domain);
+            Assert.Equal("/cookiePath", e.Request.Cookies[0].Path);
+            Assert.Equal(CookieSameSiteValue.Strict, e.Request.Cookies[0].SameSite);
+            Assert.False(e.Request.Cookies[0].Secure);
+            Assert.True(e.Request.Cookies[0].HttpOnly);
+            Assert.Equal(10, e.Request.Cookies[0].Size);
+            Assert.Null(e.Request.Cookies[0].Expires);
+            Assert.Equal(100u, e.Request.HeadersSize);
+            Assert.Equal(300u, e.Request.BodySize);
+            Assert.NotNull(e.Request.Timings);
+            Assert.Equal("An error occurred", e.ErrorText);
+
             syncEvent.Set();
         });
 
@@ -689,10 +673,10 @@ public class NetworkModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveResponseStartedEvent()
     {
         DateTime now = DateTime.UtcNow;
@@ -701,55 +685,54 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         ManualResetEvent syncEvent = new(false);
         module.OnResponseStarted.AddObserver((ResponseStartedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.RedirectCount, Is.EqualTo(0));
-                Assert.That(e.Timestamp, Is.EqualTo(eventTime));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(milliseconds));
-                Assert.That(e.Request.RequestId, Is.EqualTo("myRequestId"));
-                Assert.That(e.Request.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Request.Method, Is.EqualTo("get"));
-                Assert.That(e.Request.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Request.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Request.Cookies, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Cookies[0].Name, Is.EqualTo("cookieName"));
-                Assert.That(e.Request.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-                Assert.That(e.Request.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-                Assert.That(e.Request.Cookies[0].Path, Is.EqualTo("/cookiePath"));
-                Assert.That(e.Request.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-                Assert.That(e.Request.Cookies[0].Secure, Is.False);
-                Assert.That(e.Request.Cookies[0].HttpOnly, Is.True);
-                Assert.That(e.Request.Cookies[0].Size, Is.EqualTo(10));
-                Assert.That(e.Request.Cookies[0].Expires, Is.Null);
-                Assert.That(e.Request.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Request.BodySize, Is.EqualTo(300));
-                Assert.That(e.Request.Timings, Is.Not.Null);
-                Assert.That(e.Response.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Response.Protocol, Is.EqualTo("https"));
-                Assert.That(e.Response.Status, Is.EqualTo(200));
-                Assert.That(e.Response.StatusText, Is.EqualTo("OK"));
-                Assert.That(e.Response.FromCache, Is.False);
-                Assert.That(e.Response.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Response.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Response.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Response.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Response.MimeType, Is.EqualTo("text/html"));
-                Assert.That(e.Response.BytesReceived, Is.EqualTo(400));
-                Assert.That(e.Response.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Response.BodySize, Is.EqualTo(300));
-                Assert.That(e.Response.Content.Size, Is.EqualTo(300));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal(0u, e.RedirectCount);
+            Assert.Equal(eventTime, e.Timestamp);
+            Assert.Equal((ulong)((ulong)(milliseconds)), e.EpochTimestamp);
+            Assert.Equal("myRequestId", e.Request.RequestId);
+            Assert.Equal("https://example.com", e.Request.Url);
+            Assert.Equal("get", e.Request.Method);
+            Assert.Single(e.Request.Headers);
+            Assert.Equal("headerName", e.Request.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Request.Headers[0].Value.Value);
+            Assert.Single(e.Request.Cookies);
+            Assert.Equal("cookieName", e.Request.Cookies[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Cookies[0].Value.Type);
+            Assert.Equal("cookieValue", e.Request.Cookies[0].Value.Value);
+            Assert.Equal("cookieDomain", e.Request.Cookies[0].Domain);
+            Assert.Equal("/cookiePath", e.Request.Cookies[0].Path);
+            Assert.Equal(CookieSameSiteValue.Strict, e.Request.Cookies[0].SameSite);
+            Assert.False(e.Request.Cookies[0].Secure);
+            Assert.True(e.Request.Cookies[0].HttpOnly);
+            Assert.Equal(10, e.Request.Cookies[0].Size);
+            Assert.Null(e.Request.Cookies[0].Expires);
+            Assert.Equal(100u, e.Request.HeadersSize);
+            Assert.Equal(300u, e.Request.BodySize);
+            Assert.NotNull(e.Request.Timings);
+            Assert.Equal("https://example.com", e.Response.Url);
+            Assert.Equal("https", e.Response.Protocol);
+            Assert.Equal(200u, e.Response.Status);
+            Assert.Equal("OK", e.Response.StatusText);
+            Assert.False(e.Response.FromCache);
+            Assert.Single(e.Response.Headers);
+            Assert.Equal("headerName", e.Response.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Response.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Response.Headers[0].Value.Value);
+            Assert.Equal("text/html", e.Response.MimeType);
+            Assert.Equal(400u, e.Response.BytesReceived);
+            Assert.Equal(100u, e.Response.HeadersSize);
+            Assert.Equal(300u, e.Response.BodySize);
+            Assert.Equal(300u, e.Response.Content.Size);
+
             syncEvent.Set();
         });
 
@@ -770,10 +753,10 @@ public class NetworkModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveResponseCompletedEvent()
     {
         DateTime now = DateTime.UtcNow;
@@ -782,55 +765,54 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         ManualResetEvent syncEvent = new(false);
         module.OnResponseCompleted.AddObserver((ResponseCompletedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.NavigationId, Is.EqualTo("myNavigationId"));
-                Assert.That(e.RedirectCount, Is.EqualTo(0));
-                Assert.That(e.Timestamp, Is.EqualTo(eventTime));
-                Assert.That(e.EpochTimestamp, Is.EqualTo(milliseconds));
-                Assert.That(e.Request.RequestId, Is.EqualTo("myRequestId"));
-                Assert.That(e.Request.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Request.Method, Is.EqualTo("get"));
-                Assert.That(e.Request.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Request.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Request.Cookies, Has.Count.EqualTo(1));
-                Assert.That(e.Request.Cookies[0].Name, Is.EqualTo("cookieName"));
-                Assert.That(e.Request.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Request.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-                Assert.That(e.Request.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-                Assert.That(e.Request.Cookies[0].Path, Is.EqualTo("/cookiePath"));
-                Assert.That(e.Request.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Strict));
-                Assert.That(e.Request.Cookies[0].Secure, Is.False);
-                Assert.That(e.Request.Cookies[0].HttpOnly, Is.True);
-                Assert.That(e.Request.Cookies[0].Size, Is.EqualTo(10));
-                Assert.That(e.Request.Cookies[0].Expires, Is.Null);
-                Assert.That(e.Request.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Request.BodySize, Is.EqualTo(300));
-                Assert.That(e.Request.Timings, Is.Not.Null);
-                Assert.That(e.Response.Url, Is.EqualTo("https://example.com"));
-                Assert.That(e.Response.Protocol, Is.EqualTo("https"));
-                Assert.That(e.Response.Status, Is.EqualTo(200));
-                Assert.That(e.Response.StatusText, Is.EqualTo("OK"));
-                Assert.That(e.Response.FromCache, Is.False);
-                Assert.That(e.Response.Headers, Has.Count.EqualTo(1));
-                Assert.That(e.Response.Headers[0].Name, Is.EqualTo("headerName"));
-                Assert.That(e.Response.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-                Assert.That(e.Response.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-                Assert.That(e.Response.MimeType, Is.EqualTo("text/html"));
-                Assert.That(e.Response.BytesReceived, Is.EqualTo(400));
-                Assert.That(e.Response.HeadersSize, Is.EqualTo(100));
-                Assert.That(e.Response.BodySize, Is.EqualTo(300));
-                Assert.That(e.Response.Content.Size, Is.EqualTo(300));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("myNavigationId", e.NavigationId);
+            Assert.Equal(0u, e.RedirectCount);
+            Assert.Equal(eventTime, e.Timestamp);
+            Assert.Equal((ulong)((ulong)(milliseconds)), e.EpochTimestamp);
+            Assert.Equal("myRequestId", e.Request.RequestId);
+            Assert.Equal("https://example.com", e.Request.Url);
+            Assert.Equal("get", e.Request.Method);
+            Assert.Single(e.Request.Headers);
+            Assert.Equal("headerName", e.Request.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Request.Headers[0].Value.Value);
+            Assert.Single(e.Request.Cookies);
+            Assert.Equal("cookieName", e.Request.Cookies[0].Name);
+            Assert.Equal(BytesValueType.String, e.Request.Cookies[0].Value.Type);
+            Assert.Equal("cookieValue", e.Request.Cookies[0].Value.Value);
+            Assert.Equal("cookieDomain", e.Request.Cookies[0].Domain);
+            Assert.Equal("/cookiePath", e.Request.Cookies[0].Path);
+            Assert.Equal(CookieSameSiteValue.Strict, e.Request.Cookies[0].SameSite);
+            Assert.False(e.Request.Cookies[0].Secure);
+            Assert.True(e.Request.Cookies[0].HttpOnly);
+            Assert.Equal(10, e.Request.Cookies[0].Size);
+            Assert.Null(e.Request.Cookies[0].Expires);
+            Assert.Equal(100u, e.Request.HeadersSize);
+            Assert.Equal(300u, e.Request.BodySize);
+            Assert.NotNull(e.Request.Timings);
+            Assert.Equal("https://example.com", e.Response.Url);
+            Assert.Equal("https", e.Response.Protocol);
+            Assert.Equal(200u, e.Response.Status);
+            Assert.Equal("OK", e.Response.StatusText);
+            Assert.False(e.Response.FromCache);
+            Assert.Single(e.Response.Headers);
+            Assert.Equal("headerName", e.Response.Headers[0].Name);
+            Assert.Equal(BytesValueType.String, e.Response.Headers[0].Value.Type);
+            Assert.Equal("headerValue", e.Response.Headers[0].Value.Value);
+            Assert.Equal("text/html", e.Response.MimeType);
+            Assert.Equal(400u, e.Response.BytesReceived);
+            Assert.Equal(100u, e.Response.HeadersSize);
+            Assert.Equal(300u, e.Response.BodySize);
+            Assert.Equal(300u, e.Response.Content.Size);
+
             syncEvent.Set();
         });
 
@@ -851,6 +833,6 @@ public class NetworkModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
@@ -472,7 +472,7 @@ public class NetworkModuleTests
         NetworkModule module = driver.Network;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnAuthRequired.AddObserver((AuthRequiredEventArgs e) =>
+        module.OnAuthRequired.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
@@ -550,7 +550,7 @@ public class NetworkModuleTests
         NetworkModule module = driver.Network;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnBeforeRequestSent.AddObserver((BeforeRequestSentEventArgs e) =>
+        module.OnBeforeRequestSent.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
@@ -618,7 +618,7 @@ public class NetworkModuleTests
         NetworkModule module = driver.Network;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnFetchError.AddObserver((FetchErrorEventArgs e) =>
+        module.OnFetchError.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
@@ -683,7 +683,7 @@ public class NetworkModuleTests
         NetworkModule module = driver.Network;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnResponseStarted.AddObserver((ResponseStartedEventArgs e) =>
+        module.OnResponseStarted.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
@@ -761,7 +761,7 @@ public class NetworkModuleTests
         NetworkModule module = driver.Network;
 
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        module.OnResponseCompleted.AddObserver((ResponseCompletedEventArgs e) =>
+        module.OnResponseCompleted.AddObserver(e =>
         {
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);

--- a/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
@@ -100,7 +100,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         AddInterceptCommandParameters commandParameters = new(InterceptPhase.BeforeRequestSent)
@@ -134,7 +134,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         AddDataCollectorCommandParameters commandParameters = new(1024 * 1024);
@@ -163,7 +163,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<ContinueRequestCommandResult> task = module.ContinueRequestAsync(new ContinueRequestCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -190,7 +190,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<ContinueResponseCommandResult> task = module.ContinueResponseAsync(new ContinueResponseCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -217,7 +217,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<ContinueWithAuthCommandResult> task = module.ContinueWithAuthAsync(new ContinueWithAuthCommandParameters("requestId")
@@ -248,7 +248,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         DisownDataCommandParameters commandParameters = new("myCollectorId", "myRequestId");
@@ -276,7 +276,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<FailRequestCommandResult> task = module.FailRequestAsync(new FailRequestCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -308,7 +308,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         GetDataCommandParameters commandParameters = new("myRequestId");
@@ -338,7 +338,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<ProvideResponseCommandResult> task = module.ProvideResponseAsync(new ProvideResponseCommandParameters("requestId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -393,7 +393,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<RemoveInterceptCommandResult> task = module.RemoveInterceptAsync(new RemoveInterceptCommandParameters("interceptId"), cancellationToken: TestContext.Current.CancellationToken);
@@ -420,7 +420,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         Task<SetCacheBehaviorCommandResult> task = module.SetCacheBehaviorAsync(new SetCacheBehaviorCommandParameters(CacheBehavior.Default), cancellationToken: TestContext.Current.CancellationToken);
@@ -447,7 +447,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
         SetExtraHeadersCommandParameters commandParameters = new();
@@ -468,13 +468,12 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnAuthRequired.AddObserver((AuthRequiredEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal(0u, e.RedirectCount);
@@ -516,7 +515,7 @@ public class NetworkModuleTests
             Assert.Equal(300u, e.Response.BodySize);
             Assert.Equal(300u, e.Response.Content.Size);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -535,8 +534,7 @@ public class NetworkModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -548,13 +546,12 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnBeforeRequestSent.AddObserver((BeforeRequestSentEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal(0u, e.RedirectCount);
@@ -584,7 +581,7 @@ public class NetworkModuleTests
             Assert.NotNull(e.Initiator);
             Assert.Equal(InitiatorType.Parser, e.Initiator.Type);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -605,8 +602,7 @@ public class NetworkModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -618,13 +614,12 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnFetchError.AddObserver((FetchErrorEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal(0u, e.RedirectCount);
@@ -653,7 +648,7 @@ public class NetworkModuleTests
             Assert.NotNull(e.Request.Timings);
             Assert.Equal("An error occurred", e.ErrorText);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -672,8 +667,7 @@ public class NetworkModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -685,13 +679,12 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnResponseStarted.AddObserver((ResponseStartedEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal(0u, e.RedirectCount);
@@ -733,7 +726,7 @@ public class NetworkModuleTests
             Assert.Equal(300u, e.Response.BodySize);
             Assert.Equal(300u, e.Response.Content.Size);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -752,8 +745,7 @@ public class NetworkModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -765,13 +757,12 @@ public class NetworkModuleTests
 
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         module.OnResponseCompleted.AddObserver((ResponseCompletedEventArgs e) =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("myNavigationId", e.NavigationId);
             Assert.Equal(0u, e.RedirectCount);
@@ -813,7 +804,7 @@ public class NetworkModuleTests
             Assert.Equal(300u, e.Response.BodySize);
             Assert.Equal(300u, e.Response.Content.Size);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = $$"""
@@ -832,7 +823,6 @@ public class NetworkModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
@@ -99,7 +99,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -133,7 +133,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -162,7 +162,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -189,7 +189,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -216,7 +216,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -247,7 +247,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -275,7 +275,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -307,7 +307,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -337,7 +337,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -364,7 +364,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -392,7 +392,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -419,7 +419,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -446,7 +446,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -467,7 +467,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -545,7 +545,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -613,7 +613,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -678,7 +678,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -756,7 +756,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 

--- a/test/WebDriverBiDi.Tests/Network/ProvideResponseCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ProvideResponseCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ProvideResponseCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         ProvideResponseCommandParameters properties = new("myRequestId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.provideResponse"));
+        Assert.Equal("network.provideResponse", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         ProvideResponseCommandParameters properties = new("myRequestId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithBody()
     {
         ProvideResponseCommandParameters properties = new("myRequestId")
@@ -37,26 +36,34 @@ public class ProvideResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("body"));
-            Assert.That(serialized["body"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject bodyObject = (JObject)serialized["body"]!;
-            Assert.That(bodyObject, Has.Count.EqualTo(2));
-            Assert.That(bodyObject, Contains.Key("type"));
-            Assert.That(bodyObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(bodyObject, Contains.Key("value"));
-            Assert.That(bodyObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bodyObject["value"]!.Value<string>(), Is.EqualTo("test body"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("body"));
+        JToken? bodyToken = serialized["body"];
+        Assert.NotNull(bodyToken);
+        Assert.Equal(JTokenType.Object, bodyToken.Type);
+        JObject? bodyObject = bodyToken as JObject;
+        Assert.NotNull(bodyObject);
+        Assert.Equal(2, bodyObject.Count);
+        Assert.True(bodyObject.ContainsKey("type"));
+        JToken? bodyType = bodyObject["type"];
+        Assert.NotNull(bodyType);
+        Assert.Equal(JTokenType.String, bodyType.Type);
+        Assert.Equal("string", bodyType.Value<string>());
+        Assert.True(bodyObject.ContainsKey("value"));
+        JToken? bodyValue = bodyObject["value"];
+        Assert.NotNull(bodyValue);
+        Assert.Equal(JTokenType.String, bodyValue.Type);
+        Assert.Equal("test body", bodyValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithCookies()
     {
         ProvideResponseCommandParameters properties = new("myRequestId")
@@ -65,36 +72,50 @@ public class ProvideResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("cookies"));
-            Assert.That(serialized["cookies"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray cookieHeaderArray = (JArray)serialized["cookies"]!;
-            Assert.That(cookieHeaderArray, Has.Count.EqualTo(1));
-            Assert.That(cookieHeaderArray[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieHeaderObject = (JObject)cookieHeaderArray[0];
-            Assert.That(cookieHeaderObject, Has.Count.EqualTo(2));
-            Assert.That(cookieHeaderObject, Contains.Key("name"));
-            Assert.That(cookieHeaderObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieHeaderObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(cookieHeaderObject, Contains.Key("value"));
-            Assert.That(cookieHeaderObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieValueObject = (JObject)cookieHeaderObject["value"]!;
-            Assert.That(cookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(cookieValueObject, Contains.Key("type"));
-            Assert.That(cookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(cookieValueObject, Contains.Key("value"));
-            Assert.That(cookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("cookies"));
+        JToken? cookiesToken = serialized["cookies"];
+        Assert.NotNull(cookiesToken);
+        Assert.Equal(JTokenType.Array, cookiesToken.Type);
+        JArray? cookieHeaderArray = cookiesToken as JArray;
+        Assert.NotNull(cookieHeaderArray);
+        Assert.Single(cookieHeaderArray);
+        Assert.Equal(JTokenType.Object, cookieHeaderArray[0].Type);
+        JObject? cookieHeaderObject = cookieHeaderArray[0] as JObject;
+        Assert.NotNull(cookieHeaderObject);
+        Assert.Equal(2, cookieHeaderObject.Count);
+        Assert.True(cookieHeaderObject.ContainsKey("name"));
+        JToken? cookieName = cookieHeaderObject["name"];
+        Assert.NotNull(cookieName);
+        Assert.Equal(JTokenType.String, cookieName.Type);
+        Assert.Equal("cookieName", cookieName.Value<string>());
+        Assert.True(cookieHeaderObject.ContainsKey("value"));
+        JToken? cookieValueToken = cookieHeaderObject["value"];
+        Assert.NotNull(cookieValueToken);
+        Assert.Equal(JTokenType.Object, cookieValueToken.Type);
+        JObject? cookieValueObject = cookieValueToken as JObject;
+        Assert.NotNull(cookieValueObject);
+        Assert.Equal(2, cookieValueObject.Count);
+        Assert.True(cookieValueObject.ContainsKey("type"));
+        JToken? cookieValueType = cookieValueObject["type"];
+        Assert.NotNull(cookieValueType);
+        Assert.Equal(JTokenType.String, cookieValueType.Type);
+        Assert.Equal("string", cookieValueType.Value<string>());
+        Assert.True(cookieValueObject.ContainsKey("value"));
+        JToken? cookieValueValue = cookieValueObject["value"];
+        Assert.NotNull(cookieValueValue);
+        Assert.Equal(JTokenType.String, cookieValueValue.Type);
+        Assert.Equal("cookieValue", cookieValueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithHeaders()
     {
         ProvideResponseCommandParameters properties = new("myRequestId")
@@ -103,36 +124,50 @@ public class ProvideResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray headerArray = (JArray)serialized["headers"]!;
-            Assert.That(headerArray, Has.Count.EqualTo(1));
-            Assert.That(headerArray[0].Type, Is.EqualTo(JTokenType.Object));
-            JObject headerObject = (JObject)headerArray[0];
-            Assert.That(headerObject, Has.Count.EqualTo(2));
-            Assert.That(headerObject, Contains.Key("name"));
-            Assert.That(headerObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerObject["name"]!.Value<string>(), Is.EqualTo("headerName"));
-            Assert.That(headerObject, Contains.Key("value"));
-            Assert.That(headerObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject headerValueObject = (JObject)headerObject["value"]!;
-            Assert.That(headerValueObject, Has.Count.EqualTo(2));
-            Assert.That(headerValueObject, Contains.Key("type"));
-            Assert.That(headerValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(headerValueObject, Contains.Key("value"));
-            Assert.That(headerValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headerValueObject["value"]!.Value<string>(), Is.EqualTo("headerValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headerArray = headersToken as JArray;
+        Assert.NotNull(headerArray);
+        Assert.Single(headerArray);
+        Assert.Equal(JTokenType.Object, headerArray[0].Type);
+        JObject? headerObject = headerArray[0] as JObject;
+        Assert.NotNull(headerObject);
+        Assert.Equal(2, headerObject.Count);
+        Assert.True(headerObject.ContainsKey("name"));
+        JToken? headerName = headerObject["name"];
+        Assert.NotNull(headerName);
+        Assert.Equal(JTokenType.String, headerName.Type);
+        Assert.Equal("headerName", headerName.Value<string>());
+        Assert.True(headerObject.ContainsKey("value"));
+        JToken? headerValueToken = headerObject["value"];
+        Assert.NotNull(headerValueToken);
+        Assert.Equal(JTokenType.Object, headerValueToken.Type);
+        JObject? headerValueObject = headerValueToken as JObject;
+        Assert.NotNull(headerValueObject);
+        Assert.Equal(2, headerValueObject.Count);
+        Assert.True(headerValueObject.ContainsKey("type"));
+        JToken? headerValueType = headerValueObject["type"];
+        Assert.NotNull(headerValueType);
+        Assert.Equal(JTokenType.String, headerValueType.Type);
+        Assert.Equal("string", headerValueType.Value<string>());
+        Assert.True(headerValueObject.ContainsKey("value"));
+        JToken? headerValueValue = headerValueObject["value"];
+        Assert.NotNull(headerValueValue);
+        Assert.Equal(JTokenType.String, headerValueValue.Type);
+        Assert.Equal("headerValue", headerValueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithReasonPhrase()
     {
         ProvideResponseCommandParameters properties = new("myRequestId")
@@ -141,19 +176,22 @@ public class ProvideResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("reasonPhrase"));
-            Assert.That(serialized["reasonPhrase"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["reasonPhrase"]!.Value<string>(), Is.EqualTo("Not Found"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("reasonPhrase"));
+        JToken? reasonPhrase = serialized["reasonPhrase"];
+        Assert.NotNull(reasonPhrase);
+        Assert.Equal(JTokenType.String, reasonPhrase.Type);
+        Assert.Equal("Not Found", reasonPhrase.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithStatusCode()
     {
         ProvideResponseCommandParameters properties = new("myRequestId")
@@ -162,15 +200,18 @@ public class ProvideResponseCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("request"));
-            Assert.That(serialized["request"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["request"]!.Value<string>(), Is.EqualTo("myRequestId"));
-            Assert.That(serialized, Contains.Key("statusCode"));
-            Assert.That(serialized["statusCode"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["statusCode"]!.Value<ulong>(), Is.EqualTo(404));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("request"));
+        JToken? request = serialized["request"];
+        Assert.NotNull(request);
+        Assert.Equal(JTokenType.String, request.Type);
+        Assert.Equal("myRequestId", request.Value<string>());
+
+        Assert.True(serialized.ContainsKey("statusCode"));
+        JToken? statusCode = serialized["statusCode"];
+        Assert.NotNull(statusCode);
+        Assert.Equal(JTokenType.Integer, statusCode.Type);
+        Assert.Equal(404UL, statusCode.Value<ulong>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ProvideResponseCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ProvideResponseCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ProvideResponseCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         ProvideResponseCommandResult? result = JsonSerializer.Deserialize<ProvideResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ProvideResponseCommandResult? result = JsonSerializer.Deserialize<ProvideResponseCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProvideResponseCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ReadOnlyHeaderTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ReadOnlyHeaderTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ReadOnlyHeaderTests
 {
-    [Test]
+    [Fact]
     public void CanDeserializeHeader()
     {
         string json = """
@@ -45,17 +44,15 @@ public class ReadOnlyHeaderTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
+        Assert.NotNull(request);
         ReadOnlyHeader header = request.Headers[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(header.Name, Is.EqualTo("headerName"));
-            Assert.That(header.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(header.Value.Value, Is.EqualTo("headerValue"));
-        }
+
+        Assert.Equal("headerName", header.Name);
+        Assert.Equal(BytesValueType.String, header.Value.Type);
+        Assert.Equal("headerValue", header.Value.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -95,9 +92,9 @@ public class ReadOnlyHeaderTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
+        Assert.NotNull(request);
         ReadOnlyHeader header = request.Headers[0];
         ReadOnlyHeader copy = header with { };
-        Assert.That(copy, Is.EqualTo(header));
+        Assert.Equal(header, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/RemoveDataCollectorCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/RemoveDataCollectorCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class RemoveDataCollectorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         RemoveDataCollectorCommandParameters properties = new("myCollectorId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.removeDataCollector"));
+        Assert.Equal("network.removeDataCollector", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         RemoveDataCollectorCommandParameters properties = new("myCollectorId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("collector"));
-            Assert.That(serialized["collector"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["collector"]!.Value<string>(), Is.EqualTo("myCollectorId"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("collector"));
+        JToken? collector = serialized["collector"];
+        Assert.NotNull(collector);
+        Assert.Equal(JTokenType.String, collector.Type);
+        Assert.Equal("myCollectorId", collector.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/RemoveDataCollectorCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/RemoveDataCollectorCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RemoveDataCollectorCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         RemoveDataCollectorCommandResult? result = JsonSerializer.Deserialize<RemoveDataCollectorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         RemoveDataCollectorCommandResult? result = JsonSerializer.Deserialize<RemoveDataCollectorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoveDataCollectorCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/RemoveInterceptCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/RemoveInterceptCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class RemoveInterceptCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         RemoveInterceptCommandParameters properties = new("interceptId");
-        Assert.That(properties.MethodName, Is.EqualTo("network.removeIntercept"));
+        Assert.Equal("network.removeIntercept", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         RemoveInterceptCommandParameters properties = new("interceptId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("intercept"));
-            Assert.That(serialized["intercept"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["intercept"]!.Value<string>(), Is.EqualTo("interceptId"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("intercept"));
+        JToken? intercept = serialized["intercept"];
+        Assert.NotNull(intercept);
+        Assert.Equal(JTokenType.String, intercept.Type);
+        Assert.Equal("interceptId", intercept.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/RemoveInterceptCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/RemoveInterceptCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RemoveInterceptCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         RemoveInterceptCommandResult? result = JsonSerializer.Deserialize<RemoveInterceptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         RemoveInterceptCommandResult? result = JsonSerializer.Deserialize<RemoveInterceptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoveInterceptCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/RequestDataTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/RequestDataTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RequestDataTests
 {
-    [Test]
+    [Fact]
     public void CanDeserializeRequestData()
     {
         string json = """
@@ -37,36 +36,34 @@ public class RequestDataTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(request.RequestId, Is.EqualTo("myRequestId"));
-            Assert.That(request.Url, Is.EqualTo("requestUrl"));
-            Assert.That(request.Method, Is.EqualTo("get"));
-            Assert.That(request.Headers, Is.Empty);
-            Assert.That(request.Cookies, Is.Empty);
-            Assert.That(request.Destination, Is.EqualTo("document"));
-            Assert.That(request.InitiatorType, Is.EqualTo("other"));
-            Assert.That(request.HeadersSize, Is.EqualTo(0));
-            Assert.That(request.BodySize, Is.EqualTo(0));
-            Assert.That(request.Timings, Is.Not.Null);
-            Assert.That(request.Timings.TimeOrigin, Is.EqualTo(1));
-            Assert.That(request.Timings.RequestTime, Is.EqualTo(2));
-            Assert.That(request.Timings.RedirectStart, Is.EqualTo(3));
-            Assert.That(request.Timings.RedirectEnd, Is.EqualTo(4));
-            Assert.That(request.Timings.FetchStart, Is.EqualTo(5));
-            Assert.That(request.Timings.DnsStart, Is.EqualTo(6));
-            Assert.That(request.Timings.DnsEnd, Is.EqualTo(7));
-            Assert.That(request.Timings.ConnectStart, Is.EqualTo(8));
-            Assert.That(request.Timings.ConnectEnd, Is.EqualTo(9));
-            Assert.That(request.Timings.TlsStart, Is.EqualTo(10));
-            Assert.That(request.Timings.RequestStart, Is.EqualTo(11));
-            Assert.That(request.Timings.ResponseStart, Is.EqualTo(12));
-            Assert.That(request.Timings.ResponseEnd, Is.EqualTo(13));
-        }
+        Assert.NotNull(request);
+
+        Assert.Equal("myRequestId", request.RequestId);
+        Assert.Equal("requestUrl", request.Url);
+        Assert.Equal("get", request.Method);
+        Assert.Empty(request.Headers);
+        Assert.Empty(request.Cookies);
+        Assert.Equal("document", request.Destination);
+        Assert.Equal("other", request.InitiatorType);
+        Assert.Equal(0u, request.HeadersSize);
+        Assert.Equal(0u, request.BodySize);
+        Assert.NotNull(request.Timings);
+        Assert.Equal(1, request.Timings.TimeOrigin);
+        Assert.Equal(2, request.Timings.RequestTime);
+        Assert.Equal(3, request.Timings.RedirectStart);
+        Assert.Equal(4, request.Timings.RedirectEnd);
+        Assert.Equal(5, request.Timings.FetchStart);
+        Assert.Equal(6, request.Timings.DnsStart);
+        Assert.Equal(7, request.Timings.DnsEnd);
+        Assert.Equal(8, request.Timings.ConnectStart);
+        Assert.Equal(9, request.Timings.ConnectEnd);
+        Assert.Equal(10, request.Timings.TlsStart);
+        Assert.Equal(11, request.Timings.RequestStart);
+        Assert.Equal(12, request.Timings.ResponseStart);
+        Assert.Equal(13, request.Timings.ResponseEnd);
     }
 
-    [Test]
+    [Fact]
     public void CanDeserializeRequestDataWithHeaders()
     {
         string json = """
@@ -106,39 +103,37 @@ public class RequestDataTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(request.RequestId, Is.EqualTo("myRequestId"));
-            Assert.That(request.Url, Is.EqualTo("requestUrl"));
-            Assert.That(request.Method, Is.EqualTo("get"));
-            Assert.That(request.Headers, Has.Count.EqualTo(1));
-            Assert.That(request.Headers[0].Name, Is.EqualTo("headerName"));
-            Assert.That(request.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(request.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-            Assert.That(request.Cookies, Is.Empty);
-            Assert.That(request.Destination, Is.EqualTo("document"));
-            Assert.That(request.InitiatorType, Is.EqualTo("other"));
-            Assert.That(request.HeadersSize, Is.EqualTo(0));
-            Assert.That(request.BodySize, Is.EqualTo(0));
-            Assert.That(request.Timings, Is.Not.Null);
-            Assert.That(request.Timings.TimeOrigin, Is.EqualTo(1));
-            Assert.That(request.Timings.RequestTime, Is.EqualTo(2));
-            Assert.That(request.Timings.RedirectStart, Is.EqualTo(3));
-            Assert.That(request.Timings.RedirectEnd, Is.EqualTo(4));
-            Assert.That(request.Timings.FetchStart, Is.EqualTo(5));
-            Assert.That(request.Timings.DnsStart, Is.EqualTo(6));
-            Assert.That(request.Timings.DnsEnd, Is.EqualTo(7));
-            Assert.That(request.Timings.ConnectStart, Is.EqualTo(8));
-            Assert.That(request.Timings.ConnectEnd, Is.EqualTo(9));
-            Assert.That(request.Timings.TlsStart, Is.EqualTo(10));
-            Assert.That(request.Timings.RequestStart, Is.EqualTo(11));
-            Assert.That(request.Timings.ResponseStart, Is.EqualTo(12));
-            Assert.That(request.Timings.ResponseEnd, Is.EqualTo(13));
-        }
+        Assert.NotNull(request);
+
+        Assert.Equal("myRequestId", request.RequestId);
+        Assert.Equal("requestUrl", request.Url);
+        Assert.Equal("get", request.Method);
+        Assert.Single(request.Headers);
+        Assert.Equal("headerName", request.Headers[0].Name);
+        Assert.Equal(BytesValueType.String, request.Headers[0].Value.Type);
+        Assert.Equal("headerValue", request.Headers[0].Value.Value);
+        Assert.Empty(request.Cookies);
+        Assert.Equal("document", request.Destination);
+        Assert.Equal("other", request.InitiatorType);
+        Assert.Equal(0u, request.HeadersSize);
+        Assert.Equal(0u, request.BodySize);
+        Assert.NotNull(request.Timings);
+        Assert.Equal(1, request.Timings.TimeOrigin);
+        Assert.Equal(2, request.Timings.RequestTime);
+        Assert.Equal(3, request.Timings.RedirectStart);
+        Assert.Equal(4, request.Timings.RedirectEnd);
+        Assert.Equal(5, request.Timings.FetchStart);
+        Assert.Equal(6, request.Timings.DnsStart);
+        Assert.Equal(7, request.Timings.DnsEnd);
+        Assert.Equal(8, request.Timings.ConnectStart);
+        Assert.Equal(9, request.Timings.ConnectEnd);
+        Assert.Equal(10, request.Timings.TlsStart);
+        Assert.Equal(11, request.Timings.RequestStart);
+        Assert.Equal(12, request.Timings.ResponseStart);
+        Assert.Equal(13, request.Timings.ResponseEnd);
     }
 
-    [Test]
+    [Fact]
     public void CanDeserializeRequestDataWithCookies()
     {
         string json = """
@@ -184,47 +179,45 @@ public class RequestDataTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(request.RequestId, Is.EqualTo("myRequestId"));
-            Assert.That(request.Url, Is.EqualTo("requestUrl"));
-            Assert.That(request.Method, Is.EqualTo("get"));
-            Assert.That(request.Headers, Is.Empty);
-            Assert.That(request.Cookies, Has.Count.EqualTo(1));
-            Assert.That(request.Cookies[0].Name, Is.EqualTo("cookieName"));
-            Assert.That(request.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(request.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(request.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(request.Cookies[0].Path, Is.EqualTo("/cookiePath"));
-            Assert.That(request.Cookies[0].Secure, Is.True);
-            Assert.That(request.Cookies[0].HttpOnly, Is.True);
-            Assert.That(request.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(request.Cookies[0].Size, Is.EqualTo(100));
-            Assert.That(request.Cookies[0].Expires, Is.Null);
-            Assert.That(request.Cookies[0].EpochExpires, Is.Null);
-            Assert.That(request.Destination, Is.EqualTo("document"));
-            Assert.That(request.InitiatorType, Is.EqualTo("other"));
-            Assert.That(request.HeadersSize, Is.EqualTo(0));
-            Assert.That(request.BodySize, Is.EqualTo(0));
-            Assert.That(request.Timings, Is.Not.Null);
-            Assert.That(request.Timings.TimeOrigin, Is.EqualTo(1));
-            Assert.That(request.Timings.RequestTime, Is.EqualTo(2));
-            Assert.That(request.Timings.RedirectStart, Is.EqualTo(3));
-            Assert.That(request.Timings.RedirectEnd, Is.EqualTo(4));
-            Assert.That(request.Timings.FetchStart, Is.EqualTo(5));
-            Assert.That(request.Timings.DnsStart, Is.EqualTo(6));
-            Assert.That(request.Timings.DnsEnd, Is.EqualTo(7));
-            Assert.That(request.Timings.ConnectStart, Is.EqualTo(8));
-            Assert.That(request.Timings.ConnectEnd, Is.EqualTo(9));
-            Assert.That(request.Timings.TlsStart, Is.EqualTo(10));
-            Assert.That(request.Timings.RequestStart, Is.EqualTo(11));
-            Assert.That(request.Timings.ResponseStart, Is.EqualTo(12));
-            Assert.That(request.Timings.ResponseEnd, Is.EqualTo(13));
-        }
+        Assert.NotNull(request);
+
+        Assert.Equal("myRequestId", request.RequestId);
+        Assert.Equal("requestUrl", request.Url);
+        Assert.Equal("get", request.Method);
+        Assert.Empty(request.Headers);
+        Assert.Single(request.Cookies);
+        Assert.Equal("cookieName", request.Cookies[0].Name);
+        Assert.Equal(BytesValueType.String, request.Cookies[0].Value.Type);
+        Assert.Equal("cookieValue", request.Cookies[0].Value.Value);
+        Assert.Equal("cookieDomain", request.Cookies[0].Domain);
+        Assert.Equal("/cookiePath", request.Cookies[0].Path);
+        Assert.True(request.Cookies[0].Secure);
+        Assert.True(request.Cookies[0].HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, request.Cookies[0].SameSite);
+        Assert.Equal(100, request.Cookies[0].Size);
+        Assert.Null(request.Cookies[0].Expires);
+        Assert.Null(request.Cookies[0].EpochExpires);
+        Assert.Equal("document", request.Destination);
+        Assert.Equal("other", request.InitiatorType);
+        Assert.Equal(0u, request.HeadersSize);
+        Assert.Equal(0u, request.BodySize);
+        Assert.NotNull(request.Timings);
+        Assert.Equal(1, request.Timings.TimeOrigin);
+        Assert.Equal(2, request.Timings.RequestTime);
+        Assert.Equal(3, request.Timings.RedirectStart);
+        Assert.Equal(4, request.Timings.RedirectEnd);
+        Assert.Equal(5, request.Timings.FetchStart);
+        Assert.Equal(6, request.Timings.DnsStart);
+        Assert.Equal(7, request.Timings.DnsEnd);
+        Assert.Equal(8, request.Timings.ConnectStart);
+        Assert.Equal(9, request.Timings.ConnectEnd);
+        Assert.Equal(10, request.Timings.TlsStart);
+        Assert.Equal(11, request.Timings.RequestStart);
+        Assert.Equal(12, request.Timings.ResponseStart);
+        Assert.Equal(13, request.Timings.ResponseEnd);
     }
 
-    [Test]
+    [Fact]
     public void CanDeserializeRequestDataWithNullBodySize()
     {
         string json = """
@@ -256,36 +249,34 @@ public class RequestDataTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(request.RequestId, Is.EqualTo("myRequestId"));
-            Assert.That(request.Url, Is.EqualTo("requestUrl"));
-            Assert.That(request.Method, Is.EqualTo("get"));
-            Assert.That(request.Headers, Is.Empty);
-            Assert.That(request.Cookies, Is.Empty);
-            Assert.That(request.Destination, Is.EqualTo("document"));
-            Assert.That(request.InitiatorType, Is.EqualTo("other"));
-            Assert.That(request.HeadersSize, Is.EqualTo(0));
-            Assert.That(request.BodySize, Is.Null);
-            Assert.That(request.Timings, Is.Not.Null);
-            Assert.That(request.Timings.TimeOrigin, Is.EqualTo(1));
-            Assert.That(request.Timings.RequestTime, Is.EqualTo(2));
-            Assert.That(request.Timings.RedirectStart, Is.EqualTo(3));
-            Assert.That(request.Timings.RedirectEnd, Is.EqualTo(4));
-            Assert.That(request.Timings.FetchStart, Is.EqualTo(5));
-            Assert.That(request.Timings.DnsStart, Is.EqualTo(6));
-            Assert.That(request.Timings.DnsEnd, Is.EqualTo(7));
-            Assert.That(request.Timings.ConnectStart, Is.EqualTo(8));
-            Assert.That(request.Timings.ConnectEnd, Is.EqualTo(9));
-            Assert.That(request.Timings.TlsStart, Is.EqualTo(10));
-            Assert.That(request.Timings.RequestStart, Is.EqualTo(11));
-            Assert.That(request.Timings.ResponseStart, Is.EqualTo(12));
-            Assert.That(request.Timings.ResponseEnd, Is.EqualTo(13));
-        }
+        Assert.NotNull(request);
+
+        Assert.Equal("myRequestId", request.RequestId);
+        Assert.Equal("requestUrl", request.Url);
+        Assert.Equal("get", request.Method);
+        Assert.Empty(request.Headers);
+        Assert.Empty(request.Cookies);
+        Assert.Equal("document", request.Destination);
+        Assert.Equal("other", request.InitiatorType);
+        Assert.Equal(0u, request.HeadersSize);
+        Assert.Null(request.BodySize);
+        Assert.NotNull(request.Timings);
+        Assert.Equal(1, request.Timings.TimeOrigin);
+        Assert.Equal(2, request.Timings.RequestTime);
+        Assert.Equal(3, request.Timings.RedirectStart);
+        Assert.Equal(4, request.Timings.RedirectEnd);
+        Assert.Equal(5, request.Timings.FetchStart);
+        Assert.Equal(6, request.Timings.DnsStart);
+        Assert.Equal(7, request.Timings.DnsEnd);
+        Assert.Equal(8, request.Timings.ConnectStart);
+        Assert.Equal(9, request.Timings.ConnectEnd);
+        Assert.Equal(10, request.Timings.TlsStart);
+        Assert.Equal(11, request.Timings.RequestStart);
+        Assert.Equal(12, request.Timings.ResponseStart);
+        Assert.Equal(13, request.Timings.ResponseEnd);
     }
 
-    [Test]
+    [Fact]
     public void CanDeserializeRequestDataWithNullInitiatorType()
     {
         string json = """
@@ -317,36 +308,34 @@ public class RequestDataTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(request.RequestId, Is.EqualTo("myRequestId"));
-            Assert.That(request.Url, Is.EqualTo("requestUrl"));
-            Assert.That(request.Method, Is.EqualTo("get"));
-            Assert.That(request.Headers, Is.Empty);
-            Assert.That(request.Cookies, Is.Empty);
-            Assert.That(request.Destination, Is.EqualTo("document"));
-            Assert.That(request.InitiatorType, Is.Null);
-            Assert.That(request.HeadersSize, Is.EqualTo(0));
-            Assert.That(request.BodySize, Is.EqualTo(0));
-            Assert.That(request.Timings, Is.Not.Null);
-            Assert.That(request.Timings.TimeOrigin, Is.EqualTo(1));
-            Assert.That(request.Timings.RequestTime, Is.EqualTo(2));
-            Assert.That(request.Timings.RedirectStart, Is.EqualTo(3));
-            Assert.That(request.Timings.RedirectEnd, Is.EqualTo(4));
-            Assert.That(request.Timings.FetchStart, Is.EqualTo(5));
-            Assert.That(request.Timings.DnsStart, Is.EqualTo(6));
-            Assert.That(request.Timings.DnsEnd, Is.EqualTo(7));
-            Assert.That(request.Timings.ConnectStart, Is.EqualTo(8));
-            Assert.That(request.Timings.ConnectEnd, Is.EqualTo(9));
-            Assert.That(request.Timings.TlsStart, Is.EqualTo(10));
-            Assert.That(request.Timings.RequestStart, Is.EqualTo(11));
-            Assert.That(request.Timings.ResponseStart, Is.EqualTo(12));
-            Assert.That(request.Timings.ResponseEnd, Is.EqualTo(13));
-        }
+        Assert.NotNull(request);
+
+        Assert.Equal("myRequestId", request.RequestId);
+        Assert.Equal("requestUrl", request.Url);
+        Assert.Equal("get", request.Method);
+        Assert.Empty(request.Headers);
+        Assert.Empty(request.Cookies);
+        Assert.Equal("document", request.Destination);
+        Assert.Null(request.InitiatorType);
+        Assert.Equal(0u, request.HeadersSize);
+        Assert.Equal(0u, request.BodySize);
+        Assert.NotNull(request.Timings);
+        Assert.Equal(1, request.Timings.TimeOrigin);
+        Assert.Equal(2, request.Timings.RequestTime);
+        Assert.Equal(3, request.Timings.RedirectStart);
+        Assert.Equal(4, request.Timings.RedirectEnd);
+        Assert.Equal(5, request.Timings.FetchStart);
+        Assert.Equal(6, request.Timings.DnsStart);
+        Assert.Equal(7, request.Timings.DnsEnd);
+        Assert.Equal(8, request.Timings.ConnectStart);
+        Assert.Equal(9, request.Timings.ConnectEnd);
+        Assert.Equal(10, request.Timings.TlsStart);
+        Assert.Equal(11, request.Timings.RequestStart);
+        Assert.Equal(12, request.Timings.ResponseStart);
+        Assert.Equal(13, request.Timings.ResponseEnd);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -378,12 +367,12 @@ public class RequestDataTests
                       }
                       """;
         RequestData? request = JsonSerializer.Deserialize<RequestData>(json);
-        Assert.That(request, Is.Not.Null);
+        Assert.NotNull(request);
         RequestData copy = request with { };
-        Assert.That(copy, Is.EqualTo(request));
+        Assert.Equal(request, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingRequestIdThrows()
     {
         string json = """
@@ -413,10 +402,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'request"));
+        Assert.Contains("missing required properties including: 'request", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingUrlThrows()
     {
         string json = """
@@ -446,10 +435,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'url"));
+        Assert.Contains("missing required properties including: 'url", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingMethodThrows()
     {
         string json = """
@@ -479,10 +468,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'method"));
+        Assert.Contains("missing required properties including: 'method", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingHeadersThrows()
     {
         string json = """
@@ -512,10 +501,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'headers"));
+        Assert.Contains("missing required properties including: 'headers", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingCookiesThrows()
     {
         string json = """
@@ -545,10 +534,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'cookies"));
+        Assert.Contains("missing required properties including: 'cookies", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingHeadersSizeThrows()
     {
         string json = """
@@ -578,10 +567,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'headersSize"));
+        Assert.Contains("missing required properties including: 'headersSize", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingBodySizeThrows()
     {
         string json = """
@@ -611,10 +600,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'bodySize"));
+        Assert.Contains("missing required properties including: 'bodySize", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingDestinationThrows()
     {
         string json = """
@@ -644,10 +633,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'destination"));
+        Assert.Contains("missing required properties including: 'destination", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingInitiatorTypeThrows()
     {
         string json = """
@@ -677,10 +666,10 @@ public class RequestDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'initiatorType"));
+        Assert.Contains("missing required properties including: 'initiatorType", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingTimingsThrows()
     {
         string json = """
@@ -696,6 +685,6 @@ public class RequestDataTests
                         "bodySize": 0
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RequestData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'timings"));
+        Assert.Contains("missing required properties including: 'timings", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RequestData>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ResponseCompletedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ResponseCompletedEventArgsTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ResponseCompletedEventArgsTests
 {
     private readonly string requestDataJson = """
@@ -34,7 +33,7 @@ public class ResponseCompletedEventArgsTests
                                               }
                                               """;
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -76,25 +75,23 @@ public class ResponseCompletedEventArgsTests
                            }
                            """;
         ResponseCompletedEventArgs? eventArgs = JsonSerializer.Deserialize<ResponseCompletedEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            // Also proper ResponseData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-            Assert.That(eventArgs.Response, Is.Not.Null);
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal(milliseconds, eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        // Also proper ResponseData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
+        Assert.NotNull(eventArgs.Response);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -136,12 +133,12 @@ public class ResponseCompletedEventArgsTests
                            }
                            """;
         ResponseCompletedEventArgs? eventArgs = JsonSerializer.Deserialize<ResponseCompletedEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         ResponseCompletedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingResponseThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -157,6 +154,6 @@ public class ResponseCompletedEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseCompletedEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseCompletedEventArgs>(eventJson));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ResponseContentTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ResponseContentTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ResponseContentTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeResponseContent()
     {
         string json = """
@@ -14,14 +13,12 @@ public class ResponseContentTests
                       }
                       """;
         ResponseContent? responseContent = JsonSerializer.Deserialize<ResponseContent>(json);
-        Assert.That(responseContent, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(responseContent.Size, Is.EqualTo(300));
-        }
+        Assert.NotNull(responseContent);
+
+        Assert.Equal(300u, responseContent.Size);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -30,15 +27,15 @@ public class ResponseContentTests
                       }
                       """;
         ResponseContent? responseContent = JsonSerializer.Deserialize<ResponseContent>(json);
-        Assert.That(responseContent, Is.Not.Null);
+        Assert.NotNull(responseContent);
         ResponseContent copy = responseContent with { };
-        Assert.That(copy, Is.EqualTo(responseContent));
+        Assert.Equal(responseContent, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingSizeThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<ResponseContent>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'size"));
+        Assert.Contains("missing required properties including: 'size", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseContent>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ResponseDataTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ResponseDataTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ResponseDataTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeResponseData()
     {
         string json = """
@@ -26,26 +25,24 @@ public class ResponseDataTests
                       }
                       """;
         ResponseData? response = JsonSerializer.Deserialize<ResponseData>(json);
-        Assert.That(response, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(response.Url, Is.EqualTo("requestUrl"));
-            Assert.That(response.Protocol, Is.EqualTo("http"));
-            Assert.That(response.Status, Is.EqualTo(200));
-            Assert.That(response.StatusText, Is.EqualTo("OK"));
-            Assert.That(response.FromCache, Is.False);
-            Assert.That(response.Headers, Is.Empty);
-            Assert.That(response.MimeType, Is.EqualTo("text/html"));
-            Assert.That(response.BytesReceived, Is.EqualTo(400));
-            Assert.That(response.HeadersSize, Is.EqualTo(100));
-            Assert.That(response.BodySize, Is.EqualTo(300));
-            Assert.That(response.Content, Is.Not.Null);
-            Assert.That(response.Content.Size, Is.EqualTo(300));
-            Assert.That(response.AuthChallenges, Is.Null);
-        }
+        Assert.NotNull(response);
+
+        Assert.Equal("requestUrl", response.Url);
+        Assert.Equal("http", response.Protocol);
+        Assert.Equal(200u, response.Status);
+        Assert.Equal("OK", response.StatusText);
+        Assert.False(response.FromCache);
+        Assert.Empty(response.Headers);
+        Assert.Equal("text/html", response.MimeType);
+        Assert.Equal(400u, response.BytesReceived);
+        Assert.Equal(100u, response.HeadersSize);
+        Assert.Equal(300u, response.BodySize);
+        Assert.NotNull(response.Content);
+        Assert.Equal(300u, response.Content.Size);
+        Assert.Null(response.AuthChallenges);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeResponseDataWithHeaders()
     {
         string json = """
@@ -74,29 +71,27 @@ public class ResponseDataTests
                       }
                       """;
         ResponseData? response = JsonSerializer.Deserialize<ResponseData>(json);
-        Assert.That(response, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(response.Url, Is.EqualTo("requestUrl"));
-            Assert.That(response.Protocol, Is.EqualTo("http"));
-            Assert.That(response.Status, Is.EqualTo(200));
-            Assert.That(response.StatusText, Is.EqualTo("OK"));
-            Assert.That(response.FromCache, Is.False);
-            Assert.That(response.Headers, Has.Count.EqualTo(1));
-            Assert.That(response.Headers[0].Name, Is.EqualTo("headerName"));
-            Assert.That(response.Headers[0].Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(response.Headers[0].Value.Value, Is.EqualTo("headerValue"));
-            Assert.That(response.MimeType, Is.EqualTo("text/html"));
-            Assert.That(response.BytesReceived, Is.EqualTo(400));
-            Assert.That(response.HeadersSize, Is.EqualTo(100));
-            Assert.That(response.BodySize, Is.EqualTo(300));
-            Assert.That(response.Content, Is.Not.Null);
-            Assert.That(response.Content.Size, Is.EqualTo(300));
-            Assert.That(response.AuthChallenges, Is.Null);
-        }
+        Assert.NotNull(response);
+
+        Assert.Equal("requestUrl", response.Url);
+        Assert.Equal("http", response.Protocol);
+        Assert.Equal(200u, response.Status);
+        Assert.Equal("OK", response.StatusText);
+        Assert.False(response.FromCache);
+        Assert.Single(response.Headers);
+        Assert.Equal("headerName", response.Headers[0].Name);
+        Assert.Equal(BytesValueType.String, response.Headers[0].Value.Type);
+        Assert.Equal("headerValue", response.Headers[0].Value.Value);
+        Assert.Equal("text/html", response.MimeType);
+        Assert.Equal(400u, response.BytesReceived);
+        Assert.Equal(100u, response.HeadersSize);
+        Assert.Equal(300u, response.BodySize);
+        Assert.NotNull(response.Content);
+        Assert.Equal(300u, response.Content.Size);
+        Assert.Null(response.AuthChallenges);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeResponseDataWithNullHeadersSize()
     {
         string json = """
@@ -117,26 +112,24 @@ public class ResponseDataTests
                       }
                       """;
         ResponseData? response = JsonSerializer.Deserialize<ResponseData>(json);
-        Assert.That(response, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(response.Url, Is.EqualTo("requestUrl"));
-            Assert.That(response.Protocol, Is.EqualTo("http"));
-            Assert.That(response.Status, Is.EqualTo(200));
-            Assert.That(response.StatusText, Is.EqualTo("OK"));
-            Assert.That(response.FromCache, Is.False);
-            Assert.That(response.Headers, Is.Empty);
-            Assert.That(response.MimeType, Is.EqualTo("text/html"));
-            Assert.That(response.BytesReceived, Is.EqualTo(400));
-            Assert.That(response.HeadersSize, Is.Null);
-            Assert.That(response.BodySize, Is.EqualTo(300));
-            Assert.That(response.Content, Is.Not.Null);
-            Assert.That(response.Content.Size, Is.EqualTo(300));
-            Assert.That(response.AuthChallenges, Is.Null);
-        }
+        Assert.NotNull(response);
+
+        Assert.Equal("requestUrl", response.Url);
+        Assert.Equal("http", response.Protocol);
+        Assert.Equal(200u, response.Status);
+        Assert.Equal("OK", response.StatusText);
+        Assert.False(response.FromCache);
+        Assert.Empty(response.Headers);
+        Assert.Equal("text/html", response.MimeType);
+        Assert.Equal(400u, response.BytesReceived);
+        Assert.Null(response.HeadersSize);
+        Assert.Equal(300u, response.BodySize);
+        Assert.NotNull(response.Content);
+        Assert.Equal(300u, response.Content.Size);
+        Assert.Null(response.AuthChallenges);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeResponseDataWithNullBodySize()
     {
         string json = """
@@ -157,25 +150,23 @@ public class ResponseDataTests
                       }
                       """;
         ResponseData? response = JsonSerializer.Deserialize<ResponseData>(json);
-        Assert.That(response, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(response.Url, Is.EqualTo("requestUrl"));
-            Assert.That(response.Protocol, Is.EqualTo("http"));
-            Assert.That(response.Status, Is.EqualTo(200));
-            Assert.That(response.StatusText, Is.EqualTo("OK"));
-            Assert.That(response.FromCache, Is.False);
-            Assert.That(response.Headers, Is.Empty);
-            Assert.That(response.MimeType, Is.EqualTo("text/html"));
-            Assert.That(response.BytesReceived, Is.EqualTo(400));
-            Assert.That(response.HeadersSize, Is.EqualTo(100));
-            Assert.That(response.BodySize, Is.Null);
-            Assert.That(response.Content, Is.Not.Null);
-            Assert.That(response.Content.Size, Is.EqualTo(300));
-        }
+        Assert.NotNull(response);
+
+        Assert.Equal("requestUrl", response.Url);
+        Assert.Equal("http", response.Protocol);
+        Assert.Equal(200u, response.Status);
+        Assert.Equal("OK", response.StatusText);
+        Assert.False(response.FromCache);
+        Assert.Empty(response.Headers);
+        Assert.Equal("text/html", response.MimeType);
+        Assert.Equal(400u, response.BytesReceived);
+        Assert.Equal(100u, response.HeadersSize);
+        Assert.Null(response.BodySize);
+        Assert.NotNull(response.Content);
+        Assert.Equal(300u, response.Content.Size);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeResponseDataWithAuthChallenges()
     {
         string json = """
@@ -202,29 +193,27 @@ public class ResponseDataTests
                       }
                       """;
         ResponseData? response = JsonSerializer.Deserialize<ResponseData>(json);
-        Assert.That(response, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(response.Url, Is.EqualTo("requestUrl"));
-            Assert.That(response.Protocol, Is.EqualTo("http"));
-            Assert.That(response.Status, Is.EqualTo(200));
-            Assert.That(response.StatusText, Is.EqualTo("OK"));
-            Assert.That(response.FromCache, Is.False);
-            Assert.That(response.Headers, Is.Empty);
-            Assert.That(response.MimeType, Is.EqualTo("text/html"));
-            Assert.That(response.BytesReceived, Is.EqualTo(400));
-            Assert.That(response.HeadersSize, Is.EqualTo(100));
-            Assert.That(response.BodySize, Is.EqualTo(300));
-            Assert.That(response.Content, Is.Not.Null);
-            Assert.That(response.Content.Size, Is.EqualTo(300));
-            Assert.That(response.AuthChallenges, Is.Not.Null);
-            Assert.That(response.AuthChallenges, Has.Count.EqualTo(1));
-            Assert.That(response.AuthChallenges![0].Scheme, Is.EqualTo("basic"));
-            Assert.That(response.AuthChallenges[0]!.Realm, Is.EqualTo("example.com"));
-        }
+        Assert.NotNull(response);
+
+        Assert.Equal("requestUrl", response.Url);
+        Assert.Equal("http", response.Protocol);
+        Assert.Equal(200u, response.Status);
+        Assert.Equal("OK", response.StatusText);
+        Assert.False(response.FromCache);
+        Assert.Empty(response.Headers);
+        Assert.Equal("text/html", response.MimeType);
+        Assert.Equal(400u, response.BytesReceived);
+        Assert.Equal(100u, response.HeadersSize);
+        Assert.Equal(300u, response.BodySize);
+        Assert.NotNull(response.Content);
+        Assert.Equal(300u, response.Content.Size);
+        Assert.NotNull(response.AuthChallenges);
+        Assert.Single(response.AuthChallenges);
+        Assert.Equal("basic", response.AuthChallenges[0].Scheme);
+        Assert.Equal("example.com", response.AuthChallenges[0].Realm);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -245,12 +234,12 @@ public class ResponseDataTests
                       }
                       """;
         ResponseData? response = JsonSerializer.Deserialize<ResponseData>(json);
-        Assert.That(response, Is.Not.Null);
+        Assert.NotNull(response);
         ResponseData copy = response with { };
-        Assert.That(copy, Is.EqualTo(response));
+        Assert.Equal(response, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingUrlThrows()
     {
         string json = """
@@ -269,10 +258,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'url"));
+        Assert.Contains("missing required properties including: 'url", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingProtocolThrows()
     {
         string json = """
@@ -291,10 +280,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'protocol"));
+        Assert.Contains("missing required properties including: 'protocol", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingStatusThrows()
     {
         string json = """
@@ -313,10 +302,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'status"));
+        Assert.Contains("missing required properties including: 'status", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingStatusTextThrows()
     {
         string json = """
@@ -335,10 +324,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'statusText"));
+        Assert.Contains("missing required properties including: 'statusText", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingFromCacheThrows()
     {
         string json = """
@@ -357,10 +346,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'fromCache"));
+        Assert.Contains("missing required properties including: 'fromCache", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingHeadersThrows()
     {
         string json = """
@@ -379,10 +368,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'headers"));
+        Assert.Contains("missing required properties including: 'headers", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingMimeTypeThrows()
     {
         string json = """
@@ -401,10 +390,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'mimeType"));
+        Assert.Contains("missing required properties including: 'mimeType", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingBytesReceivedThrows()
     {
         string json = """
@@ -423,10 +412,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'bytesReceived"));
+        Assert.Contains("missing required properties including: 'bytesReceived", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingHeadersSizeThrows()
     {
         string json = """
@@ -445,10 +434,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'headersSize"));
+        Assert.Contains("missing required properties including: 'headersSize", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingBodySizeThrows()
     {
         string json = """
@@ -467,10 +456,10 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'bodySize"));
+        Assert.Contains("missing required properties including: 'bodySize", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingContentThrows()
     {
         string json = """
@@ -487,10 +476,10 @@ public class ResponseDataTests
                         "bodySize": 300
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'content"));
+        Assert.Contains("missing required properties including: 'content", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidAuthChallengesTypeThrows()
     {
         string json = """
@@ -514,10 +503,12 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted").And.Message.Contains("authChallenges"));
+        JsonException exception = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json));
+        Assert.Contains("JSON value could not be converted", exception.Message);
+        Assert.Contains("authChallenges", exception.Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidHeadersTypeThrows()
     {
         string json = """
@@ -537,6 +528,8 @@ public class ResponseDataTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseData>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted").And.Message.Contains("headers"));
+        JsonException exception = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseData>(json));
+        Assert.Contains("JSON value could not be converted", exception.Message);
+        Assert.Contains("headers", exception.Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/ResponseStartedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/ResponseStartedEventArgsTests.cs
@@ -2,7 +2,6 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ResponseStartedEventArgsTests
 {
     private readonly string requestDataJson = """
@@ -34,7 +33,7 @@ public class ResponseStartedEventArgsTests
                                              }
                                              """;
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow;
@@ -74,25 +73,23 @@ public class ResponseStartedEventArgsTests
                            }
                            """;
         ResponseStartedEventArgs? eventArgs = JsonSerializer.Deserialize<ResponseStartedEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.NavigationId, Is.EqualTo("myNavigationId"));
-            Assert.That(eventArgs.EpochTimestamp, Is.EqualTo(milliseconds));
-            Assert.That(eventArgs.Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddMilliseconds(milliseconds)));
-            Assert.That(eventArgs.RedirectCount, Is.EqualTo(0));
+        Assert.NotNull(eventArgs);
 
-            // Note that proper RequestData deserialization is tested elsewhere.
-            // Also proper ResponseData deserialization is tested elsewhere.
-            Assert.That(eventArgs.Request, Is.Not.Null);
-            Assert.That(eventArgs.IsBlocked, Is.False);
-            Assert.That(eventArgs.Intercepts, Is.Null);
-            Assert.That(eventArgs.Response, Is.Not.Null);
-        }
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("myNavigationId", eventArgs.NavigationId);
+        Assert.Equal(milliseconds, eventArgs.EpochTimestamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMilliseconds(milliseconds), eventArgs.Timestamp);
+        Assert.Equal(0u, eventArgs.RedirectCount);
+
+        // Note that proper RequestData deserialization is tested elsewhere.
+        // Also proper ResponseData deserialization is tested elsewhere.
+        Assert.NotNull(eventArgs.Request);
+        Assert.False(eventArgs.IsBlocked);
+        Assert.Null(eventArgs.Intercepts);
+        Assert.NotNull(eventArgs.Response);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow;
@@ -132,12 +129,12 @@ public class ResponseStartedEventArgsTests
                            }
                            """;
         ResponseStartedEventArgs? eventArgs = JsonSerializer.Deserialize<ResponseStartedEventArgs>(eventJson);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         ResponseStartedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingResponseThrows()
     {
         DateTime now = DateTime.UtcNow;
@@ -153,6 +150,6 @@ public class ResponseStartedEventArgsTests
                              "request": {{this.requestDataJson}}
                            }
                            """;
-        Assert.That(() => JsonSerializer.Deserialize<ResponseStartedEventArgs>(eventJson), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ResponseStartedEventArgs>(eventJson));
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/SetCacheBehaviorCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/SetCacheBehaviorCommandParametersTests.cs
@@ -1,65 +1,64 @@
 namespace WebDriverBiDi.Network;
 
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetCacheBehaviorCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetCacheBehaviorCommandParameters properties = new(CacheBehavior.Default);
-        Assert.That(properties.MethodName, Is.EqualTo("network.setCacheBehavior"));
+        Assert.Equal("network.setCacheBehavior", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetCacheBehaviorCommandParameters properties = new(CacheBehavior.Default);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("cacheBehavior"));
-            Assert.That(serialized["cacheBehavior"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["cacheBehavior"]!.Value<string>(), Is.EqualTo("default"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("cacheBehavior"));
+        JToken? cacheBehavior = serialized["cacheBehavior"];
+        Assert.NotNull(cacheBehavior);
+        Assert.Equal(JTokenType.String, cacheBehavior.Type);
+        Assert.Equal("default", cacheBehavior.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBypass()
     {
         SetCacheBehaviorCommandParameters properties = new(CacheBehavior.Bypass);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("cacheBehavior"));
-            Assert.That(serialized["cacheBehavior"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["cacheBehavior"]!.Value<string>(), Is.EqualTo("bypass"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("cacheBehavior"));
+        JToken? cacheBehavior = serialized["cacheBehavior"];
+        Assert.NotNull(cacheBehavior);
+        Assert.Equal(JTokenType.String, cacheBehavior.Type);
+        Assert.Equal("bypass", cacheBehavior.Value<string>());
     }
 
+    [Fact]
     public void TestCanSetCacheBehaviorViaProperty()
     {
         SetCacheBehaviorCommandParameters properties = new(CacheBehavior.Default);
         properties.CacheBehavior = CacheBehavior.Bypass;
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("cacheBehavior"));
-            Assert.That(serialized["cacheBehavior"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["cacheBehavior"]!.Value<string>(), Is.EqualTo("bypass"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("cacheBehavior"));
+        JToken? cacheBehavior = serialized["cacheBehavior"];
+        Assert.NotNull(cacheBehavior);
+        Assert.Equal(JTokenType.String, cacheBehavior.Type);
+        Assert.Equal("bypass", cacheBehavior.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithContexts()
     {
         SetCacheBehaviorCommandParameters properties = new(CacheBehavior.Default)
@@ -68,18 +67,22 @@ public class SetCacheBehaviorCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("cacheBehavior"));
-            Assert.That(serialized["cacheBehavior"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["cacheBehavior"]!.Value<string>(), Is.EqualTo("default"));
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray contextsObject = (JArray)serialized["contexts"]!;
-            Assert.That(contextsObject, Has.Count.EqualTo(1));
-            Assert.That(contextsObject[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsObject[0].Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("cacheBehavior"));
+        JToken? cacheBehavior = serialized["cacheBehavior"];
+        Assert.NotNull(cacheBehavior);
+        Assert.Equal(JTokenType.String, cacheBehavior.Type);
+        Assert.Equal("default", cacheBehavior.Value<string>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsObject = contextsToken as JArray;
+        Assert.NotNull(contextsObject);
+        Assert.Single(contextsObject);
+        Assert.Equal(JTokenType.String, contextsObject[0].Type);
+        Assert.Equal("myContext", contextsObject[0].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/SetCacheBehaviorCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/SetCacheBehaviorCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetCacheBehaviorCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetCacheBehaviorCommandResult? result = JsonSerializer.Deserialize<SetCacheBehaviorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetCacheBehaviorCommandResult? result = JsonSerializer.Deserialize<SetCacheBehaviorCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetCacheBehaviorCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/SetCookieHeaderTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/SetCookieHeaderTests.cs
@@ -3,61 +3,81 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-
-[TestFixture]
 public class SetCookieHeaderTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         SetCookieHeader cookieHeader = new();
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.Empty);
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.Empty);
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal(string.Empty, name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal(string.Empty, valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithConstructorValues()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue");
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithPropertySetValues()
     {
         SetCookieHeader cookieHeader = new()
@@ -67,26 +87,37 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithPropertySetAndBinaryValue()
     {
         byte[] cookieValue = new byte[] { 0x41, 0x42, 0x43 };
@@ -98,26 +129,37 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo(base64Value));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("base64", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal(base64Value, valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithDomain()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue")
@@ -126,29 +168,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myDomain"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myDomain", domain.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithPath()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue")
@@ -157,29 +213,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("path"));
-            Assert.That(serialized["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["path"]!.Value<string>(), Is.EqualTo("myPath"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("path"));
+        JToken? path = serialized["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myPath", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithHttpOnly()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue")
@@ -188,29 +258,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("httpOnly"));
-            Assert.That(serialized["httpOnly"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["httpOnly"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("httpOnly"));
+        JToken? httpOnly = serialized["httpOnly"];
+        Assert.NotNull(httpOnly);
+        Assert.Equal(JTokenType.Boolean, httpOnly.Type);
+        Assert.True(httpOnly.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithSecure()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue")
@@ -219,29 +303,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("secure"));
-            Assert.That(serialized["secure"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["secure"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("secure"));
+        JToken? secure = serialized["secure"];
+        Assert.NotNull(secure);
+        Assert.Equal(JTokenType.Boolean, secure.Type);
+        Assert.True(secure.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithSameSite()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue")
@@ -250,29 +348,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("sameSite"));
-            Assert.That(serialized["sameSite"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sameSite"]!.Value<string>(), Is.EqualTo("strict"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sameSite"));
+        JToken? sameSite = serialized["sameSite"];
+        Assert.NotNull(sameSite);
+        Assert.Equal(JTokenType.String, sameSite.Type);
+        Assert.Equal("strict", sameSite.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithExpires()
     {
         DateTime expirationTime = DateTime.Now.AddDays(3);
@@ -283,29 +395,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("expiry"));
-            Assert.That(serialized["expiry"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["expiry"]!.Value<string>(), Is.EqualTo(expected));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("expiry"));
+        JToken? expiry = serialized["expiry"];
+        Assert.NotNull(expiry);
+        Assert.Equal(JTokenType.String, expiry.Type);
+        Assert.Equal(expected, expiry.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithMaxAge()
     {
         SetCookieHeader cookieHeader = new("cookieName", "cookieValue")
@@ -314,29 +440,43 @@ public class SetCookieHeaderTests
         };
         string json = JsonSerializer.Serialize(cookieHeader);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject valueObject = (JObject)serialized["value"]!;
-            Assert.That(valueObject, Has.Count.EqualTo(2));
-            Assert.That(valueObject, Contains.Key("type"));
-            Assert.That(valueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(valueObject, Contains.Key("value"));
-            Assert.That(valueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(serialized, Contains.Key("maxAge"));
-            Assert.That(serialized["maxAge"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxAge"]!.Value<ulong>(), Is.EqualTo(100));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("cookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? valueToken = serialized["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.Object, valueToken.Type);
+        JObject? valueObject = valueToken.Value<JObject>();
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+
+        Assert.True(valueObject.ContainsKey("type"));
+        JToken? valueType = valueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("value"));
+        JToken? valueValue = valueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("cookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("maxAge"));
+        JToken? maxAge = serialized["maxAge"];
+        Assert.NotNull(maxAge);
+        Assert.Equal(JTokenType.Integer, maxAge.Type);
+        Assert.Equal(100UL, maxAge.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestConstructionWithCookie()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -344,20 +484,18 @@ public class SetCookieHeaderTests
         ulong milliseconds = Convert.ToUInt64(expireTime.Subtract(DateTime.UnixEpoch).TotalSeconds);
         string json = @"{ ""name"": ""cookieName"", ""value"":{ ""type"": ""string"", ""value"": ""cookieValue"" }, ""domain"": ""cookieDomain"", ""path"": ""/cookiePath"", ""secure"": false, ""httpOnly"": false, ""sameSite"": ""lax"", ""size"": 100, ""expiry"": " + milliseconds + @" }";
         Cookie? cookie = JsonSerializer.Deserialize<Cookie>(json);
-        Assert.That(cookie, Is.Not.Null);
+        Assert.NotNull(cookie);
         SetCookieHeader header = cookie.ToSetCookieHeader();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(header.Name, Is.EqualTo("cookieName"));
-            Assert.That(header.Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(header.Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(header.Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(header.Path, Is.EqualTo("/cookiePath"));
-            Assert.That(header.Secure, Is.False);
-            Assert.That(header.HttpOnly, Is.False);
-            Assert.That(header.SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(header.Expires, Is.EqualTo(expireTime));
-            Assert.That(header.MaxAge, Is.Null);
-        }
+
+        Assert.Equal("cookieName", header.Name);
+        Assert.Equal(BytesValueType.String, header.Value.Type);
+        Assert.Equal("cookieValue", header.Value.Value);
+        Assert.Equal("cookieDomain", header.Domain);
+        Assert.Equal("/cookiePath", header.Path);
+        Assert.False(header.Secure);
+        Assert.False(header.HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, header.SameSite);
+        Assert.Equal(expireTime, header.Expires);
+        Assert.Null(header.MaxAge);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/SetExtraHeadersCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/SetExtraHeadersCommandParametersTests.cs
@@ -3,32 +3,33 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetExtraHeadersCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetExtraHeadersCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("network.setExtraHeaders"));
+        Assert.Equal("network.setExtraHeaders", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetExtraHeadersCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["headers"], Is.Empty);
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headersArray = headersToken as JArray;
+        Assert.NotNull(headersArray);
+        Assert.Empty(headersArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSetHeadersUsingProperty()
     {
         SetExtraHeadersCommandParameters properties = new()
@@ -37,20 +38,20 @@ public class SetExtraHeadersCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray headersArray = (JArray)serialized["headers"]!;
-            Assert.That(headersArray, Has.Count.EqualTo(1));
-            Assert.That(headersArray[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headersArray[0].Value<string>(), Is.EqualTo("X-Extra-Header: headerValue"));
-        }
 
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headersArray = headersToken as JArray;
+        Assert.NotNull(headersArray);
+        Assert.Single(headersArray);
+        Assert.Equal(JTokenType.String, headersArray[0].Type);
+        Assert.Equal("X-Extra-Header: headerValue", headersArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithContexts()
     {
         SetExtraHeadersCommandParameters properties = new()
@@ -60,23 +61,29 @@ public class SetExtraHeadersCommandParametersTests
         properties.Headers.Add("X-Extra-Header: headerValue");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray headersArray = (JArray)serialized["headers"]!;
-            Assert.That(headersArray, Has.Count.EqualTo(1));
-            Assert.That(headersArray[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headersArray[0].Value<string>(), Is.EqualTo("X-Extra-Header: headerValue"));
-            JArray contextsObject = (JArray)serialized["contexts"]!;
-            Assert.That(contextsObject, Has.Count.EqualTo(1));
-            Assert.That(contextsObject[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsObject[0].Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headersArray = headersToken as JArray;
+        Assert.NotNull(headersArray);
+        Assert.Single(headersArray);
+        Assert.Equal(JTokenType.String, headersArray[0].Type);
+        Assert.Equal("X-Extra-Header: headerValue", headersArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        JArray? contextsObject = contextsToken as JArray;
+        Assert.NotNull(contextsObject);
+        Assert.Single(contextsObject);
+        Assert.Equal(JTokenType.String, contextsObject[0].Type);
+        Assert.Equal("myContext", contextsObject[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithUserContexts()
     {
         SetExtraHeadersCommandParameters properties = new()
@@ -86,42 +93,50 @@ public class SetExtraHeadersCommandParametersTests
         properties.Headers.Add("X-Extra-Header: headerValue");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray headersArray = (JArray)serialized["headers"]!;
-            Assert.That(headersArray, Has.Count.EqualTo(1));
-            Assert.That(headersArray[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(headersArray[0].Value<string>(), Is.EqualTo("X-Extra-Header: headerValue"));
-            JArray contextsObject = (JArray)serialized["userContexts"]!;
-            Assert.That(contextsObject, Has.Count.EqualTo(1));
-            Assert.That(contextsObject[0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsObject[0].Value<string>(), Is.EqualTo("myUserContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headersArray = headersToken as JArray;
+        Assert.NotNull(headersArray);
+        Assert.Single(headersArray);
+        Assert.Equal(JTokenType.String, headersArray[0].Type);
+        Assert.Equal("X-Extra-Header: headerValue", headersArray[0].Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        JArray? contextsObject = userContextsToken as JArray;
+        Assert.NotNull(contextsObject);
+        Assert.Single(contextsObject);
+        Assert.Equal(JTokenType.String, contextsObject[0].Type);
+        Assert.Equal("myUserContext", contextsObject[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetExtraHeadersCommandParameters properties = SetExtraHeadersCommandParameters.ResetExtraHeaders;
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("headers"));
-            Assert.That(serialized["headers"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["headers"], Is.Empty);
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("headers"));
+        JToken? headersToken = serialized["headers"];
+        Assert.NotNull(headersToken);
+        Assert.Equal(JTokenType.Array, headersToken.Type);
+        JArray? headersArray = headersToken as JArray;
+        Assert.NotNull(headersArray);
+        Assert.Empty(headersArray);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetExtraHeadersCommandParameters firstInstance = SetExtraHeadersCommandParameters.ResetExtraHeaders;
         SetExtraHeadersCommandParameters secondInstance = SetExtraHeadersCommandParameters.ResetExtraHeaders;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/SetExtraHeadersCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/SetExtraHeadersCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Network;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetExtraHeadersCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetExtraHeadersCommandResult? result = JsonSerializer.Deserialize<SetExtraHeadersCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetExtraHeadersCommandResult? result = JsonSerializer.Deserialize<SetExtraHeadersCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetExtraHeadersCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/UrlPatternPatternTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/UrlPatternPatternTests.cs
@@ -3,25 +3,25 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class UrlPatternPatternTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeValue()
     {
         UrlPattern value = new UrlPatternPattern();
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pattern"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pattern", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeValueWithProtocol()
     {
         UrlPattern value = new UrlPatternPattern()
@@ -30,19 +30,23 @@ public class UrlPatternPatternTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pattern"));
-            Assert.That(serialized, Contains.Key("protocol"));
-            Assert.That(serialized["protocol"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["protocol"]!.Value<string>(), Is.EqualTo("https"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pattern", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("protocol"));
+        JToken? protocol = serialized["protocol"];
+        Assert.NotNull(protocol);
+        Assert.Equal(JTokenType.String, protocol.Type);
+        Assert.Equal("https", protocol.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeValueWithHostName()
     {
         UrlPattern value = new UrlPatternPattern()
@@ -51,19 +55,23 @@ public class UrlPatternPatternTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pattern"));
-            Assert.That(serialized, Contains.Key("hostname"));
-            Assert.That(serialized["hostname"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["hostname"]!.Value<string>(), Is.EqualTo("example.com"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pattern", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("hostname"));
+        JToken? hostname = serialized["hostname"];
+        Assert.NotNull(hostname);
+        Assert.Equal(JTokenType.String, hostname.Type);
+        Assert.Equal("example.com", hostname.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeValueWithPort()
     {
         UrlPattern value = new UrlPatternPattern()
@@ -72,19 +80,23 @@ public class UrlPatternPatternTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pattern"));
-            Assert.That(serialized, Contains.Key("port"));
-            Assert.That(serialized["port"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["port"]!.Value<string>(), Is.EqualTo("2222"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pattern", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("port"));
+        JToken? port = serialized["port"];
+        Assert.NotNull(port);
+        Assert.Equal(JTokenType.String, port.Type);
+        Assert.Equal("2222", port.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeValueWithPathName()
     {
         UrlPattern value = new UrlPatternPattern()
@@ -93,19 +105,23 @@ public class UrlPatternPatternTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pattern"));
-            Assert.That(serialized, Contains.Key("pathname"));
-            Assert.That(serialized["pathname"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["pathname"]!.Value<string>(), Is.EqualTo("/data/*"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pattern", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("pathname"));
+        JToken? pathname = serialized["pathname"];
+        Assert.NotNull(pathname);
+        Assert.Equal(JTokenType.String, pathname.Type);
+        Assert.Equal("/data/*", pathname.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeValueWithSearch()
     {
         UrlPattern value = new UrlPatternPattern()
@@ -114,15 +130,19 @@ public class UrlPatternPatternTests
         };
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("pattern"));
-            Assert.That(serialized, Contains.Key("search"));
-            Assert.That(serialized["search"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["search"]!.Value<string>(), Is.EqualTo("?user=foo"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("pattern", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("search"));
+        JToken? search = serialized["search"];
+        Assert.NotNull(search);
+        Assert.Equal(JTokenType.String, search.Type);
+        Assert.Equal("?user=foo", search.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Network/UrlPatternStringTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/UrlPatternStringTests.cs
@@ -3,42 +3,49 @@ namespace WebDriverBiDi.Network;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class UrlPatternStringTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeValue()
     {
         UrlPattern value = new UrlPatternString("https://example.com/*");
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(serialized, Contains.Key("pattern"));
-            Assert.That(serialized["pattern"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["pattern"]!.Value<string>(), Is.EqualTo("https://example.com/*"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("string", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("pattern"));
+        JToken? pattern = serialized["pattern"];
+        Assert.NotNull(pattern);
+        Assert.Equal(JTokenType.String, pattern.Type);
+        Assert.Equal("https://example.com/*", pattern.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeValueWithDefaultConstructor()
     {
         UrlPattern value = new UrlPatternString();
         string json = JsonSerializer.Serialize(value);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(serialized, Contains.Key("pattern"));
-            Assert.That(serialized["pattern"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["pattern"]!.Value<string>(), Is.EqualTo(string.Empty));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("string", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("pattern"));
+        JToken? pattern = serialized["pattern"];
+        Assert.NotNull(pattern);
+        Assert.Equal(JTokenType.String, pattern.Type);
+        Assert.Equal(string.Empty, pattern.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/ObservableEventExtensionsTests.cs
+++ b/test/WebDriverBiDi.Tests/ObservableEventExtensionsTests.cs
@@ -2,18 +2,17 @@ namespace WebDriverBiDi;
 
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class ObservableEventExtensionsTests
 {
-    [Test]
-    public void TestToObservableReturnsIObservable()
+    [Fact]
+    public async Task TestToObservableReturnsIObservable()
     {
         TestEventSource testEventSource = new();
         IObservable<TestObservableEventArgs> observable = testEventSource.TestObservableEvent.ToObservable();
-        Assert.That(observable, Is.Not.Null);
+        Assert.NotNull(observable);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSubscribeReceivesRaisedEvents()
     {
         TestEventSource testEventSource = new();
@@ -33,29 +32,26 @@ public class ObservableEventExtensionsTests
 
         await testEventSource.RaiseTestEventAsync("value1");
         await testEventSource.RaiseTestEventAsync("value2");
-        await twoReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await twoReceived.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(received, Has.Count.EqualTo(2));
-            Assert.That(received[0], Is.EqualTo("value1"));
-            Assert.That(received[1], Is.EqualTo("value2"));
-        }
+        Assert.Equal(2, received.Count);
+        Assert.Equal("value1", received[0]);
+        Assert.Equal("value2", received[1]);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSubscribeReturnsIDisposable()
     {
         TestEventSource testEventSource = new();
         IObservable<TestObservableEventArgs> observable = testEventSource.TestObservableEvent.ToObservable();
         IDisposable subscription = observable.Subscribe(new DelegateObserver<TestObservableEventArgs>());
-        Assert.That(subscription, Is.Not.Null);
-        Assert.That(subscription, Is.InstanceOf<IDisposable>());
+        Assert.NotNull(subscription);
+        Assert.IsType<IDisposable>(subscription, exactMatch: false);
         await testEventSource.TestObservableEvent.InvokeNotifyObserversAsync(new TestObservableEventArgs("value"));
         subscription.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposingSubscriptionCallsOnCompleted()
     {
         TestEventSource testEventSource = new();
@@ -66,12 +62,12 @@ public class ObservableEventExtensionsTests
             onCompleted: () => completed.TrySetResult(true)));
 
         subscription.Dispose();
-        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.That(completed.Task.IsCompletedSuccessfully, Is.True);
+        Assert.True(completed.Task.IsCompletedSuccessfully);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposingSubscriptionStopsDeliveringEvents()
     {
         TestEventSource testEventSource = new();
@@ -85,17 +81,17 @@ public class ObservableEventExtensionsTests
 
         await testEventSource.RaiseTestEventAsync("before");
         subscription.Dispose();
-        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         int countAfterDispose = received.Count;
         await testEventSource.RaiseTestEventAsync("after");
 
         // Give the background task a moment to deliver any extra items (it should not)
-        await Task.Delay(50);
-        Assert.That(received, Has.Count.EqualTo(countAfterDispose));
+        await Task.Delay(TimeSpan.FromMicroseconds(50), TestContext.Current.CancellationToken);
+        Assert.Equal(countAfterDispose, received.Count);
     }
 
-    [Test]
+    [Fact]
     public async Task TestOnErrorCalledWhenOnNextThrows()
     {
         TestEventSource testEventSource = new();
@@ -108,12 +104,12 @@ public class ObservableEventExtensionsTests
             onError: ex => errorReceived.TrySetResult(ex)));
 
         await testEventSource.RaiseTestEventAsync("value");
-        Exception received = await errorReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Exception received = await errorReceived.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.That(received, Is.SameAs(thrown));
+        Assert.Same(thrown, received);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMultipleSubscribersEachReceiveAllEvents()
     {
         TestEventSource testEventSource = new();
@@ -147,17 +143,14 @@ public class ObservableEventExtensionsTests
         await testEventSource.RaiseTestEventAsync("value1");
         await testEventSource.RaiseTestEventAsync("value2");
         await Task.WhenAll(
-            sub1Done.Task.WaitAsync(TimeSpan.FromSeconds(5)),
-            sub2Done.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            sub1Done.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            sub2Done.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(received1, Has.Count.EqualTo(2));
-            Assert.That(received2, Has.Count.EqualTo(2));
-        }
+        Assert.Equal(2, received1.Count);
+        Assert.Equal(2, received2.Count);
     }
 
-    [Test]
+    [Fact]
     public async Task TestToObservableOnSameSourceProducesIndependentObservables()
     {
         TestEventSource testEventSource = new();
@@ -174,14 +167,11 @@ public class ObservableEventExtensionsTests
 
         await testEventSource.RaiseTestEventAsync("value");
         await Task.WhenAll(
-            result1.Task.WaitAsync(TimeSpan.FromSeconds(5)),
-            result2.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            result1.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            result2.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result1.Task.Result, Is.EqualTo("value"));
-            Assert.That(result2.Task.Result, Is.EqualTo("value"));
-        }
+        Assert.Equal("value", await result1.Task);
+        Assert.Equal("value", await result2.Task);
     }
 
     /// <summary>

--- a/test/WebDriverBiDi.Tests/ObservableEventNameAttributeTests.cs
+++ b/test/WebDriverBiDi.Tests/ObservableEventNameAttributeTests.cs
@@ -1,12 +1,11 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class ObservableEventNameAttributeTests
 {
-    [Test]
+    [Fact]
     public void TestCanGetEventName()
     {
         ObservableEventNameAttribute attribute = new("test event name");
-        Assert.That(attribute.EventName, Is.EqualTo("test event name"));
+        Assert.Equal("test event name", attribute.EventName);
     }
 }

--- a/test/WebDriverBiDi.Tests/ObservableEventTests.cs
+++ b/test/WebDriverBiDi.Tests/ObservableEventTests.cs
@@ -8,7 +8,7 @@ public class ObservableEventTests
     public async Task TestCanAddHandler()
     {
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((e) => { });
+        testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
     }
 
@@ -25,7 +25,7 @@ public class ObservableEventTests
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
-        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
+        EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
         await testEventSource.RaiseTestEventAsync("myValue1");
         Assert.NotNull(observedValue);
         Assert.Equal("myValue1", observedValue);
@@ -41,19 +41,19 @@ public class ObservableEventTests
         TestEventSource testEventSource = new(1);
         Assert.Equal(1u, testEventSource.TestObservableEvent.MaxObserverCount);
         Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
-        WebDriverBiDiException exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }));
+        WebDriverBiDiException exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver(e => { }));
         Assert.Equal("This observable event only allows 1 observer.", exception.Message);
 
         testEventSource = new(2);
         Assert.Equal(2u, testEventSource.TestObservableEvent.MaxObserverCount);
         Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.Equal(2, testEventSource.TestObservableEvent.CurrentObserverCount);
-        exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }));
+        exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver(e => { }));
         Assert.Equal("This observable event only allows 2 observers.", exception.Message);
     }
 
@@ -83,11 +83,11 @@ public class ObservableEventTests
         TestEventSource testEventSource = new(2);
         Assert.Equal(2u, testEventSource.TestObservableEvent.MaxObserverCount);
         Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        testEventSource.TestObservableEvent.AddObserver(e => { });
         Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddDataCollector();
         Assert.Equal(2, testEventSource.TestObservableEvent.CurrentObserverCount);
-        WebDriverBiDiException exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }));
+        WebDriverBiDiException exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver(e => { }));
         Assert.Equal("This observable event only allows 2 observers.", exception.Message);
         Assert.Equal("This observable event only allows 2 observers.", Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddDataCollector()).Message);
     }
@@ -96,7 +96,7 @@ public class ObservableEventTests
     public async Task TestToStringReturnsDescriptionForEventObserver()
     {
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }, ObservableEventHandlerOptions.RunHandlerSynchronously, "My first handler");
+        testEventSource.TestObservableEvent.AddObserver(e => { }, ObservableEventHandlerOptions.RunHandlerSynchronously, "My first handler");
         string eventSourceString = testEventSource.TestObservableEvent.ToString();
         Assert.Equal("ObservableEvent<TestObservableEventArgs> with observers:\n    My first handler", eventSourceString);
     }
@@ -105,7 +105,7 @@ public class ObservableEventTests
     public async Task TestToStringReturnsDefaultDescriptionForEventObserver()
     {
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
+        testEventSource.TestObservableEvent.AddObserver(e => { });
         string eventSourceString = testEventSource.TestObservableEvent.ToString();
         Assert.StartsWith("ObservableEvent<TestObservableEventArgs> with observers:\n    EventObserver<TestObservableEventArgs> (id:", eventSourceString);
     }
@@ -140,8 +140,8 @@ public class ObservableEventTests
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => throw new InvalidOperationException("observer failure"));
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
+        testEventSource.TestObservableEvent.AddObserver(e => throw new InvalidOperationException("observer failure"));
+        testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
 
         Assert.Equal("observer failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await testEventSource.RaiseTestEventAsync("myValue"))).Message);
         Assert.Equal("myValue", observedValue);
@@ -151,8 +151,8 @@ public class ObservableEventTests
     public async Task TestMultipleThrowingObserversProduceAggregateException()
     {
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => throw new InvalidOperationException("first failure"));
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => throw new ArgumentException("second failure"));
+        testEventSource.TestObservableEvent.AddObserver(e => throw new InvalidOperationException("first failure"));
+        testEventSource.TestObservableEvent.AddObserver(e => throw new ArgumentException("second failure"));
 
         AggregateException? caught = null;
         try
@@ -178,11 +178,11 @@ public class ObservableEventTests
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) =>
+        testEventSource.TestObservableEvent.AddObserver(e =>
         {
             return Task.FromException(new InvalidOperationException("async observer failure"));
         });
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
+        testEventSource.TestObservableEvent.AddObserver(e => observedValue = e.EventValue);
 
         Assert.Equal("async observer failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await testEventSource.RaiseTestEventAsync("myValue"))).Message);
         Assert.Equal("myValue", observedValue);
@@ -194,8 +194,8 @@ public class ObservableEventTests
         string? firstValue = null;
         string? secondValue = null;
         TestEventSource testEventSource = new();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => firstValue = e.EventValue);
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => secondValue = e.EventValue);
+        testEventSource.TestObservableEvent.AddObserver(e => firstValue = e.EventValue);
+        testEventSource.TestObservableEvent.AddObserver(e => secondValue = e.EventValue);
 
         await testEventSource.RaiseTestEventAsync("myValue");
 
@@ -209,7 +209,7 @@ public class ObservableEventTests
         int capturedEventDataCount = 0;
         TestEventSource testEventSource = new();
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
-        testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => capturedEventDataCount = collector.GetCollectedEventData().Count);
+        testEventSource.TestObservableEvent.AddObserver(e => capturedEventDataCount = collector.GetCollectedEventData().Count);
         await testEventSource.RaiseTestEventAsync("myValue1");
         Assert.Equal(1, capturedEventDataCount);
     }

--- a/test/WebDriverBiDi.Tests/ObservableEventTests.cs
+++ b/test/WebDriverBiDi.Tests/ObservableEventTests.cs
@@ -2,138 +2,140 @@ namespace WebDriverBiDi;
 
 using TestUtilities;
 
-[TestFixture]
 public class ObservableEventTests
 {
-    [Test]
-    public void TestCanAddHandler()
+    [Fact]
+    public async Task TestCanAddHandler()
     {
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver((e) => { });
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
     }
 
-    [Test]
-    public void TestCanAddEventDataCollector()
+    [Fact]
+    public async Task TestCanAddEventDataCollector()
     {
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddDataCollector();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanRemoveObservableEventHandler()
     {
         string? observedValue = null;
         TestEventSource testEventSource = new();
         EventObserver<TestObservableEventArgs> observer = testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
         await testEventSource.RaiseTestEventAsync("myValue1");
-        Assert.That(observedValue, Is.Not.Null);
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.NotNull(observedValue);
+        Assert.Equal("myValue1", observedValue);
 
         observer.Unobserve();
         await testEventSource.RaiseTestEventAsync("myValue2");
-        Assert.That(observedValue, Is.EqualTo("myValue1"));
+        Assert.Equal("myValue1", observedValue);
     }
 
-    [Test]
-    public void TestCannotAddMoreThanMaxObserversUsingStandardObservers()
+    [Fact]
+    public async Task TestCannotAddMoreThanMaxObserversUsingStandardObservers()
     {
         TestEventSource testEventSource = new(1);
-        Assert.That(testEventSource.TestObservableEvent.MaxObserverCount, Is.EqualTo(1));
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.Equal(1u, testEventSource.TestObservableEvent.MaxObserverCount);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
-        Assert.That(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("This observable event only allows 1 observer."));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
+        WebDriverBiDiException exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }));
+        Assert.Equal("This observable event only allows 1 observer.", exception.Message);
 
         testEventSource = new(2);
-        Assert.That(testEventSource.TestObservableEvent.MaxObserverCount, Is.EqualTo(2));
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.Equal(2u, testEventSource.TestObservableEvent.MaxObserverCount);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(2));
-        Assert.That(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("This observable event only allows 2 observers."));
+        Assert.Equal(2, testEventSource.TestObservableEvent.CurrentObserverCount);
+        exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }));
+        Assert.Equal("This observable event only allows 2 observers.", exception.Message);
     }
 
-    [Test]
-    public void TestCannotAddMoreThanMaxObserversUsingEventDataCollectors()
+    [Fact]
+    public async Task TestCannotAddMoreThanMaxObserversUsingEventDataCollectors()
     {
         TestEventSource testEventSource = new(1);
-        Assert.That(testEventSource.TestObservableEvent.MaxObserverCount, Is.EqualTo(1));
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.Equal(1u, testEventSource.TestObservableEvent.MaxObserverCount);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddDataCollector();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
-        Assert.That(() => testEventSource.TestObservableEvent.AddDataCollector(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("This observable event only allows 1 observer."));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
+        Assert.Equal("This observable event only allows 1 observer.", Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddDataCollector()).Message);
 
         testEventSource = new(2);
-        Assert.That(testEventSource.TestObservableEvent.MaxObserverCount, Is.EqualTo(2));
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.Equal(2u, testEventSource.TestObservableEvent.MaxObserverCount);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddDataCollector();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddDataCollector();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(2));
-        Assert.That(() => testEventSource.TestObservableEvent.AddDataCollector(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("This observable event only allows 2 observers."));
+        Assert.Equal(2, testEventSource.TestObservableEvent.CurrentObserverCount);
+        Assert.Equal("This observable event only allows 2 observers.", Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddDataCollector()).Message);
     }
 
-    [Test]
-    public void TestCannotAddMoreThanMaxObserversUsingMixedObservers()
+    [Fact]
+    public async Task TestCannotAddMoreThanMaxObserversUsingMixedObservers()
     {
         TestEventSource testEventSource = new(2);
-        Assert.That(testEventSource.TestObservableEvent.MaxObserverCount, Is.EqualTo(2));
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(0));
+        Assert.Equal(2u, testEventSource.TestObservableEvent.MaxObserverCount);
+        Assert.Equal(0, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(1));
+        Assert.Equal(1, testEventSource.TestObservableEvent.CurrentObserverCount);
         testEventSource.TestObservableEvent.AddDataCollector();
-        Assert.That(testEventSource.TestObservableEvent.CurrentObserverCount, Is.EqualTo(2));
-        Assert.That(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("This observable event only allows 2 observers."));
-        Assert.That(() => testEventSource.TestObservableEvent.AddDataCollector(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("This observable event only allows 2 observers."));
+        Assert.Equal(2, testEventSource.TestObservableEvent.CurrentObserverCount);
+        WebDriverBiDiException exception = Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }));
+        Assert.Equal("This observable event only allows 2 observers.", exception.Message);
+        Assert.Equal("This observable event only allows 2 observers.", Assert.ThrowsAny<WebDriverBiDiException>(() => testEventSource.TestObservableEvent.AddDataCollector()).Message);
     }
 
-    [Test]
-    public void TestToStringReturnsDescriptionForEventObserver()
+    [Fact]
+    public async Task TestToStringReturnsDescriptionForEventObserver()
     {
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { }, ObservableEventHandlerOptions.RunHandlerSynchronously, "My first handler");
         string eventSourceString = testEventSource.TestObservableEvent.ToString();
-        Assert.That(eventSourceString, Is.EqualTo("ObservableEvent<TestObservableEventArgs> with observers:\n    My first handler"));
+        Assert.Equal("ObservableEvent<TestObservableEventArgs> with observers:\n    My first handler", eventSourceString);
     }
 
-    [Test]
-    public void TestToStringReturnsDefaultDescriptionForEventObserver()
+    [Fact]
+    public async Task TestToStringReturnsDefaultDescriptionForEventObserver()
     {
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => { });
         string eventSourceString = testEventSource.TestObservableEvent.ToString();
-        Assert.That(eventSourceString, Does.StartWith("ObservableEvent<TestObservableEventArgs> with observers:\n    EventObserver<TestObservableEventArgs> (id:"));
+        Assert.StartsWith("ObservableEvent<TestObservableEventArgs> with observers:\n    EventObserver<TestObservableEventArgs> (id:", eventSourceString);
     }
 
-    [Test]
-    public void TestToStringReturnsDescriptionForEventDataCollector()
+    [Fact]
+    public async Task TestToStringReturnsDescriptionForEventDataCollector()
     {
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddDataCollector(description: "My first collector");
         string eventSourceString = testEventSource.TestObservableEvent.ToString();
-        Assert.That(eventSourceString, Is.EqualTo("ObservableEvent<TestObservableEventArgs> with observers:\n    My first collector"));
+        Assert.Equal("ObservableEvent<TestObservableEventArgs> with observers:\n    My first collector", eventSourceString);
     }
 
-    [Test]
-    public void TestToStringReturnsDefaultDescriptionForEventDataCollector()
+    [Fact]
+    public async Task TestToStringReturnsDefaultDescriptionForEventDataCollector()
     {
         TestEventSource testEventSource = new();
         testEventSource.TestObservableEvent.AddDataCollector();
         string eventSourceString = testEventSource.TestObservableEvent.ToString();
-        Assert.That(eventSourceString, Does.StartWith("ObservableEvent<TestObservableEventArgs> with observers:\n    EventDataCollector<TestObservableEventArgs> (id:"));
+        Assert.StartsWith("ObservableEvent<TestObservableEventArgs> with observers:\n    EventDataCollector<TestObservableEventArgs> (id:", eventSourceString);
     }
 
-    [Test]
-    public void TestEventName()
+    [Fact]
+    public async Task TestEventName()
     {
         TestEventSource testEventSource = new();
-        Assert.That(testEventSource.TestObservableEvent.EventName, Is.EqualTo("testModule.testEvent"));
+        Assert.Equal("testModule.testEvent", testEventSource.TestObservableEvent.EventName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestThrowingObserverDoesNotPreventSubsequentObserversFromBeingNotified()
     {
         string? observedValue = null;
@@ -141,11 +143,11 @@ public class ObservableEventTests
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => throw new InvalidOperationException("observer failure"));
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
 
-        Assert.That(async () => await testEventSource.RaiseTestEventAsync("myValue"), Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("observer failure"));
-        Assert.That(observedValue, Is.EqualTo("myValue"));
+        Assert.Equal("observer failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await testEventSource.RaiseTestEventAsync("myValue"))).Message);
+        Assert.Equal("myValue", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMultipleThrowingObserversProduceAggregateException()
     {
         TestEventSource testEventSource = new();
@@ -162,18 +164,16 @@ public class ObservableEventTests
             caught = ex;
         }
 
-        Assert.That(caught, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(caught!.InnerExceptions, Has.Count.EqualTo(2));
-            Assert.That(caught.InnerExceptions[0], Is.InstanceOf<InvalidOperationException>());
-            Assert.That(caught.InnerExceptions[0].Message, Is.EqualTo("first failure"));
-            Assert.That(caught.InnerExceptions[1], Is.InstanceOf<ArgumentException>());
-            Assert.That(caught.InnerExceptions[1].Message, Is.EqualTo("second failure"));
-        }
+        Assert.NotNull(caught);
+
+        Assert.Equal(2, caught.InnerExceptions.Count);
+        Assert.IsType<InvalidOperationException>(caught.InnerExceptions[0]);
+        Assert.Equal("first failure", caught.InnerExceptions[0].Message);
+        Assert.IsType<ArgumentException>(caught.InnerExceptions[1]);
+        Assert.Equal("second failure", caught.InnerExceptions[1].Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestThrowingAsyncObserverDoesNotPreventSubsequentObserversFromBeingNotified()
     {
         string? observedValue = null;
@@ -184,11 +184,11 @@ public class ObservableEventTests
         });
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => observedValue = e.EventValue);
 
-        Assert.That(async () => await testEventSource.RaiseTestEventAsync("myValue"), Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("async observer failure"));
-        Assert.That(observedValue, Is.EqualTo("myValue"));
+        Assert.Equal("async observer failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await testEventSource.RaiseTestEventAsync("myValue"))).Message);
+        Assert.Equal("myValue", observedValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestNoExceptionThrownWhenAllObserversSucceed()
     {
         string? firstValue = null;
@@ -197,15 +197,13 @@ public class ObservableEventTests
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => firstValue = e.EventValue);
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => secondValue = e.EventValue);
 
-        Assert.That(async () => await testEventSource.RaiseTestEventAsync("myValue"), Throws.Nothing);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(firstValue, Is.EqualTo("myValue"));
-            Assert.That(secondValue, Is.EqualTo("myValue"));
-        }
+        await testEventSource.RaiseTestEventAsync("myValue");
+
+        Assert.Equal("myValue", firstValue);
+        Assert.Equal("myValue", secondValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDataCollectorsExecuteBeforeHandlers()
     {
         int capturedEventDataCount = 0;
@@ -213,6 +211,6 @@ public class ObservableEventTests
         EventDataCollector<TestObservableEventArgs> collector = testEventSource.TestObservableEvent.AddDataCollector();
         testEventSource.TestObservableEvent.AddObserver((TestObservableEventArgs e) => capturedEventDataCount = collector.GetCollectedEventData().Count);
         await testEventSource.RaiseTestEventAsync("myValue1");
-        Assert.That(capturedEventDataCount, Is.EqualTo(1));
+        Assert.Equal(1, capturedEventDataCount);
     }
 }

--- a/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
@@ -21,7 +21,7 @@ public class PermissionsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         PermissionsModule module = driver.Permissions;
 
         Task<SetPermissionCommandResult> task = module.SetPermissionAsync(new SetPermissionCommandParameters("myPermission", PermissionState.Granted, "https://example.com"), cancellationToken: TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Permissions;
 
 using TestUtilities;
 
-[TestFixture]
 public class PermissionsModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecuteSetPermissionCommand()
     {
         TestWebSocketConnection connection = new();
@@ -22,13 +21,12 @@ public class PermissionsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         PermissionsModule module = driver.Permissions;
 
-        Task<SetPermissionCommandResult> task = module.SetPermissionAsync(new SetPermissionCommandParameters("myPermission", PermissionState.Granted, "https://example.com"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetPermissionCommandResult result = task.Result;
+        Task<SetPermissionCommandResult> task = module.SetPermissionAsync(new SetPermissionCommandParameters("myPermission", PermissionState.Granted, "https://example.com"), cancellationToken: TestContext.Current.CancellationToken);
+        SetPermissionCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
@@ -20,7 +20,7 @@ public class PermissionsModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         PermissionsModule module = driver.Permissions;
 

--- a/test/WebDriverBiDi.Tests/Permissions/SetPermissionCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/SetPermissionCommandParametersTests.cs
@@ -3,67 +3,84 @@ namespace WebDriverBiDi.Permissions;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetPermissionsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetPermissionCommandParameters properties = new("myPermission", PermissionState.Granted, "https://example.com");
-        Assert.That(properties.MethodName, Is.EqualTo("permissions.setPermission"));
+        Assert.Equal("permissions.setPermission", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetPermissionCommandParameters properties = new("myPermission", PermissionState.Granted, "https://example.com");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("descriptor"));
-            Assert.That(serialized["descriptor"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject descriptor = (JObject)serialized["descriptor"]!;
-            Assert.That(descriptor, Has.Count.EqualTo(1));
-            Assert.That(descriptor, Contains.Key("name"));
-            Assert.That(descriptor["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(descriptor["name"]!.Value<string>(), Is.EqualTo("myPermission"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("granted"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("https://example.com"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("descriptor"));
+        JToken? descriptorToken = serialized["descriptor"];
+        Assert.NotNull(descriptorToken);
+        Assert.Equal(JTokenType.Object, descriptorToken.Type);
+        JObject? descriptor = descriptorToken as JObject;
+        Assert.NotNull(descriptor);
+        Assert.Single(descriptor);
+        Assert.True(descriptor.ContainsKey("name"));
+        JToken? descriptorName = descriptor["name"];
+        Assert.NotNull(descriptorName);
+        Assert.Equal(JTokenType.String, descriptorName.Type);
+        Assert.Equal("myPermission", descriptorName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("granted", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("https://example.com", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithDescriptorConstructor()
     {
         SetPermissionCommandParameters properties = new(new PermissionDescriptor("myPermission"), PermissionState.Granted, "https://example.com");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("descriptor"));
-            Assert.That(serialized["descriptor"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject descriptor = (JObject)serialized["descriptor"]!;
-            Assert.That(descriptor, Has.Count.EqualTo(1));
-            Assert.That(descriptor, Contains.Key("name"));
-            Assert.That(descriptor["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(descriptor["name"]!.Value<string>(), Is.EqualTo("myPermission"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("granted"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("https://example.com"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("descriptor"));
+        JToken? descriptorToken = serialized["descriptor"];
+        Assert.NotNull(descriptorToken);
+        Assert.Equal(JTokenType.Object, descriptorToken.Type);
+        JObject? descriptor = descriptorToken as JObject;
+        Assert.NotNull(descriptor);
+        Assert.Single(descriptor);
+        Assert.True(descriptor.ContainsKey("name"));
+        JToken? descriptorName = descriptor["name"];
+        Assert.NotNull(descriptorName);
+        Assert.Equal(JTokenType.String, descriptorName.Type);
+        Assert.Equal("myPermission", descriptorName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("granted", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("https://example.com", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEmbeddedOrigin()
     {
         SetPermissionCommandParameters properties = new("myPermission", PermissionState.Granted, "https://example.com")
@@ -72,29 +89,41 @@ public class SetPermissionsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("descriptor"));
-            Assert.That(serialized["descriptor"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject descriptor = (JObject)serialized["descriptor"]!;
-            Assert.That(descriptor, Has.Count.EqualTo(1));
-            Assert.That(descriptor, Contains.Key("name"));
-            Assert.That(descriptor["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(descriptor["name"]!.Value<string>(), Is.EqualTo("myPermission"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("granted"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("https://example.com"));
-            Assert.That(serialized, Contains.Key("embeddedOrigin"));
-            Assert.That(serialized["embeddedOrigin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["embeddedOrigin"]!.Value<string>(), Is.EqualTo("myEmbeddedOrigin"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("descriptor"));
+        JToken? descriptorToken = serialized["descriptor"];
+        Assert.NotNull(descriptorToken);
+        Assert.Equal(JTokenType.Object, descriptorToken.Type);
+        JObject? descriptor = descriptorToken as JObject;
+        Assert.NotNull(descriptor);
+        Assert.Single(descriptor);
+        Assert.True(descriptor.ContainsKey("name"));
+        JToken? descriptorName = descriptor["name"];
+        Assert.NotNull(descriptorName);
+        Assert.Equal(JTokenType.String, descriptorName.Type);
+        Assert.Equal("myPermission", descriptorName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("granted", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("https://example.com", origin.Value<string>());
+
+        Assert.True(serialized.ContainsKey("embeddedOrigin"));
+        JToken? embeddedOrigin = serialized["embeddedOrigin"];
+        Assert.NotNull(embeddedOrigin);
+        Assert.Equal(JTokenType.String, embeddedOrigin.Type);
+        Assert.Equal("myEmbeddedOrigin", embeddedOrigin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUserContext()
     {
         SetPermissionCommandParameters properties = new("myPermission", PermissionState.Granted, "https://example.com")
@@ -103,75 +132,105 @@ public class SetPermissionsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("descriptor"));
-            Assert.That(serialized["descriptor"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject descriptor = (JObject)serialized["descriptor"]!;
-            Assert.That(descriptor, Has.Count.EqualTo(1));
-            Assert.That(descriptor, Contains.Key("name"));
-            Assert.That(descriptor["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(descriptor["name"]!.Value<string>(), Is.EqualTo("myPermission"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("granted"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("https://example.com"));
-            Assert.That(serialized, Contains.Key("userContext"));
-            Assert.That(serialized["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userContext"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("descriptor"));
+        JToken? descriptorToken = serialized["descriptor"];
+        Assert.NotNull(descriptorToken);
+        Assert.Equal(JTokenType.Object, descriptorToken.Type);
+        JObject? descriptor = descriptorToken as JObject;
+        Assert.NotNull(descriptor);
+        Assert.Single(descriptor);
+        Assert.True(descriptor.ContainsKey("name"));
+        JToken? descriptorName = descriptor["name"];
+        Assert.NotNull(descriptorName);
+        Assert.Equal(JTokenType.String, descriptorName.Type);
+        Assert.Equal("myPermission", descriptorName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("granted", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("https://example.com", origin.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContext"));
+        JToken? userContext = serialized["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myContext", userContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPermissionDenied()
     {
         SetPermissionCommandParameters properties = new("myPermission", PermissionState.Denied, "https://example.com");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("descriptor"));
-            Assert.That(serialized["descriptor"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject descriptor = (JObject)serialized["descriptor"]!;
-            Assert.That(descriptor, Has.Count.EqualTo(1));
-            Assert.That(descriptor, Contains.Key("name"));
-            Assert.That(descriptor["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(descriptor["name"]!.Value<string>(), Is.EqualTo("myPermission"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("denied"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("https://example.com"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("descriptor"));
+        JToken? descriptorToken = serialized["descriptor"];
+        Assert.NotNull(descriptorToken);
+        Assert.Equal(JTokenType.Object, descriptorToken.Type);
+        JObject? descriptor = descriptorToken as JObject;
+        Assert.NotNull(descriptor);
+        Assert.Single(descriptor);
+        Assert.True(descriptor.ContainsKey("name"));
+        JToken? descriptorName = descriptor["name"];
+        Assert.NotNull(descriptorName);
+        Assert.Equal(JTokenType.String, descriptorName.Type);
+        Assert.Equal("myPermission", descriptorName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("denied", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("https://example.com", origin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithPermissionPrompt()
     {
         SetPermissionCommandParameters properties = new("myPermission", PermissionState.Prompt, "https://example.com");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("descriptor"));
-            Assert.That(serialized["descriptor"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject descriptor = (JObject)serialized["descriptor"]!;
-            Assert.That(descriptor, Has.Count.EqualTo(1));
-            Assert.That(descriptor, Contains.Key("name"));
-            Assert.That(descriptor["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(descriptor["name"]!.Value<string>(), Is.EqualTo("myPermission"));
-            Assert.That(serialized, Contains.Key("state"));
-            Assert.That(serialized["state"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["state"]!.Value<string>(), Is.EqualTo("prompt"));
-            Assert.That(serialized, Contains.Key("origin"));
-            Assert.That(serialized["origin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["origin"]!.Value<string>(), Is.EqualTo("https://example.com"));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("descriptor"));
+        JToken? descriptorToken = serialized["descriptor"];
+        Assert.NotNull(descriptorToken);
+        Assert.Equal(JTokenType.Object, descriptorToken.Type);
+        JObject? descriptor = descriptorToken as JObject;
+        Assert.NotNull(descriptor);
+        Assert.Single(descriptor);
+        Assert.True(descriptor.ContainsKey("name"));
+        JToken? descriptorName = descriptor["name"];
+        Assert.NotNull(descriptorName);
+        Assert.Equal(JTokenType.String, descriptorName.Type);
+        Assert.Equal("myPermission", descriptorName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("state"));
+        JToken? state = serialized["state"];
+        Assert.NotNull(state);
+        Assert.Equal(JTokenType.String, state.Type);
+        Assert.Equal("prompt", state.Value<string>());
+
+        Assert.True(serialized.ContainsKey("origin"));
+        JToken? origin = serialized["origin"];
+        Assert.NotNull(origin);
+        Assert.Equal(JTokenType.String, origin.Type);
+        Assert.Equal("https://example.com", origin.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Permissions/SetPermissionCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/SetPermissionCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Permissions;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetPermissionCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetPermissionCommandResult? result = JsonSerializer.Deserialize<SetPermissionCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetPermissionCommandResult? result = JsonSerializer.Deserialize<SetPermissionCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetPermissionCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
@@ -96,7 +96,7 @@ public class CommandTests
         Assert.Null(command.ThrownException);
         TestCommandResult result = new();
         command.SetResult(result);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         hasResult = command.TryGetResult(out commandResult);
         Assert.True(hasResult);
         Assert.NotNull(commandResult);
@@ -130,7 +130,7 @@ public class CommandTests
         Assert.Null(commandResult);
         Assert.Null(command.ThrownException);
         command.SetException(new WebDriverBiDiException("test exception"));
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         hasResult = command.TryGetResult(out commandResult);
         Assert.False(hasResult);
         Assert.Null(commandResult);
@@ -167,7 +167,7 @@ public class CommandTests
         Assert.Null(command.ThrownException);
         Assert.False(command.IsCanceled);
         command.Cancel();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         hasResult = command.TryGetResult(out commandResult);
         Assert.False(hasResult);
         Assert.Null(commandResult);
@@ -183,7 +183,7 @@ public class CommandTests
         Command command = new(1, commandParams);
 
         command.SetException(new WebDriverBiDiException("custom fault message"));
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
         Assert.False(hasResult);
@@ -200,7 +200,7 @@ public class CommandTests
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
         Command command = new(1, commandParams);
 
-        bool completed = await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        bool completed = await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
 
         Assert.False(completed);
@@ -219,7 +219,7 @@ public class CommandTests
 
         TestCommandResult firstResult = new();
         command.SetResult(firstResult);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         command.SetResult(new TestCommandResult());
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
@@ -236,7 +236,7 @@ public class CommandTests
 
         TestCommandResult result = new();
         command.SetResult(result);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         command.SetException(new WebDriverBiDiException("late exception"));
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
@@ -254,7 +254,7 @@ public class CommandTests
 
         TestCommandResult result = new();
         command.SetResult(result);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         command.Cancel();
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
@@ -271,7 +271,7 @@ public class CommandTests
         Command command = new(1, commandParams);
 
         command.Cancel();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         command.SetResult(new TestCommandResult());
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
@@ -288,7 +288,7 @@ public class CommandTests
         Command command = new(1, commandParams);
 
         command.Cancel();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         command.SetException(new WebDriverBiDiException("late exception"));
         Assert.Null(command.ThrownException);

--- a/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
@@ -5,11 +5,10 @@ using Microsoft.Extensions.Time.Testing;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class CommandTests
 {
-    [Test]
-    public void TestCanSerializeCommand()
+    [Fact]
+    public async Task TestCanSerializeCommand()
     {
         string commandName = "module.command";
         Dictionary<string, object?> expectedCommandParameters = new()
@@ -30,11 +29,11 @@ public class CommandTests
         Command command = new(1, commandParams);
         string json = JsonSerializer.Serialize(command);
         Dictionary<string, object?> dataValue = JObject.Parse(json).ToParsedDictionary();
-        Assert.That(dataValue, Is.EquivalentTo(expected));
+        Assert.Equivalent(expected, dataValue);
     }
 
-    [Test]
-    public void TestCannotDeserializeCommand()
+    [Fact]
+    public async Task TestCannotDeserializeCommand()
     {
         string json = """
                       {
@@ -45,11 +44,11 @@ public class CommandTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Command>(json), Throws.InstanceOf<NotImplementedException>());
+        Assert.ThrowsAny<NotImplementedException>(() => JsonSerializer.Deserialize<Command>(json));
     }
 
-    [Test]
-    public void TestCommandResultType()
+    [Fact]
+    public async Task TestCommandResultType()
     {
         string commandName = "module.command";
         Dictionary<string, object?> expectedCommandParameters = new()
@@ -68,10 +67,10 @@ public class CommandTests
         commandParams.AdditionalData["overflowParameterName"] = "overflowParameterValue";
 
         Command command = new(1, commandParams);
-        Assert.That(command.ResponseType, Is.EqualTo(typeof(CommandResponseMessage<TestCommandResult>)));
+        Assert.Equal(typeof(CommandResponseMessage<TestCommandResult>), command.ResponseType);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCommandResult()
     {
         string commandName = "module.command";
@@ -92,21 +91,21 @@ public class CommandTests
 
         Command command = new(1, commandParams);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.ThrownException, Is.Null);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.Null(command.ThrownException);
         TestCommandResult result = new();
         command.SetResult(result);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
         hasResult = command.TryGetResult(out commandResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(commandResult, Is.Not.Null);
-        Assert.That(commandResult, Is.InstanceOf<TestCommandResult>());
-        Assert.That(command.ThrownException, Is.Null);
-        Assert.That(commandResult, Is.EqualTo(result with { }));
+        Assert.True(hasResult);
+        Assert.NotNull(commandResult);
+        Assert.IsType<TestCommandResult>(commandResult);
+        Assert.Null(command.ThrownException);
+        Assert.Equal(result with { }, commandResult);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCommandThrownException()
     {
         string commandName = "module.command";
@@ -127,19 +126,22 @@ public class CommandTests
 
         Command command = new(1, commandParams);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.ThrownException, Is.Null);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.Null(command.ThrownException);
         command.SetException(new WebDriverBiDiException("test exception"));
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
         hasResult = command.TryGetResult(out commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.ThrownException, Is.Not.Null);
-        Assert.That(command.ThrownException, Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("test exception"));
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.NotNull(command.ThrownException);
+        Assert.IsType<WebDriverBiDiException>(command.ThrownException);
+        WebDriverBiDiException? thrownException = command.ThrownException as WebDriverBiDiException;
+        Assert.NotNull(thrownException);
+        Assert.Equal("test exception", thrownException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCommandCancel()
     {
         string commandName = "module.command";
@@ -160,20 +162,20 @@ public class CommandTests
 
         Command command = new(1, commandParams);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.ThrownException, Is.Null);
-        Assert.That(command.IsCanceled, Is.False);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.Null(command.ThrownException);
+        Assert.False(command.IsCanceled);
         command.Cancel();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
         hasResult = command.TryGetResult(out commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.ThrownException, Is.Null);
-        Assert.That(command.IsCanceled, Is.True);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.Null(command.ThrownException);
+        Assert.True(command.IsCanceled);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetExceptionFaultsCommand()
     {
         string commandName = "module.command";
@@ -181,36 +183,34 @@ public class CommandTests
         Command command = new(1, commandParams);
 
         command.SetException(new WebDriverBiDiException("custom fault message"));
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.ThrownException, Is.Not.Null);
-        Assert.That(command.ThrownException, Is.InstanceOf<WebDriverBiDiException>());
-        Assert.That(command.ThrownException!.Message, Is.EqualTo("custom fault message"));
-        Assert.That(command.IsCanceled, Is.False);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.NotNull(command.ThrownException);
+        Assert.IsType<WebDriverBiDiException>(command.ThrownException);
+        Assert.Equal("custom fault message", command.ThrownException.Message);
+        Assert.False(command.IsCanceled);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCompletionReturnsFalseOnTimeout()
     {
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
         Command command = new(1, commandParams);
 
-        bool completed = await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        bool completed = await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(completed, Is.False);
-            Assert.That(hasResult, Is.False);
-            Assert.That(commandResult, Is.Null);
-            Assert.That(command.ThrownException, Is.Null);
-            Assert.That(command.IsCanceled, Is.False);
-        }
+
+        Assert.False(completed);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.Null(command.ThrownException);
+        Assert.False(command.IsCanceled);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSettingResultAfterAlreadyCompletedDoesNotThrow()
     {
         string commandName = "module.command";
@@ -219,15 +219,15 @@ public class CommandTests
 
         TestCommandResult firstResult = new();
         command.SetResult(firstResult);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(() => command.SetResult(new TestCommandResult()), Throws.Nothing);
+        command.SetResult(new TestCommandResult());
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(commandResult, Is.EqualTo(firstResult with { }));
+        Assert.True(hasResult);
+        Assert.Equal(firstResult with { }, commandResult);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetExceptionAfterAlreadyCompletedDoesNotThrow()
     {
         string commandName = "module.command";
@@ -236,16 +236,16 @@ public class CommandTests
 
         TestCommandResult result = new();
         command.SetResult(result);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(() => command.SetException(new WebDriverBiDiException("late exception")), Throws.Nothing);
+        command.SetException(new WebDriverBiDiException("late exception"));
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(commandResult, Is.Not.Null);
-        Assert.That(command.ThrownException, Is.Null);
+        Assert.True(hasResult);
+        Assert.NotNull(commandResult);
+        Assert.Null(command.ThrownException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCancelAfterAlreadyCompletedDoesNotThrow()
     {
         string commandName = "module.command";
@@ -254,16 +254,16 @@ public class CommandTests
 
         TestCommandResult result = new();
         command.SetResult(result);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(() => command.Cancel(), Throws.Nothing);
+        command.Cancel();
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(commandResult, Is.Not.Null);
-        Assert.That(command.IsCanceled, Is.False);
+        Assert.True(hasResult);
+        Assert.NotNull(commandResult);
+        Assert.False(command.IsCanceled);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetResultAfterCancelDoesNotThrow()
     {
         string commandName = "module.command";
@@ -271,16 +271,16 @@ public class CommandTests
         Command command = new(1, commandParams);
 
         command.Cancel();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(() => command.SetResult(new TestCommandResult()), Throws.Nothing);
+        command.SetResult(new TestCommandResult());
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.False);
-        Assert.That(commandResult, Is.Null);
-        Assert.That(command.IsCanceled, Is.True);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.True(command.IsCanceled);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetExceptionAfterCancelDoesNotThrow()
     {
         string commandName = "module.command";
@@ -288,14 +288,14 @@ public class CommandTests
         Command command = new(1, commandParams);
 
         command.Cancel();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(() => command.SetException(new WebDriverBiDiException("late exception")), Throws.Nothing);
-        Assert.That(command.ThrownException, Is.Null);
-        Assert.That(command.IsCanceled, Is.True);
+        command.SetException(new WebDriverBiDiException("late exception"));
+        Assert.Null(command.ThrownException);
+        Assert.True(command.IsCanceled);
     }
 
-    [Test]
+    [Fact]
     public async Task TestWaitForCompletionReturnsTrueWhenCompletedBeforeCancellation()
     {
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
@@ -305,11 +305,11 @@ public class CommandTests
         using CancellationTokenSource cts = new();
 
         bool completed = await command.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cts.Token);
-        Assert.That(completed, Is.True);
+        Assert.True(completed);
     }
 
-    [Test]
-    public void TestWaitForCompletionThrowsWhenCancellationTokenIsCanceled()
+    [Fact]
+    public async Task TestWaitForCompletionThrowsWhenCancellationTokenIsCanceled()
     {
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
         Command command = new(1, commandParams);
@@ -317,11 +317,11 @@ public class CommandTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        Assert.That(async () => await command.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await command.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cts.Token));
     }
 
-    [Test]
-    public void TestWaitForCompletionThrowsWhenCancellationTokenIsCanceledDuringWait()
+    [Fact]
+    public async Task TestWaitForCompletionThrowsWhenCancellationTokenIsCanceledDuringWait()
     {
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
         Command command = new(1, commandParams);
@@ -330,6 +330,6 @@ public class CommandTests
         using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(50), timeProvider);
         timeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        Assert.That(async () => await command.WaitForCompletionAsync(TimeSpan.FromSeconds(30), cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await command.WaitForCompletionAsync(TimeSpan.FromSeconds(30), cts.Token));
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/ConnectionDataReceivedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/ConnectionDataReceivedEventArgsTests.cs
@@ -1,22 +1,21 @@
 namespace WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class ConnectionDataReceivedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateConnectionDataReceivedEventArgs()
     {
         ConnectionDataReceivedEventArgs eventArgs = new([1]);
-        Assert.That(eventArgs.Data, Has.Length.EqualTo(1));
-        Assert.That(eventArgs.Data[0], Is.EqualTo(1));
-        Assert.That(eventArgs.AdditionalData, Is.Empty);
+        Assert.Single(eventArgs.Data);
+        Assert.Equal(1, eventArgs.Data[0]);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ConnectionDataReceivedEventArgs eventArgs = new([1]);
         ConnectionDataReceivedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/ConnectionErrorEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/ConnectionErrorEventArgsTests.cs
@@ -1,23 +1,22 @@
 namespace WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class ConnectionErrorEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateConnectionErrorEventArgs()
     {
         Exception exception = new("test error");
         ConnectionErrorEventArgs eventArgs = new(exception);
-        Assert.That(eventArgs.Exception, Is.SameAs(exception));
-        Assert.That(eventArgs.Exception.Message, Is.EqualTo("test error"));
-        Assert.That(eventArgs.AdditionalData, Is.Empty);
+        Assert.Same(exception, eventArgs.Exception);
+        Assert.Equal("test error", eventArgs.Exception.Message);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         ConnectionErrorEventArgs eventArgs = new(new Exception("test"));
         ConnectionErrorEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/ErrorReceivedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/ErrorReceivedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Protocol;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ErrorReceivedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateErrorReceivedEventArgs()
     {
         string json = """
@@ -17,26 +16,25 @@ public class ErrorReceivedEventArgsTests
                         "stacktrace": "stack trace"
                       }
                       """;
-        ErrorResponseMessage? errorMessage = JsonSerializer.Deserialize<ErrorResponseMessage>(json)!;
+        ErrorResponseMessage? errorMessage = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
+        Assert.NotNull(errorMessage);
         ErrorReceivedEventArgs eventArgs = new(errorMessage.GetErrorResponseData());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.ErrorData, Is.Not.Null);
-            Assert.That(eventArgs.ErrorData.IsError, Is.True);
-            Assert.That(eventArgs.ErrorData.ErrorCode, Is.EqualTo(ErrorCode.UnsetErrorCode));
-            Assert.That(eventArgs.ErrorData.ErrorType, Is.EqualTo("my error code"));
-            Assert.That(eventArgs.ErrorData.ErrorMessage, Is.EqualTo("error message"));
-            Assert.That(eventArgs.ErrorData.StackTrace, Is.EqualTo("stack trace"));
-        }
+
+        Assert.NotNull(eventArgs.ErrorData);
+        Assert.True(eventArgs.ErrorData.IsError);
+        Assert.Equal(ErrorCode.UnsetErrorCode, eventArgs.ErrorData.ErrorCode);
+        Assert.Equal("my error code", eventArgs.ErrorData.ErrorType);
+        Assert.Equal("error message", eventArgs.ErrorData.ErrorMessage);
+        Assert.Equal("stack trace", eventArgs.ErrorData.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCreateErrorReceivedEventArgsWithNullErrorDataThrows()
     {
-        Assert.That(() => new ErrorReceivedEventArgs(null!), Throws.ArgumentNullException);
+        Assert.Throws<ArgumentNullException>(() => new ErrorReceivedEventArgs(null!));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -48,9 +46,10 @@ public class ErrorReceivedEventArgsTests
                         "stacktrace": "stack trace"
                       }
                       """;
-        ErrorResponseMessage? errorMessage = JsonSerializer.Deserialize<ErrorResponseMessage>(json)!;
+        ErrorResponseMessage? errorMessage = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
+        Assert.NotNull(errorMessage);
         ErrorReceivedEventArgs eventArgs = new(errorMessage.GetErrorResponseData());
         ErrorReceivedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/EventInvokerTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/EventInvokerTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Protocol;
 
 using TestUtilities;
 
-[TestFixture]
 public class EventInvokerTests
 {
-    [Test]
+    [Fact]
     public async Task TestCanInvokeEvent()
     {
         bool eventInvoked = false;
@@ -16,17 +15,17 @@ public class EventInvokerTests
         }
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
-        Assert.That(eventInvoked, Is.True);
+        Assert.True(eventInvoked);
     }
 
-    [Test]
-    public void TestInvokeEventWithInvalidObjectTypeThrows()
+    [Fact]
+    public async Task TestInvokeEventWithInvalidObjectTypeThrows()
     {
         EventInvoker<TestEventArgs> invoker = new((info) => Task.CompletedTask);
-        Assert.That(async () => await invoker.InvokeEventAsync("this is an invalid object", ReceivedDataDictionary.EmptyDictionary), Throws.InstanceOf<WebDriverBiDiException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await invoker.InvokeEventAsync("this is an invalid object", ReceivedDataDictionary.EmptyDictionary));
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventDataPassedCorrectlyToDelegate()
     {
         TestEventArgs? capturedEventData = null;
@@ -40,11 +39,11 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(originalEventArgs, ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(capturedEventData, Is.Not.Null);
-        Assert.That(capturedEventData, Is.SameAs(originalEventArgs));
+        Assert.NotNull(capturedEventData);
+        Assert.Same(originalEventArgs, capturedEventData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAdditionalDataPassedCorrectlyToDelegate()
     {
         ReceivedDataDictionary? capturedAdditionalData = null;
@@ -60,13 +59,13 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(new TestEventArgs(), additionalData);
 
-        Assert.That(capturedAdditionalData, Is.Not.Null);
-        Assert.That(capturedAdditionalData, Is.SameAs(additionalData));
-        Assert.That(capturedAdditionalData!["key1"], Is.EqualTo("value1"));
-        Assert.That(capturedAdditionalData["key2"], Is.EqualTo(42));
+        Assert.NotNull(capturedAdditionalData);
+        Assert.Same(additionalData, capturedAdditionalData);
+        Assert.Equal("value1", capturedAdditionalData["key1"]);
+        Assert.Equal(42, capturedAdditionalData["key2"]);
     }
 
-    [Test]
+    [Fact]
     public async Task TestInvokeWithEmptyAdditionalData()
     {
         ReceivedDataDictionary? capturedAdditionalData = null;
@@ -79,11 +78,11 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(capturedAdditionalData, Is.Not.Null);
-        Assert.That(capturedAdditionalData.Count, Is.EqualTo(0));
+        Assert.NotNull(capturedAdditionalData);
+        Assert.Empty(capturedAdditionalData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestInvokeWithNestedAdditionalData()
     {
         ReceivedDataDictionary? capturedAdditionalData = null;
@@ -100,18 +99,18 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(new TestEventArgs(), additionalData);
 
-        Assert.That(capturedAdditionalData, Is.Not.Null);
-        Assert.That(capturedAdditionalData!["outer"], Is.InstanceOf<ReceivedDataDictionary>());
+        Assert.NotNull(capturedAdditionalData);
+        Assert.IsType<ReceivedDataDictionary>(capturedAdditionalData["outer"]);
     }
 
-    [Test]
-    public void TestInvokeWithNullEventDataThrows()
+    [Fact]
+    public async Task TestInvokeWithNullEventDataThrows()
     {
         EventInvoker<TestEventArgs> invoker = new((info) => Task.CompletedTask);
-        Assert.That(async () => await invoker.InvokeEventAsync(null, ReceivedDataDictionary.EmptyDictionary), Throws.InstanceOf<WebDriverBiDiException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await invoker.InvokeEventAsync(null, ReceivedDataDictionary.EmptyDictionary));
     }
 
-    [Test]
+    [Fact]
     public async Task TestInvokeWithComplexEventDataType()
     {
         TestParameterizedEventArgs? capturedEventData = null;
@@ -127,11 +126,11 @@ public class EventInvokerTests
         EventInvoker<TestParameterizedEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(eventArgs, ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(capturedEventData, Is.Not.Null);
-        Assert.That(capturedEventData!.EventName, Is.EqualTo("testEventName"));
+        Assert.NotNull(capturedEventData);
+        Assert.Equal("testEventName", capturedEventData.EventName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMultipleSequentialInvocations()
     {
         int invocationCount = 0;
@@ -147,10 +146,10 @@ public class EventInvokerTests
         await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
         await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(invocationCount, Is.EqualTo(3));
+        Assert.Equal(3, invocationCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncDelegateWithDelay()
     {
         bool delegateCompleted = false;
@@ -165,18 +164,18 @@ public class EventInvokerTests
 
         EventInvoker<TestEventArgs> invoker = new(action);
         Task invocationTask = invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
-        delegateReachedGate.Wait(TimeSpan.FromSeconds(5));
+        delegateReachedGate.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(delegateCompleted, Is.False, "Delegate should not have completed yet");
+        Assert.False(delegateCompleted);
 
         delegateGate.SetResult();
         await invocationTask;
 
-        Assert.That(delegateCompleted, Is.True, "Delegate should have completed after awaiting");
+        Assert.True(delegateCompleted);
     }
 
-    [Test]
-    public void TestExceptionInAsyncDelegateIsPropagated()
+    [Fact]
+    public async Task TestExceptionInAsyncDelegateIsPropagated()
     {
         static Task action(EventInfo<TestEventArgs> info)
         {
@@ -185,13 +184,11 @@ public class EventInvokerTests
 
         EventInvoker<TestEventArgs> invoker = new(action);
 
-        Assert.That(
-            async () => await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary),
-            Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("Test exception from delegate"));
+        Assert.Equal("Test exception from delegate", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary))).Message);
     }
 
-    [Test]
-    public void TestExceptionInAsyncTaskIsPropagated()
+    [Fact]
+    public async Task TestExceptionInAsyncTaskIsPropagated()
     {
         static async Task action(EventInfo<TestEventArgs> info)
         {
@@ -201,12 +198,10 @@ public class EventInvokerTests
 
         EventInvoker<TestEventArgs> invoker = new(action);
 
-        Assert.That(
-            async () => await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary),
-            Throws.InstanceOf<ArgumentException>().With.Message.EqualTo("Async exception from delegate"));
+        Assert.Equal("Async exception from delegate", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestReturnedTaskCompletesCorrectly()
     {
         TaskCompletionSource taskCompletionSource = new();
@@ -218,46 +213,36 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         Task invocationTask = invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(invocationTask.IsCompleted, Is.False, "Task should not be completed yet");
+        Assert.False(invocationTask.IsCompleted);
 
         taskCompletionSource.SetResult();
         await invocationTask;
 
-        Assert.That(invocationTask.IsCompletedSuccessfully, Is.True, "Task should have completed successfully");
+        Assert.True(invocationTask.IsCompletedSuccessfully);
     }
 
-    [Test]
-    public void TestInvalidTypeWithHelpfulErrorMessage()
+    [Fact]
+    public async Task TestInvalidTypeWithHelpfulErrorMessage()
     {
         EventInvoker<TestEventArgs> invoker = new((info) => Task.CompletedTask);
 
-        WebDriverBiDiException? caughtException = null;
-        try
-        {
-            invoker.InvokeEventAsync(123, ReceivedDataDictionary.EmptyDictionary).Wait();
-        }
-        catch (AggregateException ex)
-        {
-            caughtException = ex.InnerException as WebDriverBiDiException;
-        }
+        WebDriverBiDiException caughtException = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(
+            async () => await invoker.InvokeEventAsync(123, ReceivedDataDictionary.EmptyDictionary));
 
-        Assert.That(caughtException, Is.Not.Null);
-        Assert.That(caughtException!.Message, Does.Contain("TestEventArgs"));
-        Assert.That(caughtException.Message, Does.Contain("cast"));
+        Assert.Contains("TestEventArgs", caughtException.Message);
+        Assert.Contains("cast", caughtException.Message);
     }
 
-    [Test]
-    public void TestTypeCloseButNotAssignableThrows()
+    [Fact]
+    public async Task TestTypeCloseButNotAssignableThrows()
     {
         EventInvoker<TestEventArgs> invoker = new((info) => Task.CompletedTask);
         TestParameterizedEventArgs wrongTypeEventArgs = new(new TestValidEventData("test"));
 
-        Assert.That(
-            async () => await invoker.InvokeEventAsync(wrongTypeEventArgs, ReceivedDataDictionary.EmptyDictionary),
-            Throws.InstanceOf<WebDriverBiDiException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await invoker.InvokeEventAsync(wrongTypeEventArgs, ReceivedDataDictionary.EmptyDictionary));
     }
 
-    [Test]
+    [Fact]
     public async Task TestInvokerWithBaseEventArgsType()
     {
         WebDriverBiDiEventArgs? capturedEventData = null;
@@ -273,11 +258,11 @@ public class EventInvokerTests
         // TestEventArgs derives from WebDriverBiDiEventArgs, so this should work
         await invoker.InvokeEventAsync(eventArgs, ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(capturedEventData, Is.Not.Null);
-        Assert.That(capturedEventData, Is.InstanceOf<TestEventArgs>());
+        Assert.NotNull(capturedEventData);
+        Assert.IsType<TestEventArgs>(capturedEventData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventInfoCreatedCorrectlyWithEventData()
     {
         EventInfo<TestEventArgs>? capturedEventInfo = null;
@@ -291,11 +276,11 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(eventArgs, ReceivedDataDictionary.EmptyDictionary);
 
-        Assert.That(capturedEventInfo, Is.Not.Null);
-        Assert.That(capturedEventInfo!.EventData, Is.SameAs(eventArgs));
+        Assert.NotNull(capturedEventInfo);
+        Assert.Same(eventArgs, capturedEventInfo.EventData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestEventInfoCreatedCorrectlyWithAdditionalData()
     {
         EventInfo<TestEventArgs>? capturedEventInfo = null;
@@ -311,8 +296,8 @@ public class EventInvokerTests
         EventInvoker<TestEventArgs> invoker = new(action);
         await invoker.InvokeEventAsync(new TestEventArgs(), additionalData);
 
-        Assert.That(capturedEventInfo, Is.Not.Null);
-        Assert.That(capturedEventInfo!.AdditionalData, Is.SameAs(additionalData));
-        Assert.That(capturedEventInfo.AdditionalData["testKey"], Is.EqualTo("testValue"));
+        Assert.NotNull(capturedEventInfo);
+        Assert.Same(additionalData, capturedEventInfo.AdditionalData);
+        Assert.Equal("testValue", capturedEventInfo.AdditionalData["testKey"]);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/EventInvokerTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/EventInvokerTests.cs
@@ -154,17 +154,17 @@ public class EventInvokerTests
     {
         bool delegateCompleted = false;
         TaskCompletionSource delegateGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        using ManualResetEventSlim delegateReachedGate = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         async Task action(EventInfo<TestEventArgs> info)
         {
-            delegateReachedGate.Set();
+            taskCompletionSource.TrySetResult();
             await delegateGate.Task;
             delegateCompleted = true;
         }
 
         EventInvoker<TestEventArgs> invoker = new(action);
         Task invocationTask = invoker.InvokeEventAsync(new TestEventArgs(), ReceivedDataDictionary.EmptyDictionary);
-        delegateReachedGate.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.False(delegateCompleted);
 

--- a/test/WebDriverBiDi.Tests/Protocol/EventReceivedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/EventReceivedEventArgsTests.cs
@@ -2,23 +2,22 @@ using WebDriverBiDi.TestUtilities;
 
 namespace WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class EventReceivedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateEventReceivedEventArgs()
     {
         EventReceivedEventArgs eventArgs = new(new EventMessage<TestEventArgs>());
-        Assert.That(eventArgs.EventName, Is.Empty);
-        Assert.That(eventArgs.EventData, Is.Null);
-        Assert.That(eventArgs.AdditionalData, Is.Empty);
+        Assert.Empty(eventArgs.EventName);
+        Assert.Null(eventArgs.EventData);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         EventReceivedEventArgs eventArgs = new(new EventMessage<TestEventArgs>());
         EventReceivedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/MessageTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/MessageTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Protocol;
 using System.Text.Json;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class MessageTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeCommandResponseMessage()
     {
         string json = """
@@ -19,17 +18,15 @@ public class MessageTests
                       }
                       """;
         CommandResponseMessage<TestCommandResult>? result = JsonSerializer.Deserialize<CommandResponseMessage<TestCommandResult>>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("success"));
-            Assert.That(result.Result, Is.InstanceOf<TestCommandResult>());
-            Assert.That(((TestCommandResult)result.Result).Value, Is.EqualTo("response value"));
-            Assert.That(result.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("success", result.Type);
+        Assert.IsType<TestCommandResult>(result.Result);
+        Assert.Equal("response value", ((TestCommandResult)result.Result).Value);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeEventMessage()
     {
         string json = """
@@ -42,18 +39,16 @@ public class MessageTests
                       }
                       """;
         EventMessage<TestEventArgs>? result = JsonSerializer.Deserialize<EventMessage<TestEventArgs>>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("event"));
-            Assert.That(result.EventData, Is.InstanceOf<TestEventArgs>());
-            Assert.That(result.EventName, Is.EqualTo("protocol.event"));
-            Assert.That(((TestEventArgs)result.EventData!).ParamName, Is.EqualTo("paramValue"));
-            Assert.That(result.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("event", result.Type);
+        Assert.IsType<TestEventArgs>(result.EventData);
+        Assert.Equal("protocol.event", result.EventName);
+        Assert.Equal("paramValue", ((TestEventArgs)result.EventData).ParamName);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCommandErrorMessage()
     {
         string json = """
@@ -65,20 +60,18 @@ public class MessageTests
                       }
                       """;
         ErrorResponseMessage? result = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("error"));
-            Assert.That(result.CommandId, Is.EqualTo(1));
-            Assert.That(result.ErrorType, Is.EqualTo("unknown error"));
-            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCode.UnknownError));
-            Assert.That(result.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(result.AdditionalData, Is.Empty);
-            Assert.That(result.StackTrace, Is.Null);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("error", result.Type);
+        Assert.Equal(1, result.CommandId);
+        Assert.Equal("unknown error", result.ErrorType);
+        Assert.Equal(ErrorCode.UnknownError, result.ErrorCode);
+        Assert.Equal("This is a test error message", result.ErrorMessage);
+        Assert.Empty(result.AdditionalData);
+        Assert.Null(result.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCommandErrorMessageWithUnknownErrorCode()
     {
         string json = """
@@ -90,20 +83,18 @@ public class MessageTests
                       }
                       """;
         ErrorResponseMessage? result = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("error"));
-            Assert.That(result.CommandId, Is.EqualTo(1));
-            Assert.That(result.ErrorType, Is.EqualTo("invalid error code"));
-            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCode.UnsetErrorCode));
-            Assert.That(result.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(result.AdditionalData, Is.Empty);
-            Assert.That(result.StackTrace, Is.Null);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("error", result.Type);
+        Assert.Equal(1, result.CommandId);
+        Assert.Equal("invalid error code", result.ErrorType);
+        Assert.Equal(ErrorCode.UnsetErrorCode, result.ErrorCode);
+        Assert.Equal("This is a test error message", result.ErrorMessage);
+        Assert.Empty(result.AdditionalData);
+        Assert.Null(result.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNonCommandErrorMessage()
     {
         string json = """
@@ -115,19 +106,17 @@ public class MessageTests
                       }
                       """;
         ErrorResponseMessage? result = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("error"));
-            Assert.That(result.CommandId, Is.Null);
-            Assert.That(result.ErrorType, Is.EqualTo("unknown error"));
-            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCode.UnknownError));
-            Assert.That(result.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(result.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("error", result.Type);
+        Assert.Null(result.CommandId);
+        Assert.Equal("unknown error", result.ErrorType);
+        Assert.Equal(ErrorCode.UnknownError, result.ErrorCode);
+        Assert.Equal("This is a test error message", result.ErrorMessage);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeErrorMessageWithStackTrace()
     {
         string json = """
@@ -140,20 +129,18 @@ public class MessageTests
                       }
                       """;
         ErrorResponseMessage? result = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("error"));
-            Assert.That(result.CommandId, Is.EqualTo(1));
-            Assert.That(result.ErrorType, Is.EqualTo("unknown error"));
-            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCode.UnknownError));
-            Assert.That(result.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(result.AdditionalData, Is.Empty);
-            Assert.That(result.StackTrace, Is.EqualTo("full stack trace"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("error", result.Type);
+        Assert.Equal(1, result.CommandId);
+        Assert.Equal("unknown error", result.ErrorType);
+        Assert.Equal(ErrorCode.UnknownError, result.ErrorCode);
+        Assert.Equal("This is a test error message", result.ErrorMessage);
+        Assert.Empty(result.AdditionalData);
+        Assert.Equal("full stack trace", result.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetErrorResultFromMessage()
     {
         string json = """
@@ -166,20 +153,18 @@ public class MessageTests
                       }
                       """;
         ErrorResponseMessage? messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(messageResult, Is.Not.Null);
+        Assert.NotNull(messageResult);
         ErrorResult result = messageResult.GetErrorResponseData();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsError, Is.True);
-            Assert.That(result.ErrorType, Is.EqualTo("unknown error"));
-            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCode.UnknownError));
-            Assert.That(result.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(result.AdditionalData, Is.Empty);
-            Assert.That(result.StackTrace, Is.EqualTo("full stack trace"));
-        }
+
+        Assert.True(result.IsError);
+        Assert.Equal("unknown error", result.ErrorType);
+        Assert.Equal(ErrorCode.UnknownError, result.ErrorCode);
+        Assert.Equal("This is a test error message", result.ErrorMessage);
+        Assert.Empty(result.AdditionalData);
+        Assert.Equal("full stack trace", result.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeMessageWithAdditionalData()
     {
         string json = """
@@ -193,24 +178,22 @@ public class MessageTests
                       }
                       """;
         CommandResponseMessage<TestCommandResult>? result = JsonSerializer.Deserialize<CommandResponseMessage<TestCommandResult>>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Type, Is.EqualTo("success"));
-            Assert.That(result.Result, Is.InstanceOf<TestCommandResult>());
-            Assert.That(((TestCommandResult)result.Result).Value, Is.EqualTo("response value"));
-            Assert.That(result.AdditionalData, Has.Count.EqualTo(1));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("success", result.Type);
+        Assert.IsType<TestCommandResult>(result.Result);
+        Assert.Equal("response value", ((TestCommandResult)result.Result).Value);
+        Assert.Single(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCommandResponseMessageThrowsWhenResultIsNull()
     {
         CommandResponseMessage<TestCommandResult> message = new();
-        Assert.That(() => _ = message.Result, Throws.InvalidOperationException.With.Message.EqualTo("Result cannot be null"));
+        Assert.Equal("Result cannot be null", Assert.ThrowsAny<InvalidOperationException>(() => _ = message.Result).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestAdditionalDataReturnsCachedInstanceOnRepeatedAccess()
     {
         string json = """
@@ -224,13 +207,13 @@ public class MessageTests
                       }
                       """;
         CommandResponseMessage<TestCommandResult>? result = JsonSerializer.Deserialize<CommandResponseMessage<TestCommandResult>>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ReceivedDataDictionary first = result.AdditionalData;
         ReceivedDataDictionary second = result.AdditionalData;
-        Assert.That(first, Is.SameAs(second));
+        Assert.Same(second, first);
     }
 
-    [Test]
+    [Fact]
     public void TestErrorCodeReturnsCachedValueOnRepeatedAccess()
     {
         string json = """
@@ -242,10 +225,10 @@ public class MessageTests
                       }
                       """;
         ErrorResponseMessage? result = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ErrorCode first = result.ErrorCode;
         ErrorCode second = result.ErrorCode;
-        Assert.That(first, Is.EqualTo(ErrorCode.UnknownError));
-        Assert.That(second, Is.EqualTo(first));
+        Assert.Equal(ErrorCode.UnknownError, first);
+        Assert.Equal(first, second);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/PendingCommandCollectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PendingCommandCollectionTests.cs
@@ -2,177 +2,176 @@ namespace WebDriverBiDi.Protocol;
 
 using TestUtilities;
 
-[TestFixture]
 public class PendingCommandCollectionTests
 {
-    [Test]
+    [Fact]
     public async Task TestCanAddCommand()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        Assert.That(collection.PendingCommandCount, Is.EqualTo(0));
+        Assert.Equal(0, collection.PendingCommandCount);
 
-        await collection.AddPendingCommandAsync(testCommand);
-        Assert.That(collection.PendingCommandCount, Is.EqualTo(1));
-        Assert.That(collection.RemovePendingCommand(1, out Command? removedCommand), Is.True);
-        Assert.That(removedCommand!.CommandName, Is.EqualTo("module.command"));
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
+        Assert.Equal(1, collection.PendingCommandCount);
+        Assert.True(collection.RemovePendingCommand(1, out Command? removedCommand));
+        Assert.Equal("module.command", removedCommand.CommandName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanRemoveCommand()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
 
-        Assert.That(collection.RemovePendingCommand(1, out Command? removedCommand), Is.True);
-        Assert.That(removedCommand!.CommandName, Is.EqualTo("module.command"));
+        Assert.True(collection.RemovePendingCommand(1, out Command? removedCommand));
+        Assert.Equal("module.command", removedCommand.CommandName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanClearCollection()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
         await collection.CloseAsync();
         collection.Clear();
-        Assert.That(collection.PendingCommandCount, Is.EqualTo(0));
+        Assert.Equal(0, collection.PendingCommandCount);
     }
 
-    [Test]
-    public void TestCanAttemptToRemoveNonExistentCommand()
+    [Fact]
+    public async Task TestCanAttemptToRemoveNonExistentCommand()
     {
         PendingCommandCollection collection = new();
-        Assert.That(collection.RemovePendingCommand(1, out Command? removedCommand), Is.False);
+        Assert.False(collection.RemovePendingCommand(1, out Command? removedCommand));
     }
 
-    [Test]
+    [Fact]
     public async Task TestCannotAddCommandToClosedCollection()
     {
         PendingCommandCollection collection = new();
         await collection.CloseAsync();
-        Assert.That(async () => await collection.AddPendingCommandAsync(new Command(1, new TestCommandParameters("test.command"))), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Cannot add command; pending command collection is closed"));
+        Assert.Equal("Cannot add command; pending command collection is closed", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await collection.AddPendingCommandAsync(new Command(1, new TestCommandParameters("test.command")), TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCannotAddCommandWithDuplicateId()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
-        Assert.That(async () => await collection.AddPendingCommandAsync(new Command(1, new TestCommandParameters("test.command"))), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Could not add command with id 1, as id already exists"));
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
+        Assert.Equal("Could not add command with id 1, as id already exists", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await collection.AddPendingCommandAsync(new Command(1, new TestCommandParameters("test.command")), TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanRemoveCommandFromClosedCollection()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
         await collection.CloseAsync();
-        Assert.That(collection.PendingCommandCount, Is.EqualTo(1));
-        Assert.That(collection.RemovePendingCommand(1, out Command? removedCommand), Is.True);
-        Assert.That(removedCommand!.CommandName, Is.EqualTo("module.command"));
+        Assert.Equal(1, collection.PendingCommandCount);
+        Assert.True(collection.RemovePendingCommand(1, out Command? removedCommand));
+        Assert.Equal("module.command", removedCommand.CommandName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanFailAllPendingCommands()
     {
         Command testCommand1 = new(1, new TestCommandParameters("module.command1"));
         Command testCommand2 = new(2, new TestCommandParameters("module.command2"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand1);
-        await collection.AddPendingCommandAsync(testCommand2);
+        await collection.AddPendingCommandAsync(testCommand1, TestContext.Current.CancellationToken);
+        await collection.AddPendingCommandAsync(testCommand2, TestContext.Current.CancellationToken);
         await collection.CloseAsync();
 
         Exception exception = new("connection lost");
         collection.FailAllPendingCommands(exception);
-        Assert.That(collection.PendingCommandCount, Is.EqualTo(0));
-        Assert.That(testCommand1.ThrownException, Is.SameAs(exception));
-        Assert.That(testCommand2.ThrownException, Is.SameAs(exception));
+        Assert.Equal(0, collection.PendingCommandCount);
+        Assert.Same(exception, testCommand1.ThrownException);
+        Assert.Same(exception, testCommand2.ThrownException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCannotFailAllPendingCommandsUnlessClosed()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
         Exception exception = new("connection lost");
-        Assert.That(() => collection.FailAllPendingCommands(exception), Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("Cannot fail commands while the collection can accept new incoming commands; close it with the Close method first"));
+        Assert.Equal("Cannot fail commands while the collection can accept new incoming commands; close it with the Close method first", Assert.ThrowsAny<InvalidOperationException>(() => collection.FailAllPendingCommands(exception)).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCannotClearCollectionUnlessClosed()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
-        Assert.That(() => collection.Clear(), Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("Cannot clear the collection while it can accept new incoming commands; close it with the Close method first"));
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
+        Assert.Equal("Cannot clear the collection while it can accept new incoming commands; close it with the Close method first", Assert.ThrowsAny<InvalidOperationException>(() => collection.Clear()).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestIsAcceptingCommandsPropertyHasCorrectValue()
     {
         PendingCommandCollection collection = new();
-        Assert.That(collection.IsAcceptingCommands, Is.True);
+        Assert.True(collection.IsAcceptingCommands);
         await collection.CloseAsync();
-        Assert.That(collection.IsAcceptingCommands, Is.False);
+        Assert.False(collection.IsAcceptingCommands);
     }
 
-    [Test]
-    public void TestCanDispose()
-    {
-        PendingCommandCollection collection = new();
-        Assert.That(() => collection.Dispose(), Throws.Nothing);
-    }
-
-    [Test]
-    public void TestDoubleDisposeDoesNotThrow()
+    [Fact]
+    public async Task TestCanDispose()
     {
         PendingCommandCollection collection = new();
         collection.Dispose();
-        Assert.That(() => collection.Dispose(), Throws.Nothing);
     }
 
-    [Test]
+    [Fact]
+    public async Task TestDoubleDisposeDoesNotThrow()
+    {
+        PendingCommandCollection collection = new();
+        collection.Dispose();
+        collection.Dispose();
+    }
+
+    [Fact]
     public async Task TestCanDisposeAfterUse()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
-        await collection.AddPendingCommandAsync(testCommand);
+        await collection.AddPendingCommandAsync(testCommand, TestContext.Current.CancellationToken);
         collection.RemovePendingCommand(1, out _);
         await collection.CloseAsync();
         collection.Clear();
-        Assert.That(() => collection.Dispose(), Throws.Nothing);
+        collection.Dispose();
     }
 
-    [Test]
-    public void TestAddPendingCommandThrowsWhenCancellationTokenIsCanceled()
+    [Fact]
+    public async Task TestAddPendingCommandThrowsWhenCancellationTokenIsCanceled()
     {
         Command testCommand = new(1, new TestCommandParameters("module.command"));
         PendingCommandCollection collection = new();
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        Assert.That(async () => await collection.AddPendingCommandAsync(testCommand, cts.Token), Throws.InstanceOf<OperationCanceledException>());
-        Assert.That(collection.PendingCommandCount, Is.EqualTo(0));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await collection.AddPendingCommandAsync(testCommand, cts.Token));
+        Assert.Equal(0, collection.PendingCommandCount);
     }
 
-    [Test]
-    public void TestDisposeFinalizerPathDoesNotThrow()
+    [Fact]
+    public async Task TestDisposeFinalizerPathDoesNotThrow()
     {
         ExposedDisposeCollection collection = new();
-        Assert.That(() => collection.DisposeUnmanaged(), Throws.Nothing);
+        collection.DisposeUnmanaged();
     }
 
-    [Test]
-    public void TestDisposeFinalizerPathAfterManagedDisposeDoesNotThrow()
+    [Fact]
+    public async Task TestDisposeFinalizerPathAfterManagedDisposeDoesNotThrow()
     {
         ExposedDisposeCollection collection = new();
         collection.Dispose();
-        Assert.That(() => collection.DisposeUnmanaged(), Throws.Nothing);
+        collection.DisposeUnmanaged();
     }
 
     private sealed class ExposedDisposeCollection : PendingCommandCollection

--- a/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
@@ -35,20 +35,25 @@ public class PipeConnectionTests
     [Fact]
     public async Task TestCanReceiveData()
     {
+        TaskCompletionSource remoteDisconnectedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestPipeServer testPipeServer = new();
         testPipeServer.Responses.Add("Acknowledged!");
 
         List<string> receivedData = [];
         PipeConnection connection = new(testPipeServer);
         connection.OnDataReceived.AddObserver(e => receivedData.Add(Encoding.UTF8.GetString(e.Data)));
+        connection.OnRemoteDisconnected.AddObserver(e =>
+        {
+            remoteDisconnectedTaskCompletionSource.TrySetResult();
+            return Task.CompletedTask;
+        });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
         await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        // StopAsync awaits the background receive task, ensuring all data produced
-        // by the receive loop is written before we assert.
+        await remoteDisconnectedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Single(receivedData);
@@ -58,20 +63,25 @@ public class PipeConnectionTests
     [Fact]
     public async Task TestReceivedDataTerminatedWithNullCharacter()
     {
+        TaskCompletionSource remoteDisconnectedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestPipeServer testPipeServer = new();
         testPipeServer.Responses.Add("Acknowledged!\\0More data");
 
         List<string> receivedData = [];
         PipeConnection connection = new(testPipeServer);
         connection.OnDataReceived.AddObserver(e => receivedData.Add(Encoding.UTF8.GetString(e.Data)));
+        connection.OnRemoteDisconnected.AddObserver(e =>
+        {
+            remoteDisconnectedTaskCompletionSource.TrySetResult();
+            return Task.CompletedTask;
+        });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
         await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        // StopAsync awaits the background receive task, ensuring all log messages
-        // produced by the receive loop are written before we assert.
+        await remoteDisconnectedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Single(receivedData);

--- a/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
@@ -2,21 +2,19 @@ namespace WebDriverBiDi.Protocol;
 
 using System.Diagnostics;
 using System.Text;
-using NUnit.Framework.Internal;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class PipeConnectionTests
 {
-    [Test]
-    public void TestConnectionType()
+    [Fact]
+    public async Task TestConnectionType()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
-        Assert.That(connection.ConnectionType, Is.EqualTo(ConnectionType.Pipes));
+        Assert.Equal(ConnectionType.Pipes, connection.ConnectionType);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanSendData()
     {
         TestPipeServer testPipeServer = new();
@@ -24,17 +22,17 @@ public class PipeConnectionTests
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
 
-        await connection.StartAsync("pipe://local");
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"));
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), cancellationToken: TestContext.Current.CancellationToken);
         bool dataSendSuccess = testPipeServer.WaitForDataSent(TimeSpan.FromSeconds(1));
         testPipeServer.Stop();
-        Assert.That(dataSendSuccess, Is.True);
+        Assert.True(dataSendSuccess);
 
         string output = testPipeServer.GetSentData();
-        Assert.That(output, Is.EqualTo("Hello"));
+        Assert.Equal("Hello", output);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveData()
     {
         TestPipeServer testPipeServer = new();
@@ -45,15 +43,15 @@ public class PipeConnectionTests
         connection.OnDataReceived.AddObserver(e => receivedData.Add(Encoding.UTF8.GetString(e.Data)));
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"));
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.That(receivedData, Has.Count.EqualTo(1));
-        Assert.That(receivedData[0], Is.EqualTo("Acknowledged!"));
+        Assert.Single(receivedData);
+        Assert.Equal("Acknowledged!", receivedData[0]);
     }
 
-    [Test]
+    [Fact]
     public async Task TestReceivedDataTerminatedWithNullCharacter()
     {
         TestPipeServer testPipeServer = new();
@@ -64,81 +62,81 @@ public class PipeConnectionTests
         connection.OnDataReceived.AddObserver(e => receivedData.Add(Encoding.UTF8.GetString(e.Data)));
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"));
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.That(receivedData, Has.Count.EqualTo(1));
-        Assert.That(receivedData[0], Is.EqualTo("Acknowledged!"));
+        Assert.Single(receivedData);
+        Assert.Equal("Acknowledged!", receivedData[0]);
     }
 
-    [Test]
-    public void TestStartingWithoutSettingExternalProcessThrows()
+    [Fact]
+    public async Task TestStartingWithoutSettingExternalProcessThrows()
     {
         PipeConnection connection = new(new TestPipeServer());
-        Assert.That(() => connection.StartAsync("pipe"), Throws.InstanceOf<WebDriverBiDiException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(() => connection.StartAsync("pipe", cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestStartingWithoutStoppingThrows()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        Assert.That(async () => await connection.StartAsync("pipe"), Throws.InstanceOf<WebDriverBiDiException>());
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.StartAsync("pipe", cancellationToken: TestContext.Current.CancellationToken));
         testPipeServer.Stop();
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteEndClosingMarksConnectionAsInactive()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        Assert.That(connection.IsActive, Is.True);
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(connection.IsActive);
         testPipeServer.Stop();
-        Assert.That(connection.IsActive, Is.False);
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanStop()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        await connection.StopAsync();
-        Assert.That(connection.IsActive, Is.False);
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(connection.IsActive);
         testPipeServer.Stop();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanStopWithoutStarting()
     {
         PipeConnection connection = new(new TestPipeServer());
-        await connection.StopAsync();
-        Assert.That(connection.IsActive, Is.False);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanStopRepeatedly()
     {
         PipeConnection connection = new(new TestPipeServer());
-        await connection.StopAsync();
-        await connection.StopAsync();
-        Assert.That(connection.IsActive, Is.False);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendDataWithoutStartingThrows()
     {
         PipeConnection connection = new(new TestPipeServer());
-        Assert.That(async () => await connection.SendDataAsync([1, 2, 3]), Throws.InstanceOf<WebDriverBiDiException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.SendDataAsync([1, 2, 3], cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanLogMessages()
     {
         List<string> receivedData = [];
@@ -149,22 +147,23 @@ public class PipeConnectionTests
         testPipeServer.Responses.Add("Acknowledged!");
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
 
-        await connection.StartAsync("pipe://local");
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"));
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.That(receivedData, Has.Count.EqualTo(6));
-        Assert.That(receivedData, Is.EquivalentTo([
+        Assert.Equal(6, receivedData.Count);
+        Assert.Equivalent(new string[]
+        {
             "Starting pipe connection: pipe://local",
             "Pipe connection started",
             "SEND >>> Hello",
             "RECV <<< Acknowledged!",
             "Pipe closed by remote end",
             "Ending pipe receive loop",
-        ]));
+        }, receivedData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanOnlySendOneMessageAtATime()
     {
         TestPipeServer testPipeServer = new();
@@ -182,74 +181,74 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        _ = Task.Run(() => connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello")));
-        syncEvent.Wait();
-        Assert.That(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("World")), Throws.InstanceOf<WebDriverBiDiTimeoutException>());
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        _ = Task.Run(() => connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        syncEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("World"), cancellationToken: TestContext.Current.CancellationToken));
         testPipeServer.Stop();
     }
 
-    [Test]
-    public void TestCanDispose()
+    [Fact]
+    public async Task TestCanDispose()
     {
         PipeConnection connection = new(new TestPipeServer());
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeAsyncDoesNotThrow()
     {
         PipeConnection connection = new(new TestPipeServer());
         await connection.DisposeAsync();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeAsyncAfterStartDoesNotThrow()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
         testPipeServer.Stop();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestIsDisposedPropertyIsSetAfterDispose()
     {
         TestPipeConnection connection = new(new TestPipeServer());
-        Assert.That(connection.Disposed, Is.False);
+        Assert.False(connection.Disposed);
         await connection.DisposeAsync();
-        Assert.That(connection.Disposed, Is.True);
+        Assert.True(connection.Disposed);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncAfterStop()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        await connection.StopAsync();
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncWithoutStopping()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
-        Assert.That(connection.IsActive, Is.False);
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.DisposeAsync();
+        Assert.False(connection.IsActive);
         testPipeServer.Stop();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeLogsExceptionFromStop()
     {
         List<LogMessageEventArgs> logs = [];
@@ -262,33 +261,33 @@ public class PipeConnectionTests
         });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
         connection.ThrowOnStop = true;
         await connection.DisposeAsync();
         testPipeServer.Stop();
 
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Unexpected exception during disposal")
                    && log.Message.Contains("Simulated stop failure")
                    && log.Level == WebDriverBiDiLogLevel.Warn
-                   && log.ComponentName == Connection.LoggerComponentName));
+                   && log.ComponentName == Connection.LoggerComponentName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncStartedConnectionAfterStop()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"));
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.WaitForDataSent(TimeSpan.FromSeconds(1));
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendDataThrowsWhenConnectionBecomesInactiveAfterSemaphoreAcquired()
     {
         int isActiveCallCount = 0;
@@ -303,18 +302,16 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(
-            async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data")),
-            Throws.InstanceOf<WebDriverBiDiConnectionException>()
-                .With.Message.EqualTo("The pipe connection was closed before the send could be completed"));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal("The pipe connection was closed before the send could be completed", exception.Message);
 
         testPipeServer.Stop();
     }
 
-    [Test]
-    public void TestSendDataThrowsWhenCancellationTokenIsCanceled()
+    [Fact]
+    public async Task TestSendDataThrowsWhenCancellationTokenIsCanceled()
     {
         TestPipeConnection connection = new(new TestPipeServer())
         {
@@ -323,36 +320,36 @@ public class PipeConnectionTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        Assert.That(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("test"), cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("test"), cts.Token));
     }
 
-    [Test]
+    [Fact]
     public async Task TestStartAfterDisposeThrows()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
         testPipeServer.Stop();
 
-        Assert.That(async () => await connection.StartAsync("pipe://local"), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("pipes have been disposed"));
+        Assert.Contains("pipes have been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestStartAfterServerProcessExitThrows()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.That(async () => await connection.StartAsync("pipe://local"), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("External process has already exited or been disposed"));
+        Assert.Contains("External process has already exited or been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
-    public void TestStartWithDisposedServerProcessThrows()
+    [Fact]
+    public async Task TestStartWithDisposedServerProcessThrows()
     {
         // An unstarted Process instance throws InvalidOperationException when
         // HasExited is read. This covers the catch branch in IsProcessRunning
@@ -360,10 +357,10 @@ public class PipeConnectionTests
         UnstartedProcessPipeProvider provider = new();
         PipeConnection connection = new(provider);
 
-        Assert.That(async () => await connection.StartAsync("pipe://local"), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("External process has already exited or been disposed"));
+        Assert.Contains("External process has already exited or been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestIsActiveFalseWhenProviderReturnsNullAfterStart()
     {
         // After a successful StartAsync, IsConnectionActive is true, so
@@ -376,11 +373,11 @@ public class PipeConnectionTests
         realServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
         try
         {
-            await connection.StartAsync("pipe://local");
-            Assert.That(connection.IsActive, Is.True);
+            await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+            Assert.True(connection.IsActive);
 
             wrapper.ReturnNull = true;
-            Assert.That(connection.IsActive, Is.False);
+            Assert.False(connection.IsActive);
         }
         finally
         {
@@ -390,7 +387,7 @@ public class PipeConnectionTests
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendDataWrapsIOExceptionInConnectionException()
     {
         TestPipeServer testPipeServer = new();
@@ -401,18 +398,16 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(
-            async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data")),
-            Throws.InstanceOf<WebDriverBiDiConnectionException>()
-                .With.Message.Contains("An error occurred while sending data")
-                .And.InnerException.InstanceOf<IOException>());
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("An error occurred while sending data", exception.Message);
+        Assert.IsType<IOException>(exception.InnerException);
 
         testPipeServer.Stop();
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendDataWrapsObjectDisposedExceptionInConnectionException()
     {
         TestPipeServer testPipeServer = new();
@@ -423,37 +418,33 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(
-            async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data")),
-            Throws.InstanceOf<WebDriverBiDiConnectionException>()
-                .With.Message.Contains("An error occurred while sending data")
-                .And.InnerException.InstanceOf<ObjectDisposedException>());
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("An error occurred while sending data", exception.Message);
+        Assert.IsType<ObjectDisposedException>(exception.InnerException);
 
         testPipeServer.Stop();
     }
 
-    [Test]
+    [Fact]
     public async Task TestPipeHandlesReturnEmptyStringAfterDisposal()
     {
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
 
         // After disposal, pipes are null, so handles should return empty string
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(connection.ReadPipeHandle, Is.EqualTo(string.Empty));
-            Assert.That(connection.WritePipeHandle, Is.EqualTo(string.Empty));
-        }
+
+        Assert.Equal(string.Empty, connection.ReadPipeHandle);
+        Assert.Equal(string.Empty, connection.WritePipeHandle);
 
         testPipeServer.Stop();
     }
 
-    [Test]
+    [Fact]
     public async Task TestReceiveDataRaisesErrorEventOnIOException()
     {
         ConnectionErrorEventArgs? receivedErrorArgs = null;
@@ -472,21 +463,18 @@ public class PipeConnectionTests
         });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
 
         // Wait for error event (TestPipeConnection returns fake data on first read, then throws on second)
-        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3));
+        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(errorReceived, Is.True);
-            Assert.That(receivedErrorArgs, Is.Not.Null);
-            Assert.That(receivedErrorArgs!.Exception, Is.InstanceOf<IOException>());
-        }
+        Assert.True(errorReceived);
+        Assert.NotNull(receivedErrorArgs);
+        Assert.IsType<IOException>(receivedErrorArgs.Exception);
     }
 
-    [Test]
+    [Fact]
     public async Task TestReceiveDataRaisesErrorEventOnObjectDisposedException()
     {
         ConnectionErrorEventArgs? receivedErrorArgs = null;
@@ -505,80 +493,77 @@ public class PipeConnectionTests
         });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local");
+        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
 
         // Wait for error event (TestPipeConnection returns fake data on first read, then throws on second)
-        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3));
+        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(errorReceived, Is.True);
-            Assert.That(receivedErrorArgs, Is.Not.Null);
-            Assert.That(receivedErrorArgs!.Exception, Is.InstanceOf<ObjectDisposedException>());
-        }
+        Assert.True(errorReceived);
+        Assert.NotNull(receivedErrorArgs);
+        Assert.IsType<ObjectDisposedException>(receivedErrorArgs.Exception);
     }
 
-    [Test]
-    public void TestPipesDisposedPropertySetterBothBranches()
+    [Fact]
+    public async Task TestPipesDisposedPropertySetterBothBranches()
     {
         TestPipeConnection connection = new(new TestPipeServer());
 
         // Test setting to true (one branch of ternary in setter)
         connection.PipesDisposed = true;
-        Assert.That(connection.PipesDisposed, Is.True);
+        Assert.True(connection.PipesDisposed);
 
         // Test setting to false (other branch of ternary in setter)
         connection.PipesDisposed = false;
-        Assert.That(connection.PipesDisposed, Is.False);
+        Assert.False(connection.PipesDisposed);
 
         // Test setting to true again to ensure it works both ways
         connection.PipesDisposed = true;
-        Assert.That(connection.PipesDisposed, Is.True);
+        Assert.True(connection.PipesDisposed);
     }
 
-    [Test]
-    public void TestReadPipeHandleWhenPipesNotDisposed()
+    [Fact]
+    public async Task TestReadPipeHandleWhenPipesNotDisposed()
     {
         TestPipeConnection connection = new(new TestPipeServer());
         connection.PipesDisposed = false;
 
         // When pipes are not disposed, should return the actual handle
         string handle = connection.ReadPipeHandle;
-        Assert.That(handle, Is.Not.Empty);
+        Assert.NotEmpty(handle);
     }
 
-    [Test]
-    public void TestWritePipeHandleWhenPipesNotDisposed()
+    [Fact]
+    public async Task TestWritePipeHandleWhenPipesNotDisposed()
     {
         TestPipeConnection connection = new(new TestPipeServer());
         connection.PipesDisposed = false;
 
         // When pipes are not disposed, should return the actual handle
         string handle = connection.WritePipeHandle;
-        Assert.That(handle, Is.Not.Empty);
+        Assert.NotEmpty(handle);
     }
 
-    [Test]
-    public void TestReadPipeHandleWhenPipesDisposed()
+    [Fact]
+    public async Task TestReadPipeHandleWhenPipesDisposed()
     {
         TestPipeConnection connection = new(new TestPipeServer());
         connection.PipesDisposed = true;
 
         // When pipes are disposed, should return empty string
         string handle = connection.ReadPipeHandle;
-        Assert.That(handle, Is.Empty);
+        Assert.Empty(handle);
     }
 
-    [Test]
-    public void TestWritePipeHandleWhenPipesDisposed()
+    [Fact]
+    public async Task TestWritePipeHandleWhenPipesDisposed()
     {
         TestPipeConnection connection = new(new TestPipeServer());
         connection.PipesDisposed = true;
 
         // When pipes are disposed, should return empty string
         string handle = connection.WritePipeHandle;
-        Assert.That(handle, Is.Empty);
+        Assert.Empty(handle);
     }
 
     private sealed class UnstartedProcessPipeProvider : IPipeServerProcessProvider

--- a/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
@@ -22,8 +22,8 @@ public class PipeConnectionTests
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
 
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken);
         bool dataSendSuccess = testPipeServer.WaitForDataSent(TimeSpan.FromSeconds(1));
         testPipeServer.Stop();
         Assert.True(dataSendSuccess);
@@ -43,9 +43,13 @@ public class PipeConnectionTests
         connection.OnDataReceived.AddObserver(e => receivedData.Add(Encoding.UTF8.GetString(e.Data)));
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
+
+        // StopAsync awaits the background receive task, ensuring all data produced
+        // by the receive loop is written before we assert.
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Single(receivedData);
         Assert.Equal("Acknowledged!", receivedData[0]);
@@ -62,9 +66,13 @@ public class PipeConnectionTests
         connection.OnDataReceived.AddObserver(e => receivedData.Add(Encoding.UTF8.GetString(e.Data)));
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("hello"), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
+
+        // StopAsync awaits the background receive task, ensuring all log messages
+        // produced by the receive loop are written before we assert.
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Single(receivedData);
         Assert.Equal("Acknowledged!", receivedData[0]);
@@ -74,7 +82,7 @@ public class PipeConnectionTests
     public async Task TestStartingWithoutSettingExternalProcessThrows()
     {
         PipeConnection connection = new(new TestPipeServer());
-        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(() => connection.StartAsync("pipe", cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(() => connection.StartAsync("pipe", TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -83,8 +91,8 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.StartAsync("pipe", cancellationToken: TestContext.Current.CancellationToken));
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.StartAsync("pipe", TestContext.Current.CancellationToken));
         testPipeServer.Stop();
     }
 
@@ -94,7 +102,7 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         Assert.True(connection.IsActive);
         testPipeServer.Stop();
         Assert.False(connection.IsActive);
@@ -106,8 +114,8 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(connection.IsActive);
         testPipeServer.Stop();
     }
@@ -116,7 +124,7 @@ public class PipeConnectionTests
     public async Task TestCanStopWithoutStarting()
     {
         PipeConnection connection = new(new TestPipeServer());
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(connection.IsActive);
     }
 
@@ -124,8 +132,8 @@ public class PipeConnectionTests
     public async Task TestCanStopRepeatedly()
     {
         PipeConnection connection = new(new TestPipeServer());
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(connection.IsActive);
     }
 
@@ -133,7 +141,7 @@ public class PipeConnectionTests
     public async Task TestSendDataWithoutStartingThrows()
     {
         PipeConnection connection = new(new TestPipeServer());
-        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.SendDataAsync([1, 2, 3], cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.SendDataAsync([1, 2, 3], TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -147,11 +155,16 @@ public class PipeConnectionTests
         testPipeServer.Responses.Add("Acknowledged!");
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
 
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.Equal(6, receivedData.Count);
+        // StopAsync awaits the background receive task, ensuring all log messages
+        // produced by the receive loop (including "Pipe closed by remote end" and
+        // "Ending pipe receive loop") are written before we assert.
+        await connection.StopAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(8, receivedData.Count);
         Assert.Equivalent(new string[]
         {
             "Starting pipe connection: pipe://local",
@@ -160,6 +173,8 @@ public class PipeConnectionTests
             "RECV <<< Acknowledged!",
             "Pipe closed by remote end",
             "Ending pipe receive loop",
+            "Closing pipe connection",
+            "Pipe connection closed",
         }, receivedData);
     }
 
@@ -174,17 +189,17 @@ public class PipeConnectionTests
             DataTimeout = TimeSpan.FromMilliseconds(20),
         };
 
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.DataSendStarting += (sender, e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         _ = Task.Run(() => connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
-        syncEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
-        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("World"), cancellationToken: TestContext.Current.CancellationToken));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("World"), TestContext.Current.CancellationToken));
         testPipeServer.Stop();
     }
 
@@ -209,7 +224,7 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
         testPipeServer.Stop();
         await connection.DisposeAsync();
@@ -230,8 +245,8 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         testPipeServer.Stop();
         await connection.DisposeAsync();
     }
@@ -242,7 +257,7 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
         Assert.False(connection.IsActive);
         testPipeServer.Stop();
@@ -261,7 +276,7 @@ public class PipeConnectionTests
         });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         connection.ThrowOnStop = true;
         await connection.DisposeAsync();
         testPipeServer.Stop();
@@ -279,10 +294,10 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
-        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
+        await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken);
         testPipeServer.WaitForDataSent(TimeSpan.FromSeconds(1));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         testPipeServer.Stop();
         await connection.DisposeAsync();
     }
@@ -302,9 +317,9 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
 
-        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), TestContext.Current.CancellationToken));
         Assert.Equal("The pipe connection was closed before the send could be completed", exception.Message);
 
         testPipeServer.Stop();
@@ -329,11 +344,11 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
         testPipeServer.Stop();
 
-        Assert.Contains("pipes have been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("pipes have been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -342,10 +357,10 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.Contains("External process has already exited or been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("External process has already exited or been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -357,7 +372,7 @@ public class PipeConnectionTests
         UnstartedProcessPipeProvider provider = new();
         PipeConnection connection = new(provider);
 
-        Assert.Contains("External process has already exited or been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("External process has already exited or been disposed", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -373,7 +388,7 @@ public class PipeConnectionTests
         realServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
         try
         {
-            await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+            await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
             Assert.True(connection.IsActive);
 
             wrapper.ReturnNull = true;
@@ -398,9 +413,9 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
 
-        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), TestContext.Current.CancellationToken));
         Assert.Contains("An error occurred while sending data", exception.Message);
         Assert.IsType<IOException>(exception.InnerException);
 
@@ -418,9 +433,9 @@ public class PipeConnectionTests
         };
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
 
-        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("data"), TestContext.Current.CancellationToken));
         Assert.Contains("An error occurred while sending data", exception.Message);
         Assert.IsType<ObjectDisposedException>(exception.InnerException);
 
@@ -433,7 +448,7 @@ public class PipeConnectionTests
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
 
         // After disposal, pipes are null, so handles should return empty string
@@ -448,7 +463,7 @@ public class PipeConnectionTests
     public async Task TestReceiveDataRaisesErrorEventOnIOException()
     {
         ConnectionErrorEventArgs? receivedErrorArgs = null;
-        ManualResetEventSlim errorReceivedEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestPipeServer testPipeServer = new();
 
         TestPipeConnection connection = new(testPipeServer)
@@ -458,18 +473,17 @@ public class PipeConnectionTests
         connection.OnConnectionError.AddObserver(e =>
         {
             receivedErrorArgs = e;
-            errorReceivedEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
 
         // Wait for error event (TestPipeConnection returns fake data on first read, then throws on second)
-        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.True(errorReceived);
         Assert.NotNull(receivedErrorArgs);
         Assert.IsType<IOException>(receivedErrorArgs.Exception);
     }
@@ -478,7 +492,7 @@ public class PipeConnectionTests
     public async Task TestReceiveDataRaisesErrorEventOnObjectDisposedException()
     {
         ConnectionErrorEventArgs? receivedErrorArgs = null;
-        ManualResetEventSlim errorReceivedEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestPipeServer testPipeServer = new();
 
         TestPipeConnection connection = new(testPipeServer)
@@ -488,18 +502,17 @@ public class PipeConnectionTests
         connection.OnConnectionError.AddObserver(e =>
         {
             receivedErrorArgs = e;
-            errorReceivedEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
-        await connection.StartAsync("pipe://local", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
 
         // Wait for error event (TestPipeConnection returns fake data on first read, then throws on second)
-        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        Assert.True(errorReceived);
         Assert.NotNull(receivedErrorArgs);
         Assert.IsType<ObjectDisposedException>(receivedErrorArgs.Exception);
     }

--- a/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
@@ -286,7 +286,7 @@ public class PipeConnectionTests
         List<LogMessageEventArgs> logs = [];
         TestPipeServer testPipeServer = new();
         TestPipeConnection connection = new(testPipeServer);
-        connection.OnLogMessage.AddObserver((e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;

--- a/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
@@ -148,9 +148,15 @@ public class PipeConnectionTests
     public async Task TestCanLogMessages()
     {
         List<string> receivedData = [];
+        TaskCompletionSource remoteDisconnectedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestPipeServer testPipeServer = new();
         PipeConnection connection = new(testPipeServer);
         connection.OnLogMessage.AddObserver(e => receivedData.Add(e.Message));
+        connection.OnRemoteDisconnected.AddObserver(e =>
+        {
+            remoteDisconnectedTaskCompletionSource.TrySetResult();
+            return Task.CompletedTask;
+        });
 
         testPipeServer.Responses.Add("Acknowledged!");
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
@@ -159,9 +165,10 @@ public class PipeConnectionTests
         await connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken);
         testPipeServer.Stop();
 
-        // StopAsync awaits the background receive task, ensuring all log messages
-        // produced by the receive loop (including "Pipe closed by remote end" and
-        // "Ending pipe receive loop") are written before we assert.
+        // Wait for the receive loop to exit gracefully via EOF before calling StopAsync.
+        // This ensures "Pipe closed by remote end" and "Ending pipe receive loop" are
+        // logged before StopAsync's cancellation token can preempt the ReadAsync.
+        await remoteDisconnectedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(8, receivedData.Count);

--- a/test/WebDriverBiDi.Tests/Protocol/TransportEventSourceIntegrationTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportEventSourceIntegrationTests.cs
@@ -83,21 +83,22 @@ public class TransportEventSourceIntegrationTests
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         // Simulate response
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "success",
-                            "id": 1,
-                            "result": {
-                              "value": "response value"
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                                "type": "success",
+                                "id": 1,
+                                "result": {
+                                "value": "response value"
+                                }
                             }
-                          }
-                          """;
-            await Task.Delay(TimeSpan.FromMilliseconds(10));
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+                            """;
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
 
         await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
@@ -136,20 +137,21 @@ public class TransportEventSourceIntegrationTests
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         // Simulate error response
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "error",
-                            "id": 1,
-                            "error": "invalid session id",
-                            "message": "Session not found"
-                          }
-                          """;
-            await Task.Yield();
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                                "type": "error",
+                                "id": 1,
+                                "error": "invalid session id",
+                                "message": "Session not found"
+                            }
+                            """;
+                await Task.Yield();
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
 
         await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/Protocol/TransportEventSourceIntegrationTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportEventSourceIntegrationTests.cs
@@ -1,5 +1,6 @@
 namespace WebDriverBiDi.Protocol;
 
+using System.Collections.ObjectModel;
 using System.Diagnostics.Tracing;
 using TestUtilities;
 
@@ -7,77 +8,79 @@ using TestUtilities;
 /// Integration tests to verify EventSource instrumentation in Transport class.
 /// These tests ensure the Transport emits appropriate events during its lifecycle.
 /// </summary>
-[TestFixture]
+[Collection("EventSourceTests")]
 public class TransportEventSourceIntegrationTests
 {
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsConnectionOpeningAndOpenedEvents()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("ConnectionOpening", "ConnectionOpened", "TransportStarted");
-        Assert.That(events, Has.Count.EqualTo(3));
+        Assert.Equal(3, events.Count);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(events[0].EventName, Is.EqualTo("ConnectionOpening"));
-            Assert.That(events[0].Payload![1], Is.EqualTo("ws://localhost:9222"));
+        Assert.Equal("ConnectionOpening", events[0].EventName);
+        ReadOnlyCollection<object?>? payload0 = events[0].Payload;
+        Assert.NotNull(payload0);
+        Assert.Equal("ws://localhost:9222", payload0[1]);
 
-            Assert.That(events[1].EventName, Is.EqualTo("ConnectionOpened"));
-            Assert.That(events[1].Payload![1], Is.EqualTo("ws://localhost:9222"));
+        Assert.Equal("ConnectionOpened", events[1].EventName);
+        ReadOnlyCollection<object?>? payload1 = events[1].Payload;
+        Assert.NotNull(payload1);
+        Assert.Equal("ws://localhost:9222", payload1[1]);
 
-            Assert.That(events[2].EventName, Is.EqualTo("TransportStarted"));
-        }
+        Assert.Equal("TransportStarted", events[2].EventName);
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsConnectionClosingAndClosedEvents()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("ConnectionClosing", "ConnectionClosed", "TransportStopped");
-        Assert.That(events, Has.Count.EqualTo(3));
+        Assert.Equal(3, events.Count);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(events[0].EventName, Is.EqualTo("ConnectionClosing"));
-            Assert.That(events[0].Payload![1], Is.EqualTo("Normal shutdown"));
+        Assert.Equal("ConnectionClosing", events[0].EventName);
+        ReadOnlyCollection<object?>? payload0 = events[0].Payload;
+        Assert.NotNull(payload0);
+        Assert.Equal("Normal shutdown", payload0[1]);
 
-            Assert.That(events[1].EventName, Is.EqualTo("ConnectionClosed"));
+        Assert.Equal("ConnectionClosed", events[1].EventName);
 
-            Assert.That(events[2].EventName, Is.EqualTo("TransportStopped"));
-            Assert.That(events[2].Payload![0], Is.EqualTo("Normal shutdown"));
-        }
+        Assert.Equal("TransportStopped", events[2].EventName);
+        ReadOnlyCollection<object?>? payload2 = events[2].Payload;
+        Assert.NotNull(payload2);
+        Assert.Equal("Normal shutdown", payload2[0]);
 
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsCommandSendingAndCompletedEvents()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         TestCommandParameters commandParameters = new("session.status");
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         // Simulate response
         _ = Task.Run(async () =>
@@ -93,42 +96,44 @@ public class TransportEventSourceIntegrationTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(10));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
+        },
+        TestContext.Current.CancellationToken);
 
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandSending", "PendingCommandCount", "CommandCompleted");
-        Assert.That(events, Has.Count.AtLeast(2)); // At least CommandSending and CommandCompleted
+        Assert.True(events.Count >= 2); // At least CommandSending and CommandCompleted
 
         EventWrittenEventArgs sendingEvent = events.First(e => e.EventName == "CommandSending");
         EventWrittenEventArgs completedEvent = events.First(e => e.EventName == "CommandCompleted");
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(sendingEvent.Payload![0], Is.EqualTo("1"));
-            Assert.That(sendingEvent.Payload![1], Is.EqualTo("session.status"));
+        ReadOnlyCollection<object?>? sendingPayload = sendingEvent.Payload;
+        Assert.NotNull(sendingPayload);
+        Assert.Equal("1", sendingPayload[0]);
+        Assert.Equal("session.status", sendingPayload[1]);
 
-            Assert.That(completedEvent.Payload![0], Is.EqualTo("1"));
-            Assert.That(completedEvent.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(completedEvent.Payload![2], Is.InstanceOf<long>()); // elapsed time
-        }
+        ReadOnlyCollection<object?>? completedPayload = completedEvent.Payload;
+        Assert.NotNull(completedPayload);
+        Assert.Equal("1", completedPayload[0]);
+        Assert.Equal("session.status", completedPayload[1]);
+        Assert.IsType<long>(completedPayload[2]); // elapsed time
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsCommandErrorEvent()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         TestCommandParameters commandParameters = new("session.status");
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         // Simulate error response
         _ = Task.Run(async () =>
@@ -143,28 +148,29 @@ public class TransportEventSourceIntegrationTests
                           """;
             await Task.Yield();
             await connection.RaiseDataReceivedEventAsync(json);
-        });
+        },
+        TestContext.Current.CancellationToken);
 
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandError");
-        Assert.That(events, Has.Count.EqualTo(1));
+        Assert.Single(events);
 
         EventWrittenEventArgs errorEvent = events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(errorEvent.Payload![0], Is.EqualTo("1"));
-            Assert.That(errorEvent.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(errorEvent.Payload![2], Is.EqualTo(ErrorCode.InvalidSessionId));
-            Assert.That(errorEvent.Payload![3], Is.EqualTo("invalid session id"));
-            Assert.That(errorEvent.Payload![4], Is.EqualTo("Session not found"));
-        }
+        ReadOnlyCollection<object?>? errorPayload = errorEvent.Payload;
+        Assert.NotNull(errorPayload);
 
-        await transport.DisconnectAsync();
+        Assert.Equal("1", errorPayload[0]);
+        Assert.Equal("session.status", errorPayload[1]);
+        Assert.Equal(ErrorCode.InvalidSessionId, errorPayload[2]);
+        Assert.Equal("invalid session id", errorPayload[3]);
+        Assert.Equal("Session not found", errorPayload[4]);
+
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsCommandSendFailedEventWhenSendThrows()
     {
         TestEventListener listener = new();
@@ -174,38 +180,42 @@ public class TransportEventSourceIntegrationTests
         };
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents();
 
         TestCommandParameters commandParameters = new("session.status");
-        Assert.That(
-            async () => await transport.SendCommandAsync(commandParameters),
-            Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("Simulated send failure"));
+        Assert.Contains("Simulated send failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandSending", "CommandSendFailed", "PendingCommandCount", "CommandCompleted", "CommandError");
         EventWrittenEventArgs sendingEvent = events.First(e => e.EventName == "CommandSending");
         EventWrittenEventArgs failedEvent = events.First(e => e.EventName == "CommandSendFailed");
         EventWrittenEventArgs countEvent = events.Last(e => e.EventName == "PendingCommandCount");
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(sendingEvent.Payload![0], Is.EqualTo("1"));
-            Assert.That(sendingEvent.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(failedEvent.Payload![0], Is.EqualTo("1"));
-            Assert.That(failedEvent.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(failedEvent.Payload![2], Is.EqualTo(typeof(InvalidOperationException).FullName));
-            Assert.That(failedEvent.Payload![3], Is.EqualTo("Simulated send failure"));
-            Assert.That(failedEvent.Payload![4], Is.InstanceOf<long>());
-            Assert.That(countEvent.Payload![0], Is.EqualTo(0));
-            Assert.That(events.Any(e => e.EventName == "CommandCompleted"), Is.False);
-            Assert.That(events.Any(e => e.EventName == "CommandError"), Is.False);
-        }
+        ReadOnlyCollection<object?>? sendingPayload = sendingEvent.Payload;
+        Assert.NotNull(sendingPayload);
+        Assert.Equal("1", sendingPayload[0]);
+        Assert.Equal("session.status", sendingPayload[1]);
 
-        await transport.DisconnectAsync();
+        ReadOnlyCollection<object?>? failedPayload = failedEvent.Payload;
+        Assert.NotNull(failedPayload);
+        Assert.Equal("1", failedPayload[0]);
+        Assert.Equal("session.status", failedPayload[1]);
+        Assert.Equal(typeof(InvalidOperationException).FullName, failedPayload[2]);
+        Assert.Equal("Simulated send failure", failedPayload[3]);
+        Assert.IsType<long>(failedPayload[4]);
+
+        ReadOnlyCollection<object?>? countPayload = countEvent.Payload;
+        Assert.NotNull(countPayload);
+        Assert.Equal(0, countPayload[0]);
+
+        Assert.DoesNotContain(events, e => e.EventName == "CommandCompleted");
+        Assert.DoesNotContain(events, e => e.EventName == "CommandError");
+
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsCommandSendFailedEventWhenSendIsCanceled()
     {
         TestEventListener listener = new();
@@ -221,38 +231,41 @@ public class TransportEventSourceIntegrationTests
         };
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents();
 
         TestCommandParameters commandParameters = new("session.status");
         Task<Command> sendTask = transport.SendCommandAsync(commandParameters, cancellationTokenSource.Token);
-        bool sendDidStart = sendStarted.Wait(TimeSpan.FromSeconds(1));
-        Assert.That(sendDidStart, Is.True);
+        bool sendDidStart = sendStarted.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(sendDidStart);
         cancellationTokenSource.Cancel();
 
-        Assert.That(async () => await sendTask, Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandSending", "CommandSendFailed", "PendingCommandCount", "CommandCompleted", "CommandError");
         EventWrittenEventArgs failedEvent = events.First(e => e.EventName == "CommandSendFailed");
         EventWrittenEventArgs countEvent = events.Last(e => e.EventName == "PendingCommandCount");
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(failedEvent.Payload![0], Is.EqualTo("1"));
-            Assert.That(failedEvent.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(failedEvent.Payload![2], Is.EqualTo(typeof(TaskCanceledException).FullName));
-            Assert.That(failedEvent.Payload![3], Is.Not.Empty);
-            Assert.That(failedEvent.Payload![4], Is.InstanceOf<long>());
-            Assert.That(countEvent.Payload![0], Is.EqualTo(0));
-            Assert.That(events.Any(e => e.EventName == "CommandCompleted"), Is.False);
-            Assert.That(events.Any(e => e.EventName == "CommandError"), Is.False);
-        }
+        ReadOnlyCollection<object?>? failedPayload = failedEvent.Payload;
+        Assert.NotNull(failedPayload);
+        Assert.Equal("1", failedPayload[0]);
+        Assert.Equal("session.status", failedPayload[1]);
+        Assert.Equal(typeof(TaskCanceledException).FullName, failedPayload[2]);
+        Assert.NotEmpty((string)failedPayload[3]!);
+        Assert.IsType<long>(failedPayload[4]);
 
-        await transport.DisconnectAsync();
+        ReadOnlyCollection<object?>? countPayload = countEvent.Payload;
+        Assert.NotNull(countPayload);
+        Assert.Equal(0, countPayload[0]);
+
+        Assert.DoesNotContain(events, e => e.EventName == "CommandCompleted");
+        Assert.DoesNotContain(events, e => e.EventName == "CommandError");
+
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsEventReceivedEvent()
     {
         // This test verifies EventReceived is emitted by directly checking if the method
@@ -263,21 +276,24 @@ public class TransportEventSourceIntegrationTests
         WebDriverBiDiEventSource.RaiseEvent.EventReceived("test.event");
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("EventReceived");
-        Assert.That(events, Has.Count.EqualTo(1));
-        Assert.That(events[0].Payload![0], Is.EqualTo("test.event"));
+        Assert.Single(events);
+
+        ReadOnlyCollection<object?>? payload0 = events[0].Payload;
+        Assert.NotNull(payload0);
+        Assert.Equal("test.event", payload0[0]);
 
         listener.Dispose();
         await Task.CompletedTask; // Satisfy async requirement
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsUnknownMessageReceivedEvent()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate unknown message
@@ -285,27 +301,27 @@ public class TransportEventSourceIntegrationTests
         await connection.RaiseDataReceivedEventAsync(json);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName(TimeSpan.FromMilliseconds(50), "UnknownMessageReceived");
-        Assert.That(events, Has.Count.EqualTo(1));
+        Assert.Single(events);
 
         EventWrittenEventArgs unknownEvent = events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unknownEvent.Payload![0], Is.EqualTo("unknown"));
-            Assert.That(unknownEvent.Payload![1], Is.InstanceOf<int>()); // message length
-        }
+        ReadOnlyCollection<object?>? unknownPayload = unknownEvent.Payload;
+        Assert.NotNull(unknownPayload);
 
-        await transport.DisconnectAsync();
+        Assert.Equal("unknown", unknownPayload[0]);
+        Assert.IsType<int>(unknownPayload[1]); // message length
+
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsUnknownMessageReceivedEventWithNullType()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate unknown message with null type to test null-coalescing branch
@@ -313,20 +329,20 @@ public class TransportEventSourceIntegrationTests
         await connection.RaiseDataReceivedEventAsync(json);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName(TimeSpan.FromMilliseconds(50), "UnknownMessageReceived");
-        Assert.That(events, Has.Count.EqualTo(1));
+        Assert.Single(events);
 
         EventWrittenEventArgs unknownEvent = events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unknownEvent.Payload![0], Is.EqualTo("unknown")); // Should fall back to "unknown"
-            Assert.That(unknownEvent.Payload![1], Is.InstanceOf<int>()); // message length
-        }
+        ReadOnlyCollection<object?>? unknownPayload = unknownEvent.Payload;
+        Assert.NotNull(unknownPayload);
 
-        await transport.DisconnectAsync();
+        Assert.Equal("unknown", unknownPayload[0]); // Should fall back to "unknown"
+        Assert.IsType<int>(unknownPayload[1]); // message length
+
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsProtocolErrorEventForInvalidEventJson()
     {
         TestEventListener listener = new();
@@ -334,7 +350,7 @@ public class TransportEventSourceIntegrationTests
         Transport transport = new(connection);
         transport.RegisterEventMessage<TestEventArgs>("test.event");
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate malformed event (missing required property)
@@ -350,17 +366,19 @@ public class TransportEventSourceIntegrationTests
         await connection.RaiseDataReceivedEventAsync(json);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName(TimeSpan.FromMilliseconds(50), "ProtocolError");
-        Assert.That(events, Has.Count.AtLeast(1));
+        Assert.True(events.Count >= 1);
 
         EventWrittenEventArgs protocolError = events[0];
-        Assert.That(protocolError.Payload![0], Is.Not.Empty); // error message
-        Assert.That(protocolError.Payload![1], Is.Not.Empty); // message snippet
+        ReadOnlyCollection<object?>? protocolPayload = protocolError.Payload;
+        Assert.NotNull(protocolPayload);
+        Assert.NotEmpty((string)protocolPayload[0]!); // error message
+        Assert.NotEmpty((string)protocolPayload[1]!); // message snippet
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsEventHandlerErrorEvent()
     {
         // This test verifies EventHandlerError is emitted by directly checking if the method
@@ -371,50 +389,52 @@ public class TransportEventSourceIntegrationTests
         WebDriverBiDiEventSource.RaiseEvent.EventHandlerError("test.event", "Test exception message");
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("EventHandlerError");
-        Assert.That(events, Has.Count.EqualTo(1));
+        Assert.Single(events);
 
         EventWrittenEventArgs handlerError = events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handlerError.Payload![0], Is.EqualTo("test.event"));
-            Assert.That(handlerError.Payload![1], Is.EqualTo("Test exception message"));
-        }
+        ReadOnlyCollection<object?>? handlerPayload = handlerError.Payload;
+        Assert.NotNull(handlerPayload);
+
+        Assert.Equal("test.event", handlerPayload[0]);
+        Assert.Equal("Test exception message", handlerPayload[1]);
 
         listener.Dispose();
         await Task.CompletedTask; // Satisfy async requirement
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsConnectionErrorEvent()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate connection error
         await connection.RaiseConnectionErrorEventAsync(new InvalidOperationException("Connection lost"));
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName(TimeSpan.FromMilliseconds(50), "ConnectionError");
-        Assert.That(events, Has.Count.EqualTo(1));
+        Assert.Single(events);
 
         EventWrittenEventArgs connectionError = events[0];
-        Assert.That(connectionError.Payload![1], Does.Contain("Connection lost"));
+        ReadOnlyCollection<object?>? connectionPayload = connectionError.Payload;
+        Assert.NotNull(connectionPayload);
+        Assert.Contains("Connection lost", (string)connectionPayload[1]!);
 
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsConnectionErrorEventWhenTakingFastPath()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
-        await transport.DisconnectAsync();
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents();
 
         // Connection error after disconnect: fast-path guard returns early (no lock acquisition).
@@ -422,32 +442,37 @@ public class TransportEventSourceIntegrationTests
         await connection.RaiseConnectionErrorEventAsync(new InvalidOperationException("Connection lost during shutdown"));
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName(TimeSpan.FromMilliseconds(50), "ConnectionError");
-        Assert.That(events, Has.Count.EqualTo(1));
-        Assert.That(events[0].Payload![1], Does.Contain("Connection lost during shutdown"));
+        Assert.Single(events);
+
+        ReadOnlyCollection<object?>? errorPayload = events[0].Payload;
+        Assert.NotNull(errorPayload);
+        Assert.Contains("Connection lost during shutdown", (string)errorPayload[1]!);
 
         listener.Dispose();
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEmitsPendingCommandCountEvent()
     {
         TestEventListener listener = new();
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222");
+        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         TestCommandParameters commandParameters = new("session.status");
-        _ = await transport.SendCommandAsync(commandParameters);
+        _ = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("PendingCommandCount");
-        Assert.That(events, Has.Count.AtLeast(1));
+        Assert.True(events.Count >= 1);
 
         EventWrittenEventArgs countEvent = events[0];
-        Assert.That(countEvent.Payload![0], Is.InstanceOf<int>());
+        ReadOnlyCollection<object?>? countPayload = countEvent.Payload;
+        Assert.NotNull(countPayload);
+        Assert.IsType<int>(countPayload[0]);
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/TransportEventSourceIntegrationTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportEventSourceIntegrationTests.cs
@@ -18,7 +18,7 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("ConnectionOpening", "ConnectionOpened", "TransportStarted");
         Assert.Equal(3, events.Count);
@@ -35,7 +35,7 @@ public class TransportEventSourceIntegrationTests
 
         Assert.Equal("TransportStarted", events[2].EventName);
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -46,10 +46,10 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("ConnectionClosing", "ConnectionClosed", "TransportStopped");
         Assert.Equal(3, events.Count);
@@ -76,11 +76,11 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         TestCommandParameters commandParameters = new("session.status");
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         // Simulate response
         _ = Task.Run(async () =>
@@ -99,7 +99,7 @@ public class TransportEventSourceIntegrationTests
         },
         TestContext.Current.CancellationToken);
 
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandSending", "PendingCommandCount", "CommandCompleted");
         Assert.True(events.Count >= 2); // At least CommandSending and CommandCompleted
@@ -118,7 +118,7 @@ public class TransportEventSourceIntegrationTests
         Assert.Equal("session.status", completedPayload[1]);
         Assert.IsType<long>(completedPayload[2]); // elapsed time
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -129,11 +129,11 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         TestCommandParameters commandParameters = new("session.status");
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         // Simulate error response
         _ = Task.Run(async () =>
@@ -151,7 +151,7 @@ public class TransportEventSourceIntegrationTests
         },
         TestContext.Current.CancellationToken);
 
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandError");
         Assert.Single(events);
@@ -166,7 +166,7 @@ public class TransportEventSourceIntegrationTests
         Assert.Equal("invalid session id", errorPayload[3]);
         Assert.Equal("Session not found", errorPayload[4]);
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -180,11 +180,11 @@ public class TransportEventSourceIntegrationTests
         };
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents();
 
         TestCommandParameters commandParameters = new("session.status");
-        Assert.Contains("Simulated send failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Simulated send failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("CommandSending", "CommandSendFailed", "PendingCommandCount", "CommandCompleted", "CommandError");
         EventWrittenEventArgs sendingEvent = events.First(e => e.EventName == "CommandSending");
@@ -211,7 +211,7 @@ public class TransportEventSourceIntegrationTests
         Assert.DoesNotContain(events, e => e.EventName == "CommandCompleted");
         Assert.DoesNotContain(events, e => e.EventName == "CommandError");
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -219,25 +219,24 @@ public class TransportEventSourceIntegrationTests
     public async Task TestTransportEmitsCommandSendFailedEventWhenSendIsCanceled()
     {
         TestEventListener listener = new();
-        ManualResetEventSlim sendStarted = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         using CancellationTokenSource cancellationTokenSource = new();
         TestWebSocketConnection connection = new()
         {
             SendWebSocketDataOverride = async _ =>
             {
-                sendStarted.Set();
+                taskCompletionSource.TrySetResult();
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationTokenSource.Token);
             },
         };
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents();
 
         TestCommandParameters commandParameters = new("session.status");
         Task<Command> sendTask = transport.SendCommandAsync(commandParameters, cancellationTokenSource.Token);
-        bool sendDidStart = sendStarted.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.True(sendDidStart);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         cancellationTokenSource.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
@@ -261,7 +260,7 @@ public class TransportEventSourceIntegrationTests
         Assert.DoesNotContain(events, e => e.EventName == "CommandCompleted");
         Assert.DoesNotContain(events, e => e.EventName == "CommandError");
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -293,7 +292,7 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate unknown message
@@ -310,7 +309,7 @@ public class TransportEventSourceIntegrationTests
         Assert.Equal("unknown", unknownPayload[0]);
         Assert.IsType<int>(unknownPayload[1]); // message length
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -321,7 +320,7 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate unknown message with null type to test null-coalescing branch
@@ -338,7 +337,7 @@ public class TransportEventSourceIntegrationTests
         Assert.Equal("unknown", unknownPayload[0]); // Should fall back to "unknown"
         Assert.IsType<int>(unknownPayload[1]); // message length
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -350,7 +349,7 @@ public class TransportEventSourceIntegrationTests
         Transport transport = new(connection);
         transport.RegisterEventMessage<TestEventArgs>("test.event");
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate malformed event (missing required property)
@@ -374,7 +373,7 @@ public class TransportEventSourceIntegrationTests
         Assert.NotEmpty((string)protocolPayload[0]!); // error message
         Assert.NotEmpty((string)protocolPayload[1]!); // message snippet
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 
@@ -409,7 +408,7 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         // Simulate connection error
@@ -433,8 +432,8 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.ClearEvents();
 
         // Connection error after disconnect: fast-path guard returns early (no lock acquisition).
@@ -458,11 +457,11 @@ public class TransportEventSourceIntegrationTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost:9222", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost:9222", TestContext.Current.CancellationToken);
         listener.ClearEvents(); // Clear connection events
 
         TestCommandParameters commandParameters = new("session.status");
-        _ = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         List<EventWrittenEventArgs> events = listener.GetEventsForEventName("PendingCommandCount");
         Assert.True(events.Count >= 1);
@@ -472,7 +471,7 @@ public class TransportEventSourceIntegrationTests
         Assert.NotNull(countPayload);
         Assert.IsType<int>(countPayload[0]);
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         listener.Dispose();
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
@@ -5,10 +5,9 @@ using Newtonsoft.Json.Linq;
 using PinchHitter;
 using TestUtilities;
 
-[TestFixture]
 public class TransportTests
 {
-    [Test]
+    [Fact]
     public async Task TestTransportCanSendCommand()
     {
         string commandName = "module.command";
@@ -25,16 +24,16 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new(commandName);
-        _ = await transport.SendCommandAsync(command);
+        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
-        Assert.That(dataValue, Is.EquivalentTo(expected));
+        Assert.Equivalent(expected, dataValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportCanSendCommandWithComplexParameters()
     {
         string commandName = "module.command";
@@ -52,25 +51,25 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestComplexCommandParameters command = new(commandName);
-        _ = await transport.SendCommandAsync(command);
+        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
-        Assert.That(dataValue, Is.EquivalentTo(expected));
+        Assert.Equivalent(expected, dataValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportCanGetResponse()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -84,31 +83,31 @@ public class TransportTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        },
+        TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(actualResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(actualResult.IsError, Is.False);
-            Assert.That(actualResult, Is.TypeOf<TestCommandResult>());
-        }
+        Assert.True(hasResult);
+        Assert.NotNull(actualResult);
+
+        Assert.False(actualResult.IsError);
+        Assert.IsType<TestCommandResult>(actualResult);
+
         TestCommandResult? convertedResult = actualResult as TestCommandResult;
-        Assert.That(convertedResult, Is.Not.Null);
-        Assert.That(convertedResult.Value, Is.EqualTo("response value"));
+        Assert.NotNull(convertedResult);
+        Assert.Equal("response value", convertedResult.Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportCanGetResponseWithAdditionalData()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -123,36 +122,34 @@ public class TransportTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250));
+        },
+        TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), cancellationToken: TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(actualResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(actualResult.IsError, Is.False);
-            Assert.That(actualResult, Is.TypeOf<TestCommandResult>());
-        }
+        Assert.True(hasResult);
+        Assert.NotNull(actualResult);
+
+        Assert.False(actualResult.IsError);
+        Assert.IsType<TestCommandResult>(actualResult);
+
         TestCommandResult? convertedResult = actualResult as TestCommandResult;
-        Assert.That(convertedResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(convertedResult.Value, Is.EqualTo("response value"));
-            Assert.That(convertedResult.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(convertedResult.AdditionalData["extraDataName"], Is.EqualTo("extraDataValue"));
-        }
+        Assert.NotNull(convertedResult);
+
+        Assert.Equal("response value", convertedResult.Value);
+        Assert.Single(convertedResult.AdditionalData);
+        Assert.Equal("extraDataValue", convertedResult.AdditionalData["extraDataName"]);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportCanGetErrorResponse()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -165,37 +162,35 @@ public class TransportTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250));
+        },
+        TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), cancellationToken: TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(actualResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(actualResult.IsError, Is.True);
-            Assert.That(actualResult, Is.InstanceOf<ErrorResult>());
-        }
+        Assert.True(hasResult);
+        Assert.NotNull(actualResult);
+
+        Assert.True(actualResult.IsError);
+        Assert.IsType<ErrorResult>(actualResult);
+
         ErrorResult? convertedResponse = actualResult as ErrorResult;
-        Assert.That(convertedResponse, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(convertedResponse.ErrorType, Is.EqualTo("unknown command"));
-            Assert.That(convertedResponse.ErrorCode, Is.EqualTo(ErrorCode.UnknownCommand));
-            Assert.That(convertedResponse.ErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(convertedResponse.StackTrace, Is.Null);
-        }
+        Assert.NotNull(convertedResponse);
+
+        Assert.Equal("unknown command", convertedResponse.ErrorType);
+        Assert.Equal(ErrorCode.UnknownCommand, convertedResponse.ErrorCode);
+        Assert.Equal("This is a test error message", convertedResponse.ErrorMessage);
+        Assert.Null(convertedResponse.StackTrace);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportGetResponseWithThrownException()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -210,42 +205,42 @@ public class TransportTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250));
-        Assert.That(command.ThrownException, Is.InstanceOf<WebDriverBiDiSerializationException>().With.Message.Contains("Response did not contain properly formed JSON for response type"));
+        },
+        TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.IsType<WebDriverBiDiSerializationException>(command.ThrownException);
+        Assert.Contains("Response did not contain properly formed JSON for response type", command.ThrownException.Message);
     }
 
-    [Test]
-    public void TestTransportCannotSendCommandWithoutConnection()
+    [Fact]
+    public async Task TestTransportCannotSendCommandWithoutConnection()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected to a remote end to execute commands."));
+        Assert.Contains("Transport must be connected to a remote end to execute commands.", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportLeavesCommandResultAndThrownExceptionNullWithoutResponse()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(hasResult, Is.False);
-            Assert.That(commandResult, Is.Null);
-            Assert.That(command.ThrownException, Is.Null);
-        }
+
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
+        Assert.Null(command.ThrownException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendCommandExceptionRollsBackPendingCommandState()
     {
         TestWebSocketConnection connection = new()
@@ -253,18 +248,15 @@ public class TransportTests
             SendWebSocketDataOverride = _ => throw new InvalidOperationException("Simulated send failure"),
         };
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("Simulated send failure"));
+        Assert.Contains("Simulated send failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(transport.TestPendingCommandCount, Is.Zero);
-        }
+        Assert.Equal(0, transport.TestPendingCommandCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendCommandCancellationRollsBackPendingCommandState()
     {
         ManualResetEventSlim sendStarted = new(false);
@@ -278,21 +270,19 @@ public class TransportTests
             },
         };
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new("module.command");
         Task<Command> sendTask = transport.SendCommandAsync(commandParameters, cancellationTokenSource.Token);
-        sendStarted.Wait(TimeSpan.FromSeconds(1));
+        sendStarted.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
         cancellationTokenSource.Cancel();
 
-        Assert.That(async () => await sendTask, Throws.InstanceOf<OperationCanceledException>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(transport.TestPendingCommandCount, Is.Zero);
-        }
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
+
+        Assert.Equal(0, transport.TestPendingCommandCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportEventReceived()
     {
         string receivedName = string.Empty;
@@ -318,20 +308,19 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(receivedName, Is.EqualTo("protocol.event"));
-            Assert.That(receivedData, Is.TypeOf<TestEventArgs>());
-        }
+
+        Assert.Equal("protocol.event", receivedName);
+        Assert.IsType<TestEventArgs>(receivedData);
+
         TestEventArgs? convertedData = receivedData as TestEventArgs;
-        Assert.That(convertedData, Is.Not.Null);
-        Assert.That(convertedData.ParamName, Is.EqualTo("paramValue"));
+        Assert.NotNull(convertedData);
+        Assert.Equal("paramValue", convertedData.ParamName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportErrorEventReceived()
     {
         object? receivedData = null;
@@ -353,22 +342,20 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
 
-        Assert.That(receivedData, Is.TypeOf<ErrorResult>());
+        Assert.IsType<ErrorResult>(receivedData);
         ErrorResult? convertedData = receivedData as ErrorResult;
-        Assert.That(convertedData, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(convertedData.ErrorType, Is.EqualTo("unknown error"));
-            Assert.That(convertedData.ErrorCode, Is.EqualTo(ErrorCode.UnknownError));
-            Assert.That(convertedData.ErrorMessage, Is.EqualTo("This is a test error message"));
-        }
+        Assert.NotNull(convertedData);
+
+        Assert.Equal("unknown error", convertedData.ErrorType);
+        Assert.Equal(ErrorCode.UnknownError, convertedData.ErrorCode);
+        Assert.Equal("This is a test error message", convertedData.ErrorMessage);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportErrorEventReceivedWithNullValues()
     {
         object? receivedData = null;
@@ -392,13 +379,13 @@ public class TransportTests
                         "method": null
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportLogsCommands()
     {
         List<LogMessageEventArgs> logs = [];
@@ -409,17 +396,15 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseLogMessageEventAsync("test log message", WebDriverBiDiLogLevel.Warn);
-        Assert.That(logs, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(logs[0].Message, Is.EqualTo("test log message"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Warn));
-        }
+        Assert.Single(logs);
+
+        Assert.Equal("test log message", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Warn, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportLogsSuccessfulCommandResponses()
     {
         ManualResetEventSlim syncEvent = new(false);
@@ -434,10 +419,10 @@ public class TransportTests
             return Task.CompletedTask;
         });
         string commandName = "module.command";
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -451,30 +436,28 @@ public class TransportTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        },
+        TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(actualResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(actualResult.IsError, Is.False);
-            Assert.That(actualResult, Is.TypeOf<TestCommandResult>());
-        }
+        Assert.True(hasResult);
+        Assert.NotNull(actualResult);
+
+        Assert.False(actualResult.IsError);
+        Assert.IsType<TestCommandResult>(actualResult);
+
         TestCommandResult? convertedResult = actualResult as TestCommandResult;
-        Assert.That(convertedResult, Is.Not.Null);
-        Assert.That(convertedResult.Value, Is.EqualTo("response value"));
-        bool logEventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        Assert.That(logEventRaised, Is.True);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Command response message processed"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Trace));
-        }
+        Assert.NotNull(convertedResult);
+        Assert.Equal("response value", convertedResult.Value);
+        bool logEventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(logEventRaised);
+
+        Assert.Single(logs);
+        Assert.Contains("Command response message processed", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Trace, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportLogsMalformedJsonMessages()
     {
         ManualResetEventSlim syncEvent = new(false);
@@ -491,19 +474,17 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync("{ { }");
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Unexpected error parsing JSON message"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Error));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Single(logs);
+        Assert.Contains("Unexpected error parsing JSON message", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventWithMissingMessageType()
     {
         string json = """
@@ -524,17 +505,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventWithInvalidMessageTypeValue()
     {
         string json = """
@@ -556,17 +535,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForSuccessMessageWithMissingId()
     {
         string json = """
@@ -587,17 +564,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForSuccessMessageWitInvalidIdDataType()
     {
         string json = """
@@ -619,17 +594,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForSuccessMessageWitInvalidIdValue()
     {
         string json = """
@@ -651,17 +624,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForErrorMessageWithMissingId()
     {
         string json = """
@@ -692,20 +663,18 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Unexpected error parsing error JSON"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Error));
-        }
+        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
+        Assert.Single(logs);
+        Assert.Contains("Unexpected error parsing error JSON", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForErrorMessageWithMissingErrorProperty()
     {
         string json = """
@@ -736,20 +705,18 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Unexpected error parsing error JSON"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Error));
-        }
+        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
+        Assert.Single(logs);
+        Assert.Contains("Unexpected error parsing error JSON", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForErrorMessageWithMissingMessageProperty()
     {
         string json = """
@@ -780,20 +747,18 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Unexpected error parsing error JSON"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Error));
-        }
+        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
+        Assert.Single(logs);
+        Assert.Contains("Unexpected error parsing error JSON", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForEventMessageWithMissingMethod()
     {
         string json = """
@@ -814,17 +779,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForEventMessageWithMissingParams()
     {
         string json = """
@@ -843,17 +806,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForEventMessageWithUnregisteredEventMethod()
     {
         string json = """
@@ -875,17 +836,15 @@ public class TransportTests
             syncEvent.Set();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-        }
+        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForEventMessageWithMismatchingEventParameters()
     {
         string json = """
@@ -919,20 +878,18 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Unexpected error parsing event JSON"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Error));
-        }
+        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
+        Assert.Single(logs);
+        Assert.Contains("Unexpected error parsing event JSON", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportRaisesUnknownMessageEventForEventMessageDeserializingToNonEventMessageType()
     {
         string json = """
@@ -966,20 +923,18 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventRaised, Is.True);
-            Assert.That(loggedEvent, Is.EqualTo(json));
-            Assert.That(logs, Has.Count.EqualTo(1));
-            Assert.That(logs[0].Message, Contains.Substring("Deserialization of event message returned null"));
-            Assert.That(logs[0].Level, Is.EqualTo(WebDriverBiDiLogLevel.Error));
-        }
+        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(eventRaised);
+        Assert.Equal(json, loggedEvent);
+        Assert.Single(logs);
+        Assert.Contains("Deserialization of event message returned null", logs[0].Message);
+        Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportCanUseDefaultConnection()
     {
         ManualResetEvent connectionSyncEvent = new(false);
@@ -991,25 +946,25 @@ public class TransportTests
         await server.StartAsync();
 
         Transport transport = new();
-        await transport.ConnectAsync($"ws://localhost:{server.Port}");
+        await transport.ConnectAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         bool connectionEventRaised = connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
 
         await server.StopAsync();
         dataReceivedObserver.Unobserve();
         connectedObserver.Unobserve(); ;
-        Assert.That(connectionEventRaised, Is.True);
+        Assert.True(connectionEventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCannotConnectWhenAlreadyConnected()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync($"ws://localhost:1234");
-        Assert.That(async () => await transport.ConnectAsync($"ws://localhost:5678"), Throws.InstanceOf<WebDriverBiDiException>().With.Message.StartsWith($"The transport is already connected to ws://localhost:1234"));
+        await transport.ConnectAsync($"ws://localhost:1234", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.StartsWith($"The transport is already connected to ws://localhost:1234", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.ConnectAsync($"ws://localhost:5678", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConcurrentConnectAsyncCallsAreSerialized()
     {
         TaskCompletionSource startBarrier = new();
@@ -1019,26 +974,26 @@ public class TransportTests
         };
         Transport transport = new(connection);
 
-        Task firstConnect = transport.ConnectAsync("ws://localhost:1234");
-        Assert.That(firstConnect.IsCompleted, Is.False);
+        Task firstConnect = transport.ConnectAsync("ws://localhost:1234", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(firstConnect.IsCompleted);
 
-        Task secondConnect = transport.ConnectAsync("ws://localhost:5678");
+        Task secondConnect = transport.ConnectAsync("ws://localhost:5678", cancellationToken: TestContext.Current.CancellationToken);
 
         startBarrier.SetResult();
         await firstConnect;
 
-        Assert.That(async () => await secondConnect, Throws.InstanceOf<WebDriverBiDiException>().With.Message.StartsWith("The transport is already connected"));
+        Assert.StartsWith("The transport is already connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await secondConnect)).Message);
     }
 
-    [Test]
-    public void TestDisconnectWhenNotConnectedDoesNotThrow()
+    [Fact]
+    public async Task TestDisconnectWhenNotConnectedDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(async () => await transport.DisconnectAsync(), Throws.Nothing);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConcurrentDisconnectCallsAreThreadSafe()
     {
         // This test verifies the double-checked locking fix for the race condition
@@ -1051,7 +1006,7 @@ public class TransportTests
             DisconnectDelay = TimeSpan.FromMilliseconds(50)
         };
 
-        await transport.ConnectAsync("ws://localhost");
+        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         // Launch multiple concurrent disconnect calls
         const int concurrentCalls = 5;
@@ -1059,7 +1014,7 @@ public class TransportTests
 
         for (int i = 0; i < concurrentCalls; i++)
         {
-            disconnectTasks[i] = Task.Run(async () => await transport.DisconnectAsync());
+            disconnectTasks[i] = Task.Run(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
         }
 
         // Wait for all disconnect calls to complete
@@ -1067,14 +1022,14 @@ public class TransportTests
 
         // Verify that:
         // 1. All disconnect tasks completed successfully (no exceptions)
-        Assert.That(disconnectTasks, Has.All.Property("IsCompletedSuccessfully").True);
+        Assert.All(disconnectTasks, item => Assert.True(item.IsCompletedSuccessfully));
 
         // 2. The connection's StopAsync was only called once (not multiple times)
         // This verifies that the double-checked locking prevented redundant disconnect logic
-        Assert.That(connection.StopCallCount, Is.EqualTo(1), "Connection.StopAsync should only be called once despite concurrent disconnect calls");
+        Assert.Equal(1, connection.StopCallCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisconnectSecondCallHitsDoubleCheckAndReturnsEarly()
     {
         // This test specifically exercises the double-check branch where a thread
@@ -1086,13 +1041,13 @@ public class TransportTests
             DisconnectDelay = TimeSpan.FromMilliseconds(100)
         };
 
-        await transport.ConnectAsync("ws://localhost");
+        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         // Start first disconnect (will take 100ms)
-        Task firstDisconnect = Task.Run(async () => await transport.DisconnectAsync());
+        Task firstDisconnect = Task.Run(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
 
         // Give first disconnect time to start and set IsConnected = false
-        await Task.Delay(TimeSpan.FromMilliseconds(20));
+        await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
 
         // Start second disconnect while first is still running
         // This should:
@@ -1101,37 +1056,37 @@ public class TransportTests
         // 3. Acquire semaphore after first disconnect completes
         // 4. Hit the double-check and find IsConnected = false
         // 5. Return early without executing disconnect logic
-        Task secondDisconnect = Task.Run(async () => await transport.DisconnectAsync());
+        Task secondDisconnect = Task.Run(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
 
         // Wait for both to complete
         await Task.WhenAll(firstDisconnect, secondDisconnect);
 
         // Verify both completed successfully
-        Assert.That(firstDisconnect.IsCompletedSuccessfully, Is.True);
-        Assert.That(secondDisconnect.IsCompletedSuccessfully, Is.True);
+        Assert.True(firstDisconnect.IsCompletedSuccessfully);
+        Assert.True(secondDisconnect.IsCompletedSuccessfully);
 
         // Verify disconnect logic only executed once (the double-check prevented the second execution)
-        Assert.That(connection.StopCallCount, Is.EqualTo(1), "Connection.StopAsync should only be called once due to double-check");
+        Assert.Equal(1, connection.StopCallCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisconnectWithMultipleConcurrentCallsOperatesCorrectly()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost");
+        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task task1 = transport.DisconnectAsync();
-        Task task2 = transport.DisconnectAsync();
+        Task task1 = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Task task2 = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         await Task.WhenAll(task1, task2);
 
-        Assert.That(connection.StopCallCount, Is.EqualTo(1));
-        Assert.That(transport.ConcurrentConnectLockAcquisitions, Is.EqualTo(2));
+        Assert.Equal(1, connection.StopCallCount);
+        Assert.Equal(2, transport.ConcurrentConnectLockAcquisitions);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisconnectMultipleTimesAfterAlreadyDisconnectedHitsFastPath()
     {
         // This test verifies that calling disconnect on an already-disconnected transport
@@ -1139,26 +1094,26 @@ public class TransportTests
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost");
+        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         // First disconnect - this will set IsConnected = false
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Verify the first disconnect executed fully
-        Assert.That(connection.StopCallCount, Is.EqualTo(1));
+        Assert.Equal(1, connection.StopCallCount);
 
         // Second disconnect - should hit the fast-path check and return immediately
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // The fast-path check prevents the disconnect logic from executing
-        Assert.That(connection.StopCallCount, Is.EqualTo(1), "Connection.StopAsync should only be called once");
+        Assert.Equal(1, connection.StopCallCount);
 
         // Third call for good measure
-        await transport.DisconnectAsync();
-        Assert.That(connection.StopCallCount, Is.EqualTo(1), "Connection.StopAsync should still only be called once after third disconnect");
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, connection.StopCallCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportDisconnectWithPendingIncomingMessagesWillProcess()
     {
         string receivedName = string.Empty;
@@ -1187,22 +1142,21 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(receivedName, Is.EqualTo("protocol.event"));
-            Assert.That(receivedData, Is.TypeOf<TestEventArgs>());
-        }
+        Assert.True(eventRaised);
+
+        Assert.Equal("protocol.event", receivedName);
+        Assert.IsType<TestEventArgs>(receivedData);
+
         TestEventArgs? convertedData = receivedData as TestEventArgs;
-        Assert.That(convertedData, Is.Not.Null);
-        Assert.That(convertedData.ParamName, Is.EqualTo("paramValue"));
+        Assert.NotNull(convertedData);
+        Assert.Equal("paramValue", convertedData.ParamName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportCanReuseConnectionToDifferentUrl()
     {
         string commandName = "module.command";
@@ -1219,24 +1173,24 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws://example.com:1234");
+        await transport.ConnectAsync("ws://example.com:1234", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new(commandName);
-        _ = await transport.SendCommandAsync(command);
+        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
-        Assert.That(dataValue, Is.EquivalentTo(expected));
-        await transport.DisconnectAsync();
+        Assert.Equivalent(expected, dataValue);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        await transport.ConnectAsync("ws://example.com:5678");
-        _ = await transport.SendCommandAsync(command);
+        await transport.ConnectAsync("ws://example.com:5678", cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
 
         dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
-        Assert.That(dataValue, Is.EquivalentTo(expected));
-        await transport.DisconnectAsync();
+        Assert.Equivalent(expected, dataValue);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInTransportEventReceivedCanCollect()
     {
         string receivedName = string.Empty;
@@ -1262,13 +1216,16 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(async () => await transport.DisconnectAsync(), Throws.InstanceOf<AggregateException>().With.InnerException.InstanceOf<WebDriverBiDiException>().And.Message.Contains("Normal shutdown").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("This is an unexpected exception"));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("This is an unexpected exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInTransportEventReceivedCanCollectMultiple()
     {
         string receivedName = string.Empty;
@@ -1300,16 +1257,20 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
         syncEvent.Reset();
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(async () => await transport.DisconnectAsync(), Throws.InstanceOf<AggregateException>().With.Message.Contains("Normal shutdown").And.Property("InnerExceptions").Count.EqualTo(2).And.Property("InnerExceptions").All.InstanceOf<WebDriverBiDiException>().And.Message.Contains("This is an unexpected exception"));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.Equal(2, exception.InnerExceptions.Count);
+        Assert.All(exception.InnerExceptions, e => Assert.IsType<WebDriverBiDiException>(e));
+        Assert.All(exception.InnerExceptions, e => Assert.Contains("This is an unexpected exception", e.Message));
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInTransportEventReceivedCanTerminate()
     {
         string receivedName = string.Empty;
@@ -1341,16 +1302,19 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("protocol.event").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("This is an unexpected exception"));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("protocol.event", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("This is an unexpected exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncExceptionInTransportEventReceivedCanCollect()
     {
         TaskCompletionSource<bool> handlerCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1382,16 +1346,19 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Collect);
-        Assert.That(errorPropagated, Is.True, "The transport should collect the late async aggregate handler failure before shutdown.");
+        Assert.True(errorPropagated);
 
-        Assert.That(async () => await transport.DisconnectAsync(), Throws.InstanceOf<AggregateException>().With.InnerException.InstanceOf<WebDriverBiDiException>().And.Message.Contains("Normal shutdown").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("This is an async unexpected exception"));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("This is an async unexpected exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAsyncExceptionInTransportEventReceivedCanTerminate()
     {
         TaskCompletionSource<bool> handlerCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1423,18 +1390,21 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Terminate);
-        Assert.That(errorPropagated, Is.True, "The transport should collect the late async aggregate handler failure before shutdown.");
+        Assert.True(errorPropagated);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("protocol.event").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("This is an async unexpected exception"));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("protocol.event", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("This is an async unexpected exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCapturedExceptionsCanBeReset()
     {
         string receivedName = string.Empty;
@@ -1457,11 +1427,11 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         string commandName = "module.command";
         Dictionary<string, object?> expectedCommandParameters = new()
         {
@@ -1474,23 +1444,23 @@ public class TransportTests
             { "params", expectedCommandParameters }
         };
         TestCommandParameters commandParameters = new(commandName);
-        _ = await transport.SendCommandAsync(commandParameters);
+        _ = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
-        Assert.That(dataValue, Is.EquivalentTo(expected));
+        Assert.Equivalent(expected, dataValue);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportTracksCommandId()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        Assert.That(transport.LastTestCommandId, Is.Zero);
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, transport.LastTestCommandId);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -1504,39 +1474,40 @@ public class TransportTests
                           """;
             await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
-        });
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
-        Assert.That(transport.LastTestCommandId, Is.EqualTo(1));
+        },
+        TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, transport.LastTestCommandId);
     }
 
-    [Test]
-    public void TestTransportSubclassesCanAccessConnection()
+    [Fact]
+    public async Task TestTransportSubclassesCanAccessConnection()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        Assert.That(transport.GetConnection(), Is.EqualTo(connection));
+        Assert.Equal(connection, transport.GetConnection());
     }
 
-    [Test]
-    public void TestTransportShutdownTimeoutDefaultValue()
+    [Fact]
+    public async Task TestTransportShutdownTimeoutDefaultValue()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(transport.ShutdownTimeout, Is.EqualTo(TimeSpan.FromSeconds(10)));
+        Assert.Equal(TimeSpan.FromSeconds(10), transport.ShutdownTimeout);
     }
 
-    [Test]
-    public void TestTransportShutdownTimeoutCanBeSet()
+    [Fact]
+    public async Task TestTransportShutdownTimeoutCanBeSet()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
         {
             ShutdownTimeout = TimeSpan.FromSeconds(1)
         };
-        Assert.That(transport.ShutdownTimeout, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.Equal(TimeSpan.FromSeconds(1), transport.ShutdownTimeout);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportIncomingQueueDepthReflectsPendingMessages()
     {
         using ManualResetEventSlim handlerStarted = new(initialState: false);
@@ -1546,13 +1517,13 @@ public class TransportTests
         Transport transport = new(connection);
 
         // Pre-connect: documented to return 0 rather than throw.
-        Assert.That(transport.IncomingQueueDepth, Is.Zero);
+        Assert.Equal(0, transport.IncomingQueueDepth);
 
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
         transport.OnEventReceived.AddObserver(e =>
         {
             handlerStarted.Set();
-            return Task.Run(() => handlerMayComplete.Wait(TimeSpan.FromSeconds(5)));
+            return Task.Run(() => handlerMayComplete.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
         });
 
         string json = """
@@ -1564,14 +1535,14 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         // Raise the first message and wait until the reader has pulled it and begun
         // running the handler. At this point the reader is blocked inside the handler
         // and will not consume additional queued messages until the gate is released.
         await connection.RaiseDataReceivedEventAsync(json);
-        bool handlerDidStart = handlerStarted.Wait(TimeSpan.FromSeconds(5));
-        Assert.That(handlerDidStart, Is.True);
+        bool handlerDidStart = handlerStarted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(handlerDidStart);
 
         // Enqueue two more messages while the reader is stalled. Writer.WriteAsync
         // completes synchronously for an unbounded channel, so these are observable
@@ -1579,75 +1550,75 @@ public class TransportTests
         await connection.RaiseDataReceivedEventAsync(json);
         await connection.RaiseDataReceivedEventAsync(json);
 
-        Assert.That(transport.IncomingQueueDepth, Is.EqualTo(2), "queued messages should be visible while the reader is stalled");
+        Assert.Equal(2, transport.IncomingQueueDepth);
 
         // Release the handler gate so the reader can drain.
         handlerMayComplete.Set();
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // DisconnectAsync awaits Reader.Completion before returning, so the queue
         // has drained by this point and IncomingQueueDepth must be 0. This also
         // exercises the documented post-disconnect read-without-throw contract.
-        Assert.That(transport.IncomingQueueDepth, Is.EqualTo(0));
+        Assert.Equal(0, transport.IncomingQueueDepth);
     }
 
-    [Test]
-    public void TestTransportPendingCommandCountIsZeroBeforeConnect()
+    [Fact]
+    public async Task TestTransportPendingCommandCountIsZeroBeforeConnect()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
 
         // Documented behavior: reads before ConnectAsync return zero rather than throw.
-        Assert.That(transport.PendingCommandCount, Is.Zero);
+        Assert.Equal(0, transport.PendingCommandCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportPendingCommandCountReflectsSentCommands()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(transport.PendingCommandCount, Is.Zero, "no commands sent yet");
+        Assert.Equal(0, transport.PendingCommandCount);
 
-        Command firstCommand = await transport.SendCommandAsync(new TestCommandParameters("module.first"));
-        Assert.That(transport.PendingCommandCount, Is.EqualTo(1), "one command awaiting response");
+        Command firstCommand = await transport.SendCommandAsync(new TestCommandParameters("module.first"), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, transport.PendingCommandCount);
 
-        Command secondCommand = await transport.SendCommandAsync(new TestCommandParameters("module.second"));
-        Assert.That(transport.PendingCommandCount, Is.EqualTo(2), "two commands awaiting response");
+        Command secondCommand = await transport.SendCommandAsync(new TestCommandParameters("module.second"), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(2, transport.PendingCommandCount);
 
         // Complete the first command by delivering its matching success response.
         string firstResponseJson = $$$"""{"type":"success","id":{{{firstCommand.CommandId}}},"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(firstResponseJson);
-        await firstCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5));
-        Assert.That(transport.PendingCommandCount, Is.EqualTo(1), "one command remains after first response");
+        await firstCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, transport.PendingCommandCount);
 
         // Complete the second command similarly.
         string secondResponseJson = $$$"""{"type":"success","id":{{{secondCommand.CommandId}}},"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(secondResponseJson);
-        await secondCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5));
-        Assert.That(transport.PendingCommandCount, Is.Zero, "no commands remain after all responses");
+        await secondCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, transport.PendingCommandCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportPendingCommandCountIsZeroAfterDisconnect()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         // Send a command and do not deliver a response, so it sits in the pending collection.
-        _ = await transport.SendCommandAsync(new TestCommandParameters("module.command"));
-        Assert.That(transport.PendingCommandCount, Is.EqualTo(1), "command pending before disconnect");
+        _ = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, transport.PendingCommandCount);
 
         // DisconnectAsync closes and clears the pending command collection; the property
         // must reflect the cleared state and must not throw post-disconnect.
-        await transport.DisconnectAsync();
-        Assert.That(transport.PendingCommandCount, Is.Zero);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, transport.PendingCommandCount);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMessageProcessingTaskFaultIsCapturedAsUnhandledError()
     {
         // This test exercises the fault continuation attached to
@@ -1671,28 +1642,26 @@ public class TransportTests
             ProtocolErrorBehavior = TransportErrorBehavior.Collect,
         };
 
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         bool faultCaptured = await transport.WaitForCollectedEventHandlerExceptionAsync(
             TimeSpan.FromSeconds(5),
             TransportErrorBehavior.Collect);
         if (!faultCaptured)
         {
-            Assert.Fail("the fault-capture continuation should record the injected fault before the safety timeout");
+            throw new Xunit.Sdk.XunitException("the fault-capture continuation should record the injected fault before the safety timeout");
         }
 
         // Under Collect mode, DisconnectAsync surfaces the captured fault as an
         // AggregateException whose single inner exception wraps the injected fault.
-        AggregateException? caught = Assert.ThrowsAsync<AggregateException>(
-            async () => await transport.DisconnectAsync());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(caught, Is.Not.Null);
-            Assert.That(caught!.InnerExceptions, Has.Count.EqualTo(1));
-            Assert.That(caught.InnerExceptions[0], Is.SameAs(injectedFault));
-        }
+        AggregateException? caught = await Assert.ThrowsAsync<AggregateException>(
+            async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.NotNull(caught);
+        Assert.Single(caught.InnerExceptions);
+        Assert.Same(injectedFault, caught.InnerExceptions[0]);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMessageProcessingTaskFaultWithMultipleInnerExceptionsIsCapturedAsAggregate()
     {
         // Companion to TestMessageProcessingTaskFaultIsCapturedAsUnhandledError.
@@ -1709,13 +1678,13 @@ public class TransportTests
             ProtocolErrorBehavior = TransportErrorBehavior.Collect,
         };
 
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         bool faultCaptured = await transport.WaitForCollectedEventHandlerExceptionAsync(
             TimeSpan.FromSeconds(5),
             TransportErrorBehavior.Collect);
         if (!faultCaptured)
         {
-            Assert.Fail("the fault-capture continuation should record the injected faults before the safety timeout");
+            throw new Xunit.Sdk.XunitException("the fault-capture continuation should record the injected faults before the safety timeout");
         }
 
         // Under Collect mode, DisconnectAsync surfaces the captured fault as an
@@ -1723,21 +1692,19 @@ public class TransportTests
         // AggregateException with multiple inner exceptions, the library
         // forwarded it whole — so the outer aggregate has a single inner that
         // is itself an AggregateException containing both injected faults.
-        AggregateException? caught = Assert.ThrowsAsync<AggregateException>(
-            async () => await transport.DisconnectAsync());
-        Assert.That(caught, Is.Not.Null);
-        Assert.That(caught!.InnerExceptions, Has.Count.EqualTo(1));
+        AggregateException? caught = await Assert.ThrowsAsync<AggregateException>(
+            async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.NotNull(caught);
+        Assert.Single(caught.InnerExceptions);
         AggregateException? forwardedAggregate = caught.InnerExceptions[0] as AggregateException;
-        Assert.That(forwardedAggregate, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(forwardedAggregate!.InnerExceptions, Has.Count.EqualTo(2));
-            Assert.That(forwardedAggregate.InnerExceptions, Contains.Item(firstFault));
-            Assert.That(forwardedAggregate.InnerExceptions, Contains.Item(secondFault));
-        }
+        Assert.NotNull(forwardedAggregate);
+
+        Assert.Equal(2, forwardedAggregate.InnerExceptions.Count);
+        Assert.Contains(firstFault, forwardedAggregate.InnerExceptions);
+        Assert.Contains(secondFault, forwardedAggregate.InnerExceptions);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportDisconnectTimesOutWithHangingEventHandler()
     {
         ManualResetEvent handlerStarted = new(false);
@@ -1769,19 +1736,19 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         bool handlerDidStart = handlerStarted.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(handlerDidStart, Is.True);
+        Assert.True(handlerDidStart);
 
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Timed out waiting for message processing to complete during shutdown")
-                   && log.Level == WebDriverBiDiLogLevel.Warn));
+                   && log.Level == WebDriverBiDiLogLevel.Warn);
     }
 
-    [Test]
+    [Fact]
     public async Task TestTransportDisconnectCompletesWithinShutdownTimeout()
     {
         List<LogMessageEventArgs> logs = [];
@@ -1797,82 +1764,82 @@ public class TransportTests
             return Task.CompletedTask;
         });
 
-        await transport.ConnectAsync("ws:localhost");
-        await transport.DisconnectAsync();
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(logs, Has.None.Matches<LogMessageEventArgs>(
-            log => log.Message.Contains("Timed out waiting for message processing to complete during shutdown")));
+        Assert.DoesNotContain(logs,
+            log => log.Message.Contains("Timed out waiting for message processing to complete during shutdown"));
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeWithoutConnecting()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAfterConnectAndDisconnect()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        await transport.DisconnectAsync();
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeWhileConnected()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeDoesNotThrow()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await transport.DisposeAsync();
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeDefaultTransport()
     {
         Transport transport = new();
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeDisposesOldPendingCommandsAfterReconnect()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        await transport.DisconnectAsync();
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        await transport.ConnectAsync("ws:localhost");
-        await transport.DisconnectAsync();
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeSuppressesDisconnectException()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         transport.ThrowOnDisconnect = true;
-        Assert.That(async () => await transport.DisposeAsync(), Throws.Nothing);
+        await transport.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeLogsExceptionFromDisconnect()
     {
         List<LogMessageEventArgs> logs = [];
@@ -1883,17 +1850,17 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         transport.ThrowOnDisconnect = true;
         await transport.DisposeAsync();
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Unexpected exception during disposal")
                    && log.Message.Contains("Simulated disconnect failure")
                    && log.Level == WebDriverBiDiLogLevel.Warn
-                   && log.ComponentName == Transport.LoggerComponentName));
+                   && log.ComponentName == Transport.LoggerComponentName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMessageProcessingLoopContinuesAfterUnhandledException()
     {
         string commandName = "module.command";
@@ -1910,12 +1877,12 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         transport.DeserializeThrowCount = 1;
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         await connection.RaiseDataReceivedEventAsync("this message will cause the exception");
 
@@ -1931,25 +1898,24 @@ public class TransportTests
         _ = Task.Run(async () =>
         {
             await connection.RaiseDataReceivedEventAsync(responseJson);
-        });
+        },
+        TestContext.Current.CancellationToken);
 
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(1));
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
 
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        Assert.That(hasResult, Is.True);
-        Assert.That(commandResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(commandResult.IsError, Is.False);
-            Assert.That(commandResult, Is.TypeOf<TestCommandResult>());
-            Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
-                log => log.Message.Contains("Unexpected error in message processing loop")
-                       && log.Message.Contains("Simulated deserialization failure")
-                       && log.Level == WebDriverBiDiLogLevel.Error));
-        }
+        Assert.True(hasResult);
+        Assert.NotNull(commandResult);
+
+        Assert.False(commandResult.IsError);
+        Assert.IsType<TestCommandResult>(commandResult);
+        Assert.Contains(logs,
+            log => log.Message.Contains("Unexpected error in message processing loop")
+                   && log.Message.Contains("Simulated deserialization failure")
+                   && log.Level == WebDriverBiDiLogLevel.Error);
     }
 
-    [Test]
+    [Fact]
     public async Task TestMessageProcessingLoopExceptionCapturedAsUnhandledError()
     {
         ManualResetEventSlim syncEvent = new(false);
@@ -1968,151 +1934,145 @@ public class TransportTests
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         transport.DeserializeThrowCount = 1;
         await connection.RaiseDataReceivedEventAsync("this message will cause the exception");
-        syncEvent.Wait(TimeSpan.FromSeconds(1));
+        syncEvent.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(
-            async () => await transport.DisconnectAsync(),
-            Throws.InstanceOf<AggregateException>()
-                .With.Message.Contains("Normal shutdown")
-                .And.InnerException.InstanceOf<InvalidOperationException>()
-                .And.InnerException.Message.Contains("Simulated deserialization failure"));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("Simulated deserialization failure", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCancelCommandRemovesFromPendingAndCancelsCommand()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"));
-        Assert.That(command.IsCanceled, Is.False);
+        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(command.IsCanceled);
 
         transport.CancelCommand(command);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(command.IsCanceled, Is.True);
-            Assert.That(hasResult, Is.False);
-            Assert.That(commandResult, Is.Null);
-        }
+
+        Assert.True(command.IsCanceled);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCancelCommandIsIdempotent()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"));
+        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
         transport.CancelCommand(command);
-        Assert.That(() => transport.CancelCommand(command), Throws.Nothing);
+        transport.CancelCommand(command);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCancelCommandPreventsLateResponseFromSettingResult()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"));
+        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
         transport.CancelCommand(command);
 
         string responseJson = $$$"""{"type":"success","id":{{{command.CommandId}}},"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(responseJson);
-        await Task.Delay(50);
+        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(command.IsCanceled, Is.True);
-            Assert.That(hasResult, Is.False);
-            Assert.That(commandResult, Is.Null);
-        }
+
+        Assert.True(command.IsCanceled);
+        Assert.False(hasResult);
+        Assert.Null(commandResult);
     }
 
-    [Test]
-    public void TestRegisterTypeInfoResolverBeforeConnecting()
+    [Fact]
+    public async Task TestRegisterTypeInfoResolverBeforeConnecting()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        Assert.That(async () => await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver()), Throws.Nothing);
+        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterTypeInfoResolverMultipleTimesBeforeConnecting()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver());
-        Assert.That(async () => await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver()), Throws.Nothing);
+        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
+        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterTypeInfoResolverAfterConnectingThrows()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        Assert.That(async () => await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver()), Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("Cannot register a type info resolver after the transport is connected"));
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains("Cannot register a type info resolver after the transport is connected", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRegisterTypeInfoDuringConnectIsSynchronized()
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task connectTask = transport.ConnectAsync("ws:localhost");
-        Task registerTask = transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver());
+        Task connectTask = transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        Task registerTask = transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
         await connectTask;
 
-        Assert.That(async () => await registerTask, Throws.InstanceOf<InvalidOperationException>().With.Message.Contains("Cannot register a type info resolver after the transport is connected"));
+        Assert.Contains("Cannot register a type info resolver after the transport is connected", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await registerTask)).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorFailsPendingCommands()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("WebSocket connection dropped");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(command.ThrownException, Is.InstanceOf<WebDriverBiDiConnectionException>());
-        Assert.That(command.ThrownException!.Message, Does.Contain("Unexpected connection error"));
-        Assert.That(command.ThrownException!.InnerException, Is.SameAs(simulatedError));
+        Assert.IsType<WebDriverBiDiConnectionException>(command.ThrownException);
+        Assert.Contains("Unexpected connection error", command.ThrownException.Message);
+        Assert.Same(simulatedError, command.ThrownException.InnerException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorPreventsNewCommands()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("WebSocket connection dropped");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
 
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorLogsMessage()
     {
         List<LogMessageEventArgs> logs = [];
@@ -2123,18 +2083,18 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("WebSocket connection dropped");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
 
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Connection error; pending commands failed")
                    && log.Message.Contains("WebSocket connection dropped")
-                   && log.Level == WebDriverBiDiLogLevel.Error));
+                   && log.Level == WebDriverBiDiLogLevel.Error);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorWhenNotConnectedDoesNothing()
     {
         TestWebSocketConnection connection = new();
@@ -2145,26 +2105,26 @@ public class TransportTests
 
         // Should not throw; early return path taken. Verify transport rejects commands.
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorWhenAlreadyDisconnectedDoesNothing()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        await transport.DisconnectAsync();
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // IsConnected is now false; raise error (e.g., receive loop dying during shutdown)
         await connection.RaiseConnectionErrorEventAsync(new Exception("Connection lost"));
 
         // Should not throw; early return path taken. Verify still disconnected.
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorWhenDisconnectRacesHitsInnerReturnBranch()
     {
         // Covers the inner "if (!this.IsConnected) return" branch (line 609): OnConnectionErrorAsync
@@ -2172,73 +2132,70 @@ public class TransportTests
         // DisconnectAsync has already set IsConnected = false.
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task disconnectTask = transport.DisconnectAsync();
+        Task disconnectTask = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseConnectionErrorEventAsync(new Exception("Connection lost during race"));
         await disconnectTask;
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionErrorFailsMultiplePendingCommands()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"));
-        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"));
+        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"), cancellationToken: TestContext.Current.CancellationToken);
+        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"), cancellationToken: TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("connection lost");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
 
-        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
-        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(command1.ThrownException, Is.InstanceOf<WebDriverBiDiConnectionException>());
-            Assert.That(command2.ThrownException, Is.InstanceOf<WebDriverBiDiConnectionException>());
-        }
+        Assert.IsType<WebDriverBiDiConnectionException>(command1.ThrownException);
+        Assert.IsType<WebDriverBiDiConnectionException>(command2.ThrownException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectFailsPendingCommands()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters);
+        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(command.ThrownException, Is.InstanceOf<WebDriverBiDiConnectionException>());
-        Assert.That(command.ThrownException!.Message, Does.Contain("Remote end closed the connection"));
+        Assert.IsType<WebDriverBiDiConnectionException>(command.ThrownException);
+        Assert.Contains("Remote end closed the connection", command.ThrownException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectPreventsNewCommands()
     {
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectLogsMessage()
     {
         List<LogMessageEventArgs> logs = [];
@@ -2249,16 +2206,16 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Remote end closed connection")
-                   && log.Level == WebDriverBiDiLogLevel.Warn));
+                   && log.Level == WebDriverBiDiLogLevel.Warn);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectWhenNotConnectedDoesNothing()
     {
         TestWebSocketConnection connection = new();
@@ -2267,46 +2224,43 @@ public class TransportTests
         await connection.RaiseRemoteDisconnectedEventAsync();
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectWhenAlreadyDisconnectedDoesNothing()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
-        await transport.DisconnectAsync();
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectFailsMultiplePendingCommands()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"));
-        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"));
+        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"), cancellationToken: TestContext.Current.CancellationToken);
+        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"), cancellationToken: TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
-        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
-        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250));
+        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(command1.ThrownException, Is.InstanceOf<WebDriverBiDiConnectionException>());
-            Assert.That(command2.ThrownException, Is.InstanceOf<WebDriverBiDiConnectionException>());
-        }
+        Assert.IsType<WebDriverBiDiConnectionException>(command1.ThrownException);
+        Assert.IsType<WebDriverBiDiConnectionException>(command2.ThrownException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestRemoteDisconnectWhenDisconnectRacesHitsInnerReturnBranch()
     {
         // Covers the inner "if (!this.IsConnected) return" branch in OnConnectionRemotelyDisconnectedAsync:
@@ -2314,18 +2268,18 @@ public class TransportTests
         // DisconnectAsync has already set IsConnected = false.
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task disconnectTask = transport.DisconnectAsync();
+        Task disconnectTask = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseRemoteDisconnectedEventAsync();
         await disconnectTask;
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiConnectionException>().With.Message.Contains("Transport must be connected"));
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInErrorEventHandlerIsIgnoredByDefault()
     {
         ManualResetEvent syncEvent = new(false);
@@ -2345,13 +2299,13 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInErrorEventHandlerCanCollect()
     {
         ManualResetEvent syncEvent = new(false);
@@ -2374,13 +2328,16 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(async () => await transport.DisconnectAsync(), Throws.InstanceOf<AggregateException>().With.InnerException.InstanceOf<WebDriverBiDiException>().And.With.Message.Contains("Normal shutdown").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("Error handler exception"));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("Error handler exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInErrorEventHandlerCanTerminate()
     {
         ManualResetEvent syncEvent = new(false);
@@ -2403,16 +2360,20 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("error event").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("Error handler exception"));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("error event", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("Error handler exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInUnknownMessageHandlerIsIgnoredByDefault()
     {
         ManualResetEvent syncEvent = new(false);
@@ -2429,13 +2390,13 @@ public class TransportTests
                         "type": "unknown"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await transport.DisconnectAsync();
+        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInUnknownMessageHandlerCanCollect()
     {
         ManualResetEvent syncEvent = new(false);
@@ -2455,13 +2416,16 @@ public class TransportTests
                         "type": "unknown"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(async () => await transport.DisconnectAsync(), Throws.InstanceOf<AggregateException>().With.InnerException.InstanceOf<WebDriverBiDiException>().And.With.Message.Contains("Normal shutdown").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("Unknown message handler exception"));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Normal shutdown", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("Unknown message handler exception", exception.InnerException.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExceptionInUnknownMessageHandlerCanTerminate()
     {
         ManualResetEvent syncEvent = new(false);
@@ -2481,36 +2445,39 @@ public class TransportTests
                         "type": "unknown"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost");
+        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         syncEvent.WaitOne(TimeSpan.FromSeconds(1));
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("unknown message event").And.InnerException.InstanceOf<WebDriverBiDiException>().And.InnerException.Message.Contains("Unknown message handler exception"));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("unknown message event", exception.Message);
+        Assert.IsType<WebDriverBiDiException>(exception.InnerException);
+        Assert.Contains("Unknown message handler exception", exception.InnerException.Message);
     }
 
-    [Test]
-    public void TestConnectAsyncThrowsWhenCancellationTokenIsCanceled()
+    [Fact]
+    public async Task TestConnectAsyncThrowsWhenCancellationTokenIsCanceled()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        Assert.That(async () => await transport.ConnectAsync("ws://localhost", cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await transport.ConnectAsync("ws://localhost", cts.Token));
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendCommandAsyncThrowsWhenCancellationTokenIsCanceled()
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws://localhost");
+        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.That(async () => await transport.SendCommandAsync(commandParameters, cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await transport.SendCommandAsync(commandParameters, cts.Token));
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
@@ -24,10 +24,10 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new(commandName);
-        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(command, TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
         Assert.Equivalent(expected, dataValue);
@@ -51,10 +51,10 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestComplexCommandParameters command = new(commandName);
-        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(command, TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
         Assert.Equivalent(expected, dataValue);
@@ -66,10 +66,10 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -81,11 +81,10 @@ public class TransportTests
                             }
                           }
                           """;
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
         },
         TestContext.Current.CancellationToken);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
         Assert.NotNull(actualResult);
@@ -104,10 +103,10 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -120,11 +119,10 @@ public class TransportTests
                             "extraDataName": "extraDataValue"
                           }
                           """;
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
         },
         TestContext.Current.CancellationToken);
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
         Assert.NotNull(actualResult);
@@ -146,10 +144,10 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -160,11 +158,10 @@ public class TransportTests
                             "message": "This is a test error message"
                           }
                           """;
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
         },
         TestContext.Current.CancellationToken);
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
         Assert.NotNull(actualResult);
@@ -187,10 +184,10 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -203,11 +200,10 @@ public class TransportTests
                             }
                           }
                           """;
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
         },
         TestContext.Current.CancellationToken);
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), TestContext.Current.CancellationToken);
         Assert.IsType<WebDriverBiDiSerializationException>(command.ThrownException);
         Assert.Contains("Response did not contain properly formed JSON for response type", command.ThrownException.Message);
     }
@@ -220,7 +216,7 @@ public class TransportTests
         Transport transport = new(connection);
 
         TestCommandParameters commandParameters = new(commandName);
-        Assert.Contains("Transport must be connected to a remote end to execute commands.", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected to a remote end to execute commands.", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -229,10 +225,10 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
 
         Assert.False(hasResult);
@@ -248,10 +244,10 @@ public class TransportTests
             SendWebSocketDataOverride = _ => throw new InvalidOperationException("Simulated send failure"),
         };
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Simulated send failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Simulated send failure", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
 
         Assert.Equal(0, transport.TestPendingCommandCount);
     }
@@ -259,22 +255,22 @@ public class TransportTests
     [Fact]
     public async Task TestSendCommandCancellationRollsBackPendingCommandState()
     {
-        ManualResetEventSlim sendStarted = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         using CancellationTokenSource cancellationTokenSource = new();
         TestWebSocketConnection connection = new()
         {
             SendWebSocketDataOverride = async _ =>
             {
-                sendStarted.Set();
+                taskCompletionSource.TrySetResult();
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationTokenSource.Token);
             },
         };
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new("module.command");
         Task<Command> sendTask = transport.SendCommandAsync(commandParameters, cancellationTokenSource.Token);
-        sendStarted.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         cancellationTokenSource.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sendTask);
@@ -287,7 +283,7 @@ public class TransportTests
     {
         string receivedName = string.Empty;
         object? receivedData = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -296,7 +292,7 @@ public class TransportTests
         {
             receivedName = e.EventName;
             receivedData = e.EventData;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         string json = """
@@ -304,13 +300,13 @@ public class TransportTests
                         "type": "event",
                         "method": "protocol.event",
                         "params": {
-                          "paramName": "paramValue" 
+                          "paramName": "paramValue"
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal("protocol.event", receivedName);
         Assert.IsType<TestEventArgs>(receivedData);
@@ -324,14 +320,14 @@ public class TransportTests
     public async Task TestTransportErrorEventReceived()
     {
         object? receivedData = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
         {
             receivedData = e.ErrorData;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         string json = """
@@ -342,9 +338,9 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.IsType<ErrorResult>(receivedData);
         ErrorResult? convertedData = receivedData as ErrorResult;
@@ -359,14 +355,14 @@ public class TransportTests
     public async Task TestTransportErrorEventReceivedWithNullValues()
     {
         object? receivedData = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             receivedData = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
@@ -379,10 +375,9 @@ public class TransportTests
                         "method": null
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -396,7 +391,7 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseLogMessageEventAsync("test log message", WebDriverBiDiLogLevel.Warn);
         Assert.Single(logs);
 
@@ -407,22 +402,21 @@ public class TransportTests
     [Fact]
     public async Task TestTransportLogsSuccessfulCommandResponses()
     {
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        TaskCompletionSource logCompletionSource = new();
         transport.OnLogMessage.AddObserver((e) =>
         {
             logs.Add(e);
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         string commandName = "module.command";
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -434,11 +428,10 @@ public class TransportTests
                             }
                           }
                           """;
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
         },
         TestContext.Current.CancellationToken);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
         Assert.NotNull(actualResult);
@@ -449,8 +442,7 @@ public class TransportTests
         TestCommandResult? convertedResult = actualResult as TestCommandResult;
         Assert.NotNull(convertedResult);
         Assert.Equal("response value", convertedResult.Value);
-        bool logEventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.True(logEventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Single(logs);
         Assert.Contains("Command response message processed", logs[0].Message);
@@ -460,7 +452,7 @@ public class TransportTests
     [Fact]
     public async Task TestTransportLogsMalformedJsonMessages()
     {
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -469,16 +461,15 @@ public class TransportTests
             if (e.ComponentName == Transport.LoggerComponentName)
             {
                 logs.Add(e);
-                syncEvent.Set();
+                taskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync("{ { }");
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Single(logs);
         Assert.Contains("Unexpected error parsing JSON message", logs[0].Message);
         Assert.Equal(WebDriverBiDiLogLevel.Error, logs[0].Level);
@@ -496,20 +487,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -526,20 +516,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -555,20 +544,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -585,20 +573,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -615,20 +602,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -644,13 +630,14 @@ public class TransportTests
                       """;
         string loggedEvent = string.Empty;
         List<LogMessageEventArgs> logs = [];
-        CountdownEvent signaler = new(2);
+        TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            signaler.Signal();
+            unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         transport.OnLogMessage.AddObserver((e) =>
@@ -658,16 +645,17 @@ public class TransportTests
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
                 logs.Add(e);
-                signaler.Signal();
+                logTaskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.WhenAll(
+            unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
         Assert.Single(logs);
         Assert.Contains("Unexpected error parsing error JSON", logs[0].Message);
@@ -686,13 +674,14 @@ public class TransportTests
                       """;
         string loggedEvent = string.Empty;
         List<LogMessageEventArgs> logs = [];
-        CountdownEvent signaler = new(2);
+        TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            signaler.Signal();
+            unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         transport.OnLogMessage.AddObserver((e) =>
@@ -700,16 +689,17 @@ public class TransportTests
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
                 logs.Add(e);
-                signaler.Signal();
+                logTaskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.WhenAll(
+            unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
         Assert.Single(logs);
         Assert.Contains("Unexpected error parsing error JSON", logs[0].Message);
@@ -728,13 +718,14 @@ public class TransportTests
                       """;
         string loggedEvent = string.Empty;
         List<LogMessageEventArgs> logs = [];
-        CountdownEvent signaler = new(2);
+        TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            signaler.Signal();
+            unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         transport.OnLogMessage.AddObserver((e) =>
@@ -742,16 +733,17 @@ public class TransportTests
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
                 logs.Add(e);
-                signaler.Signal();
+                logTaskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.WhenAll(
+            unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
         Assert.Single(logs);
         Assert.Contains("Unexpected error parsing error JSON", logs[0].Message);
@@ -770,20 +762,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -797,20 +788,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -827,20 +817,19 @@ public class TransportTests
                       }
                       """;
         string loggedEvent = string.Empty;
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = syncEvent.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
     }
 
@@ -858,14 +847,15 @@ public class TransportTests
                       """;
         string loggedEvent = string.Empty;
         List<LogMessageEventArgs> logs = [];
-        CountdownEvent signaler = new(2);
+        TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            signaler.Signal();
+            unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         transport.OnLogMessage.AddObserver((e) =>
@@ -873,16 +863,17 @@ public class TransportTests
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
                 logs.Add(e);
-                signaler.Signal();
+                logTaskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.WhenAll(
+            unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
         Assert.Single(logs);
         Assert.Contains("Unexpected error parsing event JSON", logs[0].Message);
@@ -903,14 +894,15 @@ public class TransportTests
                       """;
         string loggedEvent = string.Empty;
         List<LogMessageEventArgs> logs = [];
-        CountdownEvent signaler = new(2);
+        TaskCompletionSource unknownMessageTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         transport.RegisterInvalidEventMessageType("protocol.event", typeof(object));
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
             loggedEvent = e.Message;
-            signaler.Signal();
+            unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         transport.OnLogMessage.AddObserver((e) =>
@@ -918,16 +910,17 @@ public class TransportTests
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
                 logs.Add(e);
-                signaler.Signal();
+                logTaskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool eventRaised = signaler.Wait(TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
+        await Task.WhenAll(
+            unknownMessageTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            logTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        Assert.True(eventRaised);
         Assert.Equal(json, loggedEvent);
         Assert.Single(logs);
         Assert.Contains("Deserialization of event message returned null", logs[0].Message);
@@ -937,22 +930,21 @@ public class TransportTests
     [Fact]
     public async Task TestTransportCanUseDefaultConnection()
     {
-        ManualResetEvent connectionSyncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         static void dataReceivedHandler(ServerDataReceivedEventArgs e) { }
-        void connectionHandler(ClientConnectionEventArgs e) { connectionSyncEvent.Set(); }
+        void connectionHandler(ClientConnectionEventArgs e) { taskCompletionSource.TrySetResult(); }
         Server server = new();
         ServerEventObserver<ServerDataReceivedEventArgs> dataReceivedObserver = server.OnDataReceived.AddObserver(dataReceivedHandler);
         ServerEventObserver<ClientConnectionEventArgs> connectedObserver = server.OnClientConnected.AddObserver(connectionHandler);
         await server.StartAsync();
 
         Transport transport = new();
-        await transport.ConnectAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
-        bool connectionEventRaised = connectionSyncEvent.WaitOne(TimeSpan.FromSeconds(1));
+        await transport.ConnectAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         await server.StopAsync();
         dataReceivedObserver.Unobserve();
-        connectedObserver.Unobserve(); ;
-        Assert.True(connectionEventRaised);
+        connectedObserver.Unobserve();
     }
 
     [Fact]
@@ -960,8 +952,8 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync($"ws://localhost:1234", cancellationToken: TestContext.Current.CancellationToken);
-        Assert.StartsWith($"The transport is already connected to ws://localhost:1234", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.ConnectAsync($"ws://localhost:5678", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        await transport.ConnectAsync($"ws://localhost:1234", TestContext.Current.CancellationToken);
+        Assert.StartsWith($"The transport is already connected to ws://localhost:1234", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.ConnectAsync($"ws://localhost:5678", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -974,10 +966,10 @@ public class TransportTests
         };
         Transport transport = new(connection);
 
-        Task firstConnect = transport.ConnectAsync("ws://localhost:1234", cancellationToken: TestContext.Current.CancellationToken);
+        Task firstConnect = transport.ConnectAsync("ws://localhost:1234", TestContext.Current.CancellationToken);
         Assert.False(firstConnect.IsCompleted);
 
-        Task secondConnect = transport.ConnectAsync("ws://localhost:5678", cancellationToken: TestContext.Current.CancellationToken);
+        Task secondConnect = transport.ConnectAsync("ws://localhost:5678", TestContext.Current.CancellationToken);
 
         startBarrier.SetResult();
         await firstConnect;
@@ -990,7 +982,7 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1006,7 +998,7 @@ public class TransportTests
             DisconnectDelay = TimeSpan.FromMilliseconds(50)
         };
 
-        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost", TestContext.Current.CancellationToken);
 
         // Launch multiple concurrent disconnect calls
         const int concurrentCalls = 5;
@@ -1014,7 +1006,7 @@ public class TransportTests
 
         for (int i = 0; i < concurrentCalls; i++)
         {
-            disconnectTasks[i] = Task.Run(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+            disconnectTasks[i] = Task.Run(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
         }
 
         // Wait for all disconnect calls to complete
@@ -1041,10 +1033,10 @@ public class TransportTests
             DisconnectDelay = TimeSpan.FromMilliseconds(100)
         };
 
-        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost", TestContext.Current.CancellationToken);
 
         // Start first disconnect (will take 100ms)
-        Task firstDisconnect = Task.Run(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        Task firstDisconnect = Task.Run(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
 
         // Give first disconnect time to start and set IsConnected = false
         await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
@@ -1056,7 +1048,7 @@ public class TransportTests
         // 3. Acquire semaphore after first disconnect completes
         // 4. Hit the double-check and find IsConnected = false
         // 5. Return early without executing disconnect logic
-        Task secondDisconnect = Task.Run(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        Task secondDisconnect = Task.Run(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
 
         // Wait for both to complete
         await Task.WhenAll(firstDisconnect, secondDisconnect);
@@ -1075,11 +1067,11 @@ public class TransportTests
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost", TestContext.Current.CancellationToken);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task task1 = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
-        Task task2 = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Task task1 = transport.DisconnectAsync(TestContext.Current.CancellationToken);
+        Task task2 = transport.DisconnectAsync(TestContext.Current.CancellationToken);
         await Task.WhenAll(task1, task2);
 
         Assert.Equal(1, connection.StopCallCount);
@@ -1094,22 +1086,22 @@ public class TransportTests
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
 
-        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost", TestContext.Current.CancellationToken);
 
         // First disconnect - this will set IsConnected = false
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         // Verify the first disconnect executed fully
         Assert.Equal(1, connection.StopCallCount);
 
         // Second disconnect - should hit the fast-path check and return immediately
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         // The fast-path check prevents the disconnect logic from executing
         Assert.Equal(1, connection.StopCallCount);
 
         // Third call for good measure
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         Assert.Equal(1, connection.StopCallCount);
     }
 
@@ -1118,7 +1110,7 @@ public class TransportTests
     {
         string receivedName = string.Empty;
         object? receivedData = null;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection)
@@ -1130,7 +1122,7 @@ public class TransportTests
         {
             receivedName = e.EventName;
             receivedData = e.EventData;
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         string json = """
@@ -1142,11 +1134,10 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal("protocol.event", receivedName);
         Assert.IsType<TestEventArgs>(receivedData);
@@ -1173,28 +1164,28 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws://example.com:1234", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://example.com:1234", TestContext.Current.CancellationToken);
 
         TestCommandParameters command = new(commandName);
-        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(command, TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
         Assert.Equivalent(expected, dataValue);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
-        await transport.ConnectAsync("ws://example.com:5678", cancellationToken: TestContext.Current.CancellationToken);
-        _ = await transport.SendCommandAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://example.com:5678", TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(command, TestContext.Current.CancellationToken);
 
         dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
         Assert.Equivalent(expected, dataValue);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task TestExceptionInTransportEventReceivedCanCollect()
     {
         string receivedName = string.Empty;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
@@ -1204,7 +1195,7 @@ public class TransportTests
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
         transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("This is an unexpected exception");
         });
         string json = """
@@ -1216,10 +1207,10 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("This is an unexpected exception", exception.InnerException.Message);
@@ -1229,7 +1220,9 @@ public class TransportTests
     public async Task TestExceptionInTransportEventReceivedCanCollectMultiple()
     {
         string receivedName = string.Empty;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource firstEventTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource secondEventTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int callCount = 0;
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
@@ -1245,7 +1238,14 @@ public class TransportTests
             }
             finally
             {
-                syncEvent.Set();
+                if (Interlocked.Increment(ref callCount) == 1)
+                {
+                    firstEventTaskCompletionSource.TrySetResult();
+                }
+                else
+                {
+                    secondEventTaskCompletionSource.TrySetResult();
+                }
             }
         });
         string json = """
@@ -1257,13 +1257,12 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        syncEvent.Reset();
+        await firstEventTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        await secondEventTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.Equal(2, exception.InnerExceptions.Count);
         Assert.All(exception.InnerExceptions, e => Assert.IsType<WebDriverBiDiException>(e));
@@ -1274,7 +1273,7 @@ public class TransportTests
     public async Task TestExceptionInTransportEventReceivedCanTerminate()
     {
         string receivedName = string.Empty;
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
@@ -1290,7 +1289,7 @@ public class TransportTests
             }
             finally
             {
-                syncEvent.Set();
+                taskCompletionSource.TrySetResult();
             }
         });
         string json = """
@@ -1302,13 +1301,13 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken));
         Assert.Contains("protocol.event", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("This is an unexpected exception", exception.InnerException.Message);
@@ -1346,13 +1345,13 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Collect);
         Assert.True(errorPropagated);
 
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("This is an async unexpected exception", exception.InnerException.Message);
@@ -1390,7 +1389,7 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
         await handlerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         bool errorPropagated = await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(1), TransportErrorBehavior.Terminate);
@@ -1398,7 +1397,7 @@ public class TransportTests
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken));
         Assert.Contains("protocol.event", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("This is an async unexpected exception", exception.InnerException.Message);
@@ -1427,11 +1426,11 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         string commandName = "module.command";
         Dictionary<string, object?> expectedCommandParameters = new()
         {
@@ -1444,7 +1443,7 @@ public class TransportTests
             { "params", expectedCommandParameters }
         };
         TestCommandParameters commandParameters = new(commandName);
-        _ = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         Dictionary<string, object?> dataValue = JObject.Parse(connection.DataSent ?? "").ToParsedDictionary();
         Assert.Equivalent(expected, dataValue);
@@ -1455,12 +1454,12 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         Assert.Equal(0, transport.LastTestCommandId);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
         _ = Task.Run(async () =>
         {
             string json = """
@@ -1472,11 +1471,10 @@ public class TransportTests
                             }
                           }
                           """;
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
             await connection.RaiseDataReceivedEventAsync(json);
         },
         TestContext.Current.CancellationToken);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
         Assert.Equal(1, transport.LastTestCommandId);
     }
 
@@ -1510,8 +1508,8 @@ public class TransportTests
     [Fact]
     public async Task TestTransportIncomingQueueDepthReflectsPendingMessages()
     {
-        using ManualResetEventSlim handlerStarted = new(initialState: false);
-        using ManualResetEventSlim handlerMayComplete = new(initialState: false);
+        TaskCompletionSource handlerStartedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource handlerMayCompleteTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
@@ -1522,8 +1520,8 @@ public class TransportTests
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
         transport.OnEventReceived.AddObserver(e =>
         {
-            handlerStarted.Set();
-            return Task.Run(() => handlerMayComplete.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
+            handlerStartedTaskCompletionSource.TrySetResult();
+            return handlerMayCompleteTaskCompletionSource.Task;
         });
 
         string json = """
@@ -1535,14 +1533,13 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         // Raise the first message and wait until the reader has pulled it and begun
         // running the handler. At this point the reader is blocked inside the handler
         // and will not consume additional queued messages until the gate is released.
         await connection.RaiseDataReceivedEventAsync(json);
-        bool handlerDidStart = handlerStarted.Wait(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.True(handlerDidStart);
+        await handlerStartedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Enqueue two more messages while the reader is stalled. Writer.WriteAsync
         // completes synchronously for an unbounded channel, so these are observable
@@ -1553,9 +1550,9 @@ public class TransportTests
         Assert.Equal(2, transport.IncomingQueueDepth);
 
         // Release the handler gate so the reader can drain.
-        handlerMayComplete.Set();
+        handlerMayCompleteTaskCompletionSource.TrySetResult();
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         // DisconnectAsync awaits Reader.Completion before returning, so the queue
         // has drained by this point and IncomingQueueDepth must be 0. This also
@@ -1578,26 +1575,26 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Assert.Equal(0, transport.PendingCommandCount);
 
-        Command firstCommand = await transport.SendCommandAsync(new TestCommandParameters("module.first"), cancellationToken: TestContext.Current.CancellationToken);
+        Command firstCommand = await transport.SendCommandAsync(new TestCommandParameters("module.first"), TestContext.Current.CancellationToken);
         Assert.Equal(1, transport.PendingCommandCount);
 
-        Command secondCommand = await transport.SendCommandAsync(new TestCommandParameters("module.second"), cancellationToken: TestContext.Current.CancellationToken);
+        Command secondCommand = await transport.SendCommandAsync(new TestCommandParameters("module.second"), TestContext.Current.CancellationToken);
         Assert.Equal(2, transport.PendingCommandCount);
 
         // Complete the first command by delivering its matching success response.
         string firstResponseJson = $$$"""{"type":"success","id":{{{firstCommand.CommandId}}},"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(firstResponseJson);
-        await firstCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await firstCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(1, transport.PendingCommandCount);
 
         // Complete the second command similarly.
         string secondResponseJson = $$$"""{"type":"success","id":{{{secondCommand.CommandId}}},"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(secondResponseJson);
-        await secondCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await secondCommand.WaitForCompletionAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(0, transport.PendingCommandCount);
     }
 
@@ -1606,15 +1603,15 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         // Send a command and do not deliver a response, so it sits in the pending collection.
-        _ = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
+        _ = await transport.SendCommandAsync(new TestCommandParameters("module.command"), TestContext.Current.CancellationToken);
         Assert.Equal(1, transport.PendingCommandCount);
 
         // DisconnectAsync closes and clears the pending command collection; the property
         // must reflect the cleared state and must not throw post-disconnect.
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         Assert.Equal(0, transport.PendingCommandCount);
     }
 
@@ -1642,7 +1639,7 @@ public class TransportTests
             ProtocolErrorBehavior = TransportErrorBehavior.Collect,
         };
 
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         bool faultCaptured = await transport.WaitForCollectedEventHandlerExceptionAsync(
             TimeSpan.FromSeconds(5),
             TransportErrorBehavior.Collect);
@@ -1654,7 +1651,7 @@ public class TransportTests
         // Under Collect mode, DisconnectAsync surfaces the captured fault as an
         // AggregateException whose single inner exception wraps the injected fault.
         AggregateException? caught = await Assert.ThrowsAsync<AggregateException>(
-            async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+            async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
 
         Assert.NotNull(caught);
         Assert.Single(caught.InnerExceptions);
@@ -1678,7 +1675,7 @@ public class TransportTests
             ProtocolErrorBehavior = TransportErrorBehavior.Collect,
         };
 
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         bool faultCaptured = await transport.WaitForCollectedEventHandlerExceptionAsync(
             TimeSpan.FromSeconds(5),
             TransportErrorBehavior.Collect);
@@ -1693,7 +1690,7 @@ public class TransportTests
         // forwarded it whole — so the outer aggregate has a single inner that
         // is itself an AggregateException containing both injected faults.
         AggregateException? caught = await Assert.ThrowsAsync<AggregateException>(
-            async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+            async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(caught);
         Assert.Single(caught.InnerExceptions);
         AggregateException? forwardedAggregate = caught.InnerExceptions[0] as AggregateException;
@@ -1707,7 +1704,7 @@ public class TransportTests
     [Fact]
     public async Task TestTransportDisconnectTimesOutWithHangingEventHandler()
     {
-        ManualResetEvent handlerStarted = new(false);
+        TaskCompletionSource handlerStartedTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         List<LogMessageEventArgs> logs = [];
 
         TestWebSocketConnection connection = new();
@@ -1718,7 +1715,7 @@ public class TransportTests
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
         transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
         {
-            handlerStarted.Set();
+            handlerStartedTaskCompletionSource.TrySetResult();
             return new TaskCompletionSource<bool>().Task;
         });
         transport.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
@@ -1736,12 +1733,11 @@ public class TransportTests
                         }
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        bool handlerDidStart = handlerStarted.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(handlerDidStart);
+        await handlerStartedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains(logs,
             log => log.Message.Contains("Timed out waiting for message processing to complete during shutdown")
@@ -1764,8 +1760,8 @@ public class TransportTests
             return Task.CompletedTask;
         });
 
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         Assert.DoesNotContain(logs,
             log => log.Message.Contains("Timed out waiting for message processing to complete during shutdown"));
@@ -1784,8 +1780,8 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
         await transport.DisposeAsync();
     }
 
@@ -1794,7 +1790,7 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await transport.DisposeAsync();
     }
 
@@ -1803,7 +1799,7 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await transport.DisposeAsync();
         await transport.DisposeAsync();
     }
@@ -1820,11 +1816,11 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         await transport.DisposeAsync();
     }
@@ -1834,7 +1830,7 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         transport.ThrowOnDisconnect = true;
         await transport.DisposeAsync();
     }
@@ -1850,7 +1846,7 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         transport.ThrowOnDisconnect = true;
         await transport.DisposeAsync();
         Assert.Contains(logs,
@@ -1864,7 +1860,6 @@ public class TransportTests
     public async Task TestMessageProcessingLoopContinuesAfterUnhandledException()
     {
         string commandName = "module.command";
-        ManualResetEventSlim syncEvent = new(false);
         List<LogMessageEventArgs> logs = [];
 
         TestWebSocketConnection connection = new();
@@ -1877,12 +1872,12 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         transport.DeserializeThrowCount = 1;
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         await connection.RaiseDataReceivedEventAsync("this message will cause the exception");
 
@@ -1901,7 +1896,7 @@ public class TransportTests
         },
         TestContext.Current.CancellationToken);
 
-        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
         Assert.True(hasResult);
@@ -1918,7 +1913,7 @@ public class TransportTests
     [Fact]
     public async Task TestMessageProcessingLoopExceptionCapturedAsUnhandledError()
     {
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection)
@@ -1929,18 +1924,18 @@ public class TransportTests
         {
             if (e.Level == WebDriverBiDiLogLevel.Error)
             {
-                syncEvent.Set();
+                taskCompletionSource.TrySetResult();
             }
 
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         transport.DeserializeThrowCount = 1;
         await connection.RaiseDataReceivedEventAsync("this message will cause the exception");
-        syncEvent.Wait(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.IsType<InvalidOperationException>(exception.InnerException);
         Assert.Contains("Simulated deserialization failure", exception.InnerException.Message);
@@ -1951,9 +1946,9 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
-        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), TestContext.Current.CancellationToken);
         Assert.False(command.IsCanceled);
 
         transport.CancelCommand(command);
@@ -1969,9 +1964,9 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
-        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), TestContext.Current.CancellationToken);
         transport.CancelCommand(command);
         transport.CancelCommand(command);
     }
@@ -1981,14 +1976,13 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Command command = await transport.SendCommandAsync(new TestCommandParameters("module.command"), cancellationToken: TestContext.Current.CancellationToken);
         transport.CancelCommand(command);
 
         string responseJson = $$$"""{"type":"success","id":{{{command.CommandId}}},"result":{"parameterName":"parameterValue"}}""";
         await connection.RaiseDataReceivedEventAsync(responseJson);
-        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
 
         bool hasResult = command.TryGetResult(out CommandResult? commandResult);
 
@@ -2002,7 +1996,7 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
+        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -2010,8 +2004,8 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
-        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
+        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken);
+        await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -2019,8 +2013,8 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Contains("Cannot register a type info resolver after the transport is connected", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        Assert.Contains("Cannot register a type info resolver after the transport is connected", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2030,8 +2024,8 @@ public class TransportTests
         TestTransport transport = new(connection);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task connectTask = transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        Task registerTask = transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), cancellationToken: TestContext.Current.CancellationToken);
+        Task connectTask = transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        Task registerTask = transport.RegisterTypeInfoResolverAsync(new DefaultJsonTypeInfoResolver(), TestContext.Current.CancellationToken);
         await connectTask;
 
         Assert.Contains("Cannot register a type info resolver after the transport is connected", (await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await registerTask)).Message);
@@ -2043,14 +2037,14 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("WebSocket connection dropped");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
         Assert.IsType<WebDriverBiDiConnectionException>(command.ThrownException);
         Assert.Contains("Unexpected connection error", command.ThrownException.Message);
@@ -2063,13 +2057,13 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("WebSocket connection dropped");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
 
         TestCommandParameters commandParameters = new(commandName);
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2083,7 +2077,7 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("WebSocket connection dropped");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
@@ -2105,7 +2099,7 @@ public class TransportTests
 
         // Should not throw; early return path taken. Verify transport rejects commands.
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2113,15 +2107,15 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         // IsConnected is now false; raise error (e.g., receive loop dying during shutdown)
         await connection.RaiseConnectionErrorEventAsync(new Exception("Connection lost"));
 
         // Should not throw; early return path taken. Verify still disconnected.
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2132,15 +2126,15 @@ public class TransportTests
         // DisconnectAsync has already set IsConnected = false.
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task disconnectTask = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Task disconnectTask = transport.DisconnectAsync(TestContext.Current.CancellationToken);
         await connection.RaiseConnectionErrorEventAsync(new Exception("Connection lost during race"));
         await disconnectTask;
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2148,16 +2142,16 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
-        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"), cancellationToken: TestContext.Current.CancellationToken);
-        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"), cancellationToken: TestContext.Current.CancellationToken);
+        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"), TestContext.Current.CancellationToken);
+        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"), TestContext.Current.CancellationToken);
 
         Exception simulatedError = new("connection lost");
         await connection.RaiseConnectionErrorEventAsync(simulatedError);
 
-        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
-        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
+        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
         Assert.IsType<WebDriverBiDiConnectionException>(command1.ThrownException);
         Assert.IsType<WebDriverBiDiConnectionException>(command2.ThrownException);
@@ -2169,13 +2163,13 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         TestCommandParameters commandParameters = new(commandName);
-        Command command = await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
-        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
         Assert.IsType<WebDriverBiDiConnectionException>(command.ThrownException);
         Assert.Contains("Remote end closed the connection", command.ThrownException.Message);
@@ -2187,12 +2181,12 @@ public class TransportTests
         string commandName = "module.command";
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
         TestCommandParameters commandParameters = new(commandName);
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2206,7 +2200,7 @@ public class TransportTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
@@ -2224,7 +2218,7 @@ public class TransportTests
         await connection.RaiseRemoteDisconnectedEventAsync();
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2232,13 +2226,13 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -2246,15 +2240,15 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
 
-        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"), cancellationToken: TestContext.Current.CancellationToken);
-        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"), cancellationToken: TestContext.Current.CancellationToken);
+        Command command1 = await transport.SendCommandAsync(new TestCommandParameters("module.command1"), TestContext.Current.CancellationToken);
+        Command command2 = await transport.SendCommandAsync(new TestCommandParameters("module.command2"), TestContext.Current.CancellationToken);
 
         await connection.RaiseRemoteDisconnectedEventAsync();
 
-        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
-        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), cancellationToken: TestContext.Current.CancellationToken);
+        await command1.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
+        await command2.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
 
         Assert.IsType<WebDriverBiDiConnectionException>(command1.ThrownException);
         Assert.IsType<WebDriverBiDiConnectionException>(command2.ThrownException);
@@ -2268,27 +2262,27 @@ public class TransportTests
         // DisconnectAsync has already set IsConnected = false.
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         transport.EnableConnectLockConcurrencyTesting();
 
-        Task disconnectTask = transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Task disconnectTask = transport.DisconnectAsync(TestContext.Current.CancellationToken);
         await connection.RaiseRemoteDisconnectedEventAsync();
         await disconnectTask;
 
         TestCommandParameters commandParameters = new("module.command");
-        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("Transport must be connected", (await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
     public async Task TestExceptionInErrorEventHandlerIsIgnoredByDefault()
     {
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Error handler exception");
         });
         string json = """
@@ -2299,16 +2293,16 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task TestExceptionInErrorEventHandlerCanCollect()
     {
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
@@ -2317,7 +2311,7 @@ public class TransportTests
         };
         transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Error handler exception");
         });
         string json = """
@@ -2328,10 +2322,10 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("Error handler exception", exception.InnerException.Message);
@@ -2340,18 +2334,13 @@ public class TransportTests
     [Fact]
     public async Task TestExceptionInErrorEventHandlerCanTerminate()
     {
-        ManualResetEvent syncEvent = new(false);
-
         TestWebSocketConnection connection = new();
-        Transport transport = new(connection)
+        TestTransport transport = new(connection)
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
         transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
-        {
-            syncEvent.Set();
-            throw new WebDriverBiDiException("Error handler exception");
-        });
+            throw new WebDriverBiDiException("Error handler exception"));
         string json = """
                       {
                         "type": "error",
@@ -2360,14 +2349,13 @@ public class TransportTests
                         "message": "This is a test error message"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
+        await transport.WaitForCollectedEventHandlerExceptionAsync(TimeSpan.FromSeconds(5), TransportErrorBehavior.Terminate);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken));
         Assert.Contains("error event", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("Error handler exception", exception.InnerException.Message);
@@ -2376,13 +2364,13 @@ public class TransportTests
     [Fact]
     public async Task TestExceptionInUnknownMessageHandlerIsIgnoredByDefault()
     {
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Unknown message handler exception");
         });
         string json = """
@@ -2390,16 +2378,16 @@ public class TransportTests
                         "type": "unknown"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await transport.DisconnectAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task TestExceptionInUnknownMessageHandlerCanCollect()
     {
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
@@ -2408,7 +2396,7 @@ public class TransportTests
         };
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Unknown message handler exception");
         });
         string json = """
@@ -2416,10 +2404,10 @@ public class TransportTests
                         "type": "unknown"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(cancellationToken: TestContext.Current.CancellationToken));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        AggregateException exception = await Assert.ThrowsAnyAsync<AggregateException>(async () => await transport.DisconnectAsync(TestContext.Current.CancellationToken));
         Assert.Contains("Normal shutdown", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("Unknown message handler exception", exception.InnerException.Message);
@@ -2428,7 +2416,7 @@ public class TransportTests
     [Fact]
     public async Task TestExceptionInUnknownMessageHandlerCanTerminate()
     {
-        ManualResetEvent syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection)
@@ -2437,7 +2425,7 @@ public class TransportTests
         };
         transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Unknown message handler exception");
         });
         string json = """
@@ -2445,13 +2433,13 @@ public class TransportTests
                         "type": "unknown"
                       }
                       """;
-        await transport.ConnectAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
         await connection.RaiseDataReceivedEventAsync(json);
-        syncEvent.WaitOne(TimeSpan.FromSeconds(1));
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
-        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken));
         Assert.Contains("unknown message event", exception.Message);
         Assert.IsType<WebDriverBiDiException>(exception.InnerException);
         Assert.Contains("Unknown message handler exception", exception.InnerException.Message);
@@ -2473,7 +2461,7 @@ public class TransportTests
     {
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        await transport.ConnectAsync("ws://localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await transport.ConnectAsync("ws://localhost", TestContext.Current.CancellationToken);
         using CancellationTokenSource cts = new();
         cts.Cancel();
 

--- a/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
@@ -70,20 +70,21 @@ public class TransportTests
 
         TestCommandParameters commandParameters = new(commandName);
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "success",
-                            "id": 1,
-                            "result": {
-                              "value": "response value"
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                              "type": "success",
+                              "id": 1,
+                              "result": {
+                                "value": "response value"
+                              }
                             }
-                          }
-                          """;
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
         await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
@@ -107,21 +108,22 @@ public class TransportTests
 
         TestCommandParameters commandParameters = new(commandName);
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "success",
-                            "id": 1,
-                            "result": {
-                              "value": "response value" 
-                            },
-                            "extraDataName": "extraDataValue"
-                          }
-                          """;
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                              "type": "success",
+                              "id": 1,
+                              "result": {
+                                "value": "response value" 
+                              },
+                              "extraDataName": "extraDataValue"
+                            }
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
         await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
@@ -148,19 +150,20 @@ public class TransportTests
 
         TestCommandParameters commandParameters = new(commandName);
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "error",
-                            "id": 1,
-                            "error": "unknown command",
-                            "message": "This is a test error message"
-                          }
-                          """;
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                              "type": "error",
+                              "id": 1,
+                              "error": "unknown command",
+                              "message": "This is a test error message"
+                            }
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
         await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
@@ -188,21 +191,22 @@ public class TransportTests
 
         TestCommandParameters commandParameters = new(commandName);
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "success",
-                            "id": 1, 
-                            "noResult": {
-                              "invalid": "unknown command",
-                              "message": "This is a test error message"
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                              "type": "success",
+                              "id": 1, 
+                              "noResult": {
+                                "invalid": "unknown command",
+                                "message": "This is a test error message"
+                              }
                             }
-                          }
-                          """;
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
         await command.WaitForCompletionAsync(TimeSpan.FromSeconds(250), TestContext.Current.CancellationToken);
         Assert.IsType<WebDriverBiDiSerializationException>(command.ThrownException);
         Assert.Contains("Response did not contain properly formed JSON for response type", command.ThrownException.Message);
@@ -288,7 +292,7 @@ public class TransportTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             receivedName = e.EventName;
             receivedData = e.EventData;
@@ -324,7 +328,7 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
+        transport.OnErrorEventReceived.AddObserver(e =>
         {
             receivedData = e.ErrorData;
             taskCompletionSource.TrySetResult();
@@ -359,13 +363,13 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             receivedData = e.Message;
             taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
+        transport.OnErrorEventReceived.AddObserver(e =>
         {
             return Task.CompletedTask;
         });
@@ -386,7 +390,7 @@ public class TransportTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -406,7 +410,7 @@ public class TransportTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             taskCompletionSource.TrySetResult();
@@ -417,20 +421,21 @@ public class TransportTests
 
         TestCommandParameters commandParameters = new(commandName);
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "success",
-                            "id": 1,
-                            "result": {
-                              "value": "response value"
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                                "type": "success",
+                                "id": 1,
+                                "result": {
+                                "value": "response value"
+                                }
                             }
-                          }
-                          """;
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
         await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
         bool hasResult = command.TryGetResult(out CommandResult? actualResult);
         Assert.True(hasResult);
@@ -456,7 +461,7 @@ public class TransportTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.ComponentName == Transport.LoggerComponentName)
             {
@@ -490,7 +495,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -519,7 +524,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -547,7 +552,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -576,7 +581,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -605,7 +610,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -634,13 +639,13 @@ public class TransportTests
         TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
@@ -678,13 +683,13 @@ public class TransportTests
         TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
@@ -722,13 +727,13 @@ public class TransportTests
         TaskCompletionSource logTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
@@ -765,7 +770,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -791,7 +796,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -820,7 +825,7 @@ public class TransportTests
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             taskCompletionSource.TrySetResult();
@@ -852,13 +857,13 @@ public class TransportTests
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
@@ -899,13 +904,13 @@ public class TransportTests
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
         transport.RegisterInvalidEventMessageType("protocol.event", typeof(object));
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             loggedEvent = e.Message;
             unknownMessageTaskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level > WebDriverBiDiLogLevel.Trace)
             {
@@ -1118,7 +1123,7 @@ public class TransportTests
             MessageProcessingDelay = TimeSpan.FromMilliseconds(100)
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             receivedName = e.EventName;
             receivedData = e.EventData;
@@ -1193,7 +1198,7 @@ public class TransportTests
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("This is an unexpected exception");
@@ -1230,7 +1235,7 @@ public class TransportTests
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             try
             {
@@ -1281,7 +1286,7 @@ public class TransportTests
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             try
             {
@@ -1324,7 +1329,7 @@ public class TransportTests
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver(async (EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(async e =>
         {
             try
             {
@@ -1368,7 +1373,7 @@ public class TransportTests
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver(async (EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(async e =>
         {
             try
             {
@@ -1413,7 +1418,7 @@ public class TransportTests
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             return Task.FromException(new WebDriverBiDiException("This is an unexpected exception"));
         });
@@ -1460,20 +1465,21 @@ public class TransportTests
         string commandName = "module.command";
         TestCommandParameters commandParameters = new(commandName);
         Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
-        _ = Task.Run(async () =>
-        {
-            string json = """
-                          {
-                            "type": "success",
-                            "id": 1,
-                            "result": {
-                              "value": "response value"
+        _ = Task.Run(
+            async () =>
+            {
+                string json = """
+                            {
+                                "type": "success",
+                                "id": 1,
+                                "result": {
+                                "value": "response value"
+                                }
                             }
-                          }
-                          """;
-            await connection.RaiseDataReceivedEventAsync(json);
-        },
-        TestContext.Current.CancellationToken);
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
         await command.WaitForCompletionAsync(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
         Assert.Equal(1, transport.LastTestCommandId);
     }
@@ -1713,12 +1719,12 @@ public class TransportTests
             ShutdownTimeout = TimeSpan.FromMilliseconds(250),
         };
         transport.RegisterEventMessage<TestEventArgs>("protocol.event");
-        transport.OnEventReceived.AddObserver((EventReceivedEventArgs e) =>
+        transport.OnEventReceived.AddObserver(e =>
         {
             handlerStartedTaskCompletionSource.TrySetResult();
             return new TaskCompletionSource<bool>().Task;
         });
-        transport.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -1754,7 +1760,7 @@ public class TransportTests
         {
             ShutdownTimeout = TimeSpan.FromSeconds(5),
         };
-        transport.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -1841,7 +1847,7 @@ public class TransportTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         TestTransport transport = new(connection);
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -1867,7 +1873,7 @@ public class TransportTests
         {
             ProtocolErrorBehavior = TransportErrorBehavior.Collect,
         };
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -1890,11 +1896,7 @@ public class TransportTests
                                 }
                               }
                               """;
-        _ = Task.Run(async () =>
-        {
-            await connection.RaiseDataReceivedEventAsync(responseJson);
-        },
-        TestContext.Current.CancellationToken);
+        _ = Task.Run(async () => await connection.RaiseDataReceivedEventAsync(responseJson), TestContext.Current.CancellationToken);
 
         await command.WaitForCompletionAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
@@ -1920,7 +1922,7 @@ public class TransportTests
         {
             ProtocolErrorBehavior = TransportErrorBehavior.Collect,
         };
-        transport.OnLogMessage.AddObserver((e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             if (e.Level == WebDriverBiDiLogLevel.Error)
             {
@@ -2072,7 +2074,7 @@ public class TransportTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -2195,7 +2197,7 @@ public class TransportTests
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        transport.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -2280,7 +2282,7 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
+        transport.OnErrorEventReceived.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Error handler exception");
@@ -2309,7 +2311,7 @@ public class TransportTests
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
-        transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
+        transport.OnErrorEventReceived.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Error handler exception");
@@ -2339,7 +2341,7 @@ public class TransportTests
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
-        transport.OnErrorEventReceived.AddObserver((ErrorReceivedEventArgs e) =>
+        transport.OnErrorEventReceived.AddObserver(e =>
             throw new WebDriverBiDiException("Error handler exception"));
         string json = """
                       {
@@ -2368,7 +2370,7 @@ public class TransportTests
 
         TestWebSocketConnection connection = new();
         Transport transport = new(connection);
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Unknown message handler exception");
@@ -2394,7 +2396,7 @@ public class TransportTests
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect,
         };
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Unknown message handler exception");
@@ -2423,7 +2425,7 @@ public class TransportTests
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Terminate,
         };
-        transport.OnUnknownMessageReceived.AddObserver((UnknownMessageReceivedEventArgs e) =>
+        transport.OnUnknownMessageReceived.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             throw new WebDriverBiDiException("Unknown message handler exception");

--- a/test/WebDriverBiDi.Tests/Protocol/UnhandledErrorCollectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/UnhandledErrorCollectionTests.cs
@@ -1,39 +1,34 @@
 namespace WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class UnhandledErrorCollectionTests()
 {
-    [Test]
+    [Fact]
     public void TestDefaultPropertyValues()
     {
         UnhandledErrorCollection unhandledErrors = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.ProtocolErrorBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
-            Assert.That(unhandledErrors.UnexpectedErrorBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
-            Assert.That(unhandledErrors.UnknownMessageBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
-            Assert.That(unhandledErrors.EventHandlerExceptionBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
-            Assert.That(() => unhandledErrors.Exceptions, Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("No unhandled errors."));
-        }
+
+        Assert.Equal(TransportErrorBehavior.Ignore, unhandledErrors.ProtocolErrorBehavior);
+        Assert.Equal(TransportErrorBehavior.Ignore, unhandledErrors.UnexpectedErrorBehavior);
+        Assert.Equal(TransportErrorBehavior.Ignore, unhandledErrors.UnknownMessageBehavior);
+        Assert.Equal(TransportErrorBehavior.Ignore, unhandledErrors.EventHandlerExceptionBehavior);
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
+        Assert.Equal("No unhandled errors.", Assert.ThrowsAny<InvalidOperationException>(() => unhandledErrors.Exceptions).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestAddingUnhandledErrorWithIgnoreDoesNotAddErrorToCollection()
     {
         UnhandledErrorCollection unhandledErrors = new();
         unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
-        }
+
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
     }
 
-    [Test]
+    [Fact]
     public void TestAddingUnhandledErrorWithCollect()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -41,15 +36,13 @@ public class UnhandledErrorCollectionTests()
             ProtocolErrorBehavior = TransportErrorBehavior.Collect
         };
         unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
-        }
+
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
     }
 
-    [Test]
+    [Fact]
     public void TestAddingUnhandledErrorWithTerminate()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -57,16 +50,13 @@ public class UnhandledErrorCollectionTests()
             ProtocolErrorBehavior = TransportErrorBehavior.Terminate
         };
         unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.True);
-        }
+
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
     }
 
-
-    [Test]
+    [Fact]
     public void TestClearingUnhandledErrors()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -74,22 +64,19 @@ public class UnhandledErrorCollectionTests()
             ProtocolErrorBehavior = TransportErrorBehavior.Collect
         };
         unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
-        }
+
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
+
         unhandledErrors.ClearUnhandledErrors();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
-        }
+
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetExceptions()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -97,11 +84,14 @@ public class UnhandledErrorCollectionTests()
             ProtocolErrorBehavior = TransportErrorBehavior.Collect
         };
         unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
-        Assert.That(unhandledErrors.Exceptions, Has.Count.EqualTo(1));
-        Assert.That(unhandledErrors.Exceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("new exception"));
+        Assert.Single(unhandledErrors.Exceptions);
+        Assert.IsType<WebDriverBiDiException>(unhandledErrors.Exceptions[0]);
+        WebDriverBiDiException? typedException = unhandledErrors.Exceptions[0] as WebDriverBiDiException;
+        Assert.NotNull(typedException);
+        Assert.Equal("new exception", typedException.Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCaptureErrorsForDifferentBehaviorTypes()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -112,64 +102,70 @@ public class UnhandledErrorCollectionTests()
         unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("invalid protocol message"));
         unhandledErrors.AddUnhandledError(UnhandledErrorType.UnexpectedError, new WebDriverBiDiException("unexpected error"));
         unhandledErrors.AddUnhandledError(UnhandledErrorType.EventHandlerException, new WebDriverBiDiException("event handler"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.True);
-            Assert.That(unhandledErrors.Exceptions, Has.Count.EqualTo(2));
-            Assert.That(unhandledErrors.Exceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("invalid protocol message"));
-            Assert.That(unhandledErrors.Exceptions[1], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("unexpected error"));
-        }
+
+        Assert.False(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore));
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate));
+        Assert.Equal(2, unhandledErrors.Exceptions.Count);
+
+        Assert.IsType<WebDriverBiDiException>(unhandledErrors.Exceptions[0]);
+        WebDriverBiDiException? exception0 = unhandledErrors.Exceptions[0] as WebDriverBiDiException;
+        Assert.NotNull(exception0);
+        Assert.Equal("invalid protocol message", exception0.Message);
+
+        Assert.IsType<WebDriverBiDiException>(unhandledErrors.Exceptions[1]);
+        WebDriverBiDiException? exception1 = unhandledErrors.Exceptions[1] as WebDriverBiDiException;
+        Assert.NotNull(exception1);
+        Assert.Equal("unexpected error", exception1.Message);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingUnknownMessageBehaviorCollectsErrors()
     {
         UnhandledErrorCollection unhandledErrors = new()
         {
             UnknownMessageBehavior = TransportErrorBehavior.Collect
         };
-        Assert.That(unhandledErrors.UnknownMessageBehavior, Is.EqualTo(TransportErrorBehavior.Collect));
+        Assert.Equal(TransportErrorBehavior.Collect, unhandledErrors.UnknownMessageBehavior);
         unhandledErrors.AddUnhandledError(UnhandledErrorType.UnknownMessage, new WebDriverBiDiException("unknown message"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
-            Assert.That(unhandledErrors.Exceptions, Has.Count.EqualTo(1));
-            Assert.That(unhandledErrors.Exceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("unknown message"));
-        }
+
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.Single(unhandledErrors.Exceptions);
+        Assert.IsType<WebDriverBiDiException>(unhandledErrors.Exceptions[0]);
+        WebDriverBiDiException? unknownException = unhandledErrors.Exceptions[0] as WebDriverBiDiException;
+        Assert.NotNull(unknownException);
+        Assert.Equal("unknown message", unknownException.Message);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingEventHandlerExceptionBehaviorCollectsErrors()
     {
         UnhandledErrorCollection unhandledErrors = new()
         {
             EventHandlerExceptionBehavior = TransportErrorBehavior.Collect
         };
-        Assert.That(unhandledErrors.EventHandlerExceptionBehavior, Is.EqualTo(TransportErrorBehavior.Collect));
+        Assert.Equal(TransportErrorBehavior.Collect, unhandledErrors.EventHandlerExceptionBehavior);
         unhandledErrors.AddUnhandledError(UnhandledErrorType.EventHandlerException, new WebDriverBiDiException("event handler exception"));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
-            Assert.That(unhandledErrors.Exceptions, Has.Count.EqualTo(1));
-            Assert.That(unhandledErrors.Exceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("event handler exception"));
-        }
+
+        Assert.True(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect));
+        Assert.Single(unhandledErrors.Exceptions);
+        Assert.IsType<WebDriverBiDiException>(unhandledErrors.Exceptions[0]);
+        WebDriverBiDiException? handlerException = unhandledErrors.Exceptions[0] as WebDriverBiDiException;
+        Assert.NotNull(handlerException);
+        Assert.Equal("event handler exception", handlerException.Message);
     }
 
-    [Test]
+    [Fact]
     public void TestTryGetExceptionsReturnsFalseForIgnoreBehavior()
     {
         UnhandledErrorCollection unhandledErrors = new();
         bool result = unhandledErrors.TryGetExceptions(TransportErrorBehavior.Ignore, out IList<Exception> exceptions);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Is.False);
-            Assert.That(exceptions, Is.Empty);
-        }
+
+        Assert.False(result);
+        Assert.Empty(exceptions);
     }
 
-    [Test]
+    [Fact]
     public void TestTryGetExceptionsReturnsFalseWhenNoMatchingErrors()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -177,14 +173,12 @@ public class UnhandledErrorCollectionTests()
             ProtocolErrorBehavior = TransportErrorBehavior.Collect
         };
         bool result = unhandledErrors.TryGetExceptions(TransportErrorBehavior.Terminate, out IList<Exception> exceptions);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Is.False);
-            Assert.That(exceptions, Is.Empty);
-        }
+
+        Assert.False(result);
+        Assert.Empty(exceptions);
     }
 
-    [Test]
+    [Fact]
     public void TestTryGetExceptionsReturnsMatchingExceptions()
     {
         UnhandledErrorCollection unhandledErrors = new()
@@ -197,14 +191,19 @@ public class UnhandledErrorCollectionTests()
 
         bool collectResult = unhandledErrors.TryGetExceptions(TransportErrorBehavior.Collect, out IList<Exception> collectExceptions);
         bool terminateResult = unhandledErrors.TryGetExceptions(TransportErrorBehavior.Terminate, out IList<Exception> terminateExceptions);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(collectResult, Is.True);
-            Assert.That(collectExceptions, Has.Count.EqualTo(1));
-            Assert.That(collectExceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("collected error"));
-            Assert.That(terminateResult, Is.True);
-            Assert.That(terminateExceptions, Has.Count.EqualTo(1));
-            Assert.That(terminateExceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("terminal error"));
-        }
+
+        Assert.True(collectResult);
+        Assert.Single(collectExceptions);
+        Assert.IsType<WebDriverBiDiException>(collectExceptions[0]);
+        WebDriverBiDiException? collectedException = collectExceptions[0] as WebDriverBiDiException;
+        Assert.NotNull(collectedException);
+        Assert.Equal("collected error", collectedException.Message);
+
+        Assert.True(terminateResult);
+        Assert.Single(terminateExceptions);
+        Assert.IsType<WebDriverBiDiException>(terminateExceptions[0]);
+        WebDriverBiDiException? terminatedException = terminateExceptions[0] as WebDriverBiDiException;
+        Assert.NotNull(terminatedException);
+        Assert.Equal("terminal error", terminatedException.Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/UnknownMessageReceivedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/UnknownMessageReceivedEventArgsTests.cs
@@ -1,21 +1,20 @@
 namespace WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class UnknownMessageReceivedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateErrorReceivedEventArgsWithNullErrorData()
     {
         UnknownMessageReceivedEventArgs eventArgs = new("unknown message");
-        Assert.That(eventArgs.Message, Is.EqualTo("unknown message"));
-        Assert.That(eventArgs.AdditionalData, Is.Empty);
+        Assert.Equal("unknown message", eventArgs.Message);
+        Assert.Empty(eventArgs.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         UnknownMessageReceivedEventArgs eventArgs = new("unknown message");
         UnknownMessageReceivedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
@@ -158,7 +158,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         List<LogMessageEventArgs> allLogs = [];
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             allLogs.Add(e);
             return Task.CompletedTask;
@@ -188,7 +188,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         List<LogMessageEventArgs> logValues = [];
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             if (e.Level >= WebDriverBiDiLogLevel.Info)
             {
@@ -269,7 +269,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
     {
         List<string> connectionLog = [];
         WebSocketConnection connection = new();
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -317,7 +317,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         List<string> connectionLog = [];
         WebSocketConnection connection = new();
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -357,13 +357,13 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        connection.OnConnectionError.AddObserver((ConnectionErrorEventArgs e) =>
+        connection.OnConnectionError.AddObserver(e =>
         {
             taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         List<string> connectionLog = [];
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -417,7 +417,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         };
 
         List<string> connectionLog = [];
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -449,7 +449,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         List<string> connectionLog = [];
         WebSocketConnection connection = new();
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -483,7 +483,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -493,7 +493,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        this.clientDisconnectedObserver = server.OnClientDisconnected.AddObserver((e) =>
+        this.clientDisconnectedObserver = server.OnClientDisconnected.AddObserver(e =>
         {
             if (e.ConnectionId == registeredConnectionId)
             {
@@ -530,7 +530,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -557,7 +557,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        connection.OnConnectionError.AddObserver((ConnectionErrorEventArgs e) =>
+        connection.OnConnectionError.AddObserver(e =>
         {
             receivedErrorArgs = e;
             taskCompletionSource.TrySetResult();
@@ -738,7 +738,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.Zero,
         };
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
@@ -858,7 +858,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         List<LogMessageEventArgs> logs = [];
         TestWebSocketConnection connection = new();
-        connection.OnLogMessage.AddObserver((e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             logs.Add(e);
             return Task.CompletedTask;
@@ -1030,7 +1030,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
         ConnectionDisconnectedEventArgs? receivedEventArgs = null;
-        connection.OnRemoteDisconnected.AddObserver((ConnectionDisconnectedEventArgs e) =>
+        connection.OnRemoteDisconnected.AddObserver(e =>
         {
             receivedEventArgs = e with { };
             taskCompletionSource.TrySetResult();
@@ -1056,7 +1056,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         List<string> connectionLog = [];
         WebSocketConnection connection = new();
-        connection.OnLogMessage.AddObserver((LogMessageEventArgs e) =>
+        connection.OnLogMessage.AddObserver(e =>
         {
             connectionLog.Add(e.Message);
             return Task.CompletedTask;

--- a/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
@@ -70,7 +70,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         {
             StartupTimeout = TimeSpan.FromMilliseconds(50)
         };
-        Assert.Contains($"{0.05} seconds", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.StartAsync($"ws://localhost:{port}", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains($"{0.05} seconds", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.StartAsync($"ws://localhost:{port}", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -80,15 +80,15 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("Hello world"u8.ToArray(), TestContext.Current.CancellationToken);
         string dataReceivedByServer = this.WaitForServerToReceiveData(TimeSpan.FromSeconds(3));
 
         Assert.Equal("Hello world", dataReceivedByServer);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
@@ -106,7 +106,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
 
         Assert.Equal("Hello back"u8.ToArray(), dataReceivedByConnection);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
@@ -126,7 +126,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
 
         Assert.Equal(Encoding.UTF8.GetBytes(data), dataReceivedByConnection);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
@@ -146,7 +146,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
 
         Assert.Equal(Encoding.UTF8.GetBytes(data), dataReceivedByConnection);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -163,15 +163,15 @@ public class WebSocketConnectionTests : IAsyncDisposable
             allLogs.Add(e);
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("Hello world"u8.ToArray(), TestContext.Current.CancellationToken);
         this.WaitForServerToReceiveData(TimeSpan.FromSeconds(4));
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(4));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains(allLogs,
             e => e.Message.StartsWith("SEND >>> ") && e.Level == WebDriverBiDiLogLevel.Debug);
@@ -197,15 +197,15 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
-        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("Hello world"u8.ToArray(), TestContext.Current.CancellationToken);
         this.WaitForServerToReceiveData(TimeSpan.FromSeconds(4));
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(4));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         List<string> messages = [];
         foreach (LogMessageEventArgs logValue in logValues)
@@ -231,10 +231,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
         WebSocketConnection connection = new();
         Assert.False(connection.IsActive);
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         Assert.True(connection.IsActive);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(connection.IsActive);
     }
 
@@ -248,10 +248,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
         WebSocketConnection connection = new();
         Assert.Equal(string.Empty, connection.ConnectionString);
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync(serverWebSocketUrl, cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync(serverWebSocketUrl, TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         Assert.Equal(serverWebSocketUrl, connection.ConnectionString);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equal(string.Empty, connection.ConnectionString);
     }
 
@@ -260,7 +260,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
     {
         WebSocketConnection connection = new();
         Assert.False(connection.IsActive);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(connection.IsActive);
     }
 
@@ -274,7 +274,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
         });
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         List<string> expectedLogEntries =
         [
@@ -297,7 +297,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         };
         Assert.False(connection.IsActive);
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         Assert.True(connection.IsActive);
 
@@ -305,7 +305,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         // task to enter a waiting state after receiving the first message.
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.False(connection.IsActive);
     }
 
@@ -323,10 +323,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
             return Task.CompletedTask;
         });
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         // First call: socket Open -> CloseClientWebSocketAsync -> "Client state is Closed"
         // Second call: socket Closed -> early-exit -> "Client state is Closed"
@@ -351,7 +351,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             "Client state is Aborted"
         ];
 
-        ManualResetEvent clientDetectedErrorEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         WebSocketConnection connection = new()
         {
             StartupTimeout = TimeSpan.FromSeconds(1),
@@ -359,7 +359,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         };
         connection.OnConnectionError.AddObserver((ConnectionErrorEventArgs e) =>
         {
-            clientDetectedErrorEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
         List<string> connectionLog = [];
@@ -368,17 +368,16 @@ public class WebSocketConnectionTests : IAsyncDisposable
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         await server.StopAsync();
 
         // Wait for the client's receive loop to detect the abrupt close (WebSocketException)
         // before calling StopAsync. This ensures client.State is Aborted when StopAsync runs,
         // so we take the early-exit path and avoid calling CloseOutputAsync on an Aborted socket.
-        bool clientDetectedError = clientDetectedErrorEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(clientDetectedError);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
@@ -424,11 +423,11 @@ public class WebSocketConnectionTests : IAsyncDisposable
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
 
         // Receive loop is blocked in ReceiveHandler; client.State is still Open.
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Equivalent(expectedLogEntries, connectionLog);
     }
@@ -456,9 +455,9 @@ public class WebSocketConnectionTests : IAsyncDisposable
             return Task.CompletedTask;
         });
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
@@ -491,22 +490,22 @@ public class WebSocketConnectionTests : IAsyncDisposable
         });
 
         IReadOnlyList<string> serverLog = server.Log;
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        ManualResetEvent disconnectEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         this.clientDisconnectedObserver = server.OnClientDisconnected.AddObserver((e) =>
         {
             if (e.ConnectionId == registeredConnectionId)
             {
-                disconnectEvent.Set();
+                taskCompletionSource.TrySetResult();
             }
         });
 
         // Server initiated disconnection requires waiting for the
         // close websocket message to be received by the client.
         await server.DisconnectAsync(registeredConnectionId);
-        disconnectEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
@@ -538,10 +537,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
         });
 
         IReadOnlyList<string> serverLog = server.Log;
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         server.IgnoreCloseConnectionRequest(registeredConnectionId, true);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
@@ -552,7 +551,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await server.StartAsync();
 
         ConnectionErrorEventArgs? receivedErrorArgs = null;
-        ManualResetEventSlim errorReceivedEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         WebSocketConnection connection = new()
         {
             StartupTimeout = TimeSpan.FromSeconds(1),
@@ -561,17 +560,16 @@ public class WebSocketConnectionTests : IAsyncDisposable
         connection.OnConnectionError.AddObserver((ConnectionErrorEventArgs e) =>
         {
             receivedErrorArgs = e;
-            errorReceivedEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         server.IgnoreCloseConnectionRequest(this.connectionId, true);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
-        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.True(errorReceived);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.NotNull(receivedErrorArgs);
         Assert.IsType<WebSocketException>(receivedErrorArgs.Exception);
     }
@@ -589,32 +587,32 @@ public class WebSocketConnectionTests : IAsyncDisposable
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         ServerEventObserver<ServerDataReceivedEventArgs> observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("First connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("First connection hello"u8.ToArray(), TestContext.Current.CancellationToken);
         string serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
         Assert.Equal("First connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "First connection acknowledged");
         byte[] receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equal("First connection acknowledged"u8.ToArray(), receivedData);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Second connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("Second connection hello"u8.ToArray(), TestContext.Current.CancellationToken);
         serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
         Assert.Equal("Second connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Second connection acknowledged");
         receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equal("Second connection acknowledged"u8.ToArray(), receivedData);
     }
 
@@ -631,11 +629,11 @@ public class WebSocketConnectionTests : IAsyncDisposable
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         ServerEventObserver<ServerDataReceivedEventArgs> observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("First connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("First connection hello"u8.ToArray(), TestContext.Current.CancellationToken);
         string serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
         Assert.Equal("First connection hello", serverReceivedData);
@@ -643,21 +641,21 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await server.SendWebSocketDataAsync(registeredConnectionId, "First connection acknowledged");
         byte[] receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
         server.IgnoreCloseConnectionRequest(registeredConnectionId, true);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equal("First connection acknowledged"u8.ToArray(), receivedData);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Second connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("Second connection hello"u8.ToArray(), TestContext.Current.CancellationToken);
         serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
         Assert.Equal("Second connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Second connection acknowledged");
         receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         Assert.Equal("Second connection acknowledged"u8.ToArray(), receivedData);
     }
 
@@ -672,23 +670,23 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        Assert.StartsWith($"The WebSocket is already connected to ws://localhost:{server.Port}", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.StartsWith($"The WebSocket is already connected to ws://localhost:{server.Port}", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
     public async Task TestStartAsyncThrowsForInvalidUrl()
     {
         WebSocketConnection connection = new();
-        Assert.Contains("not a valid absolute URI", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await connection.StartAsync("not-a-valid-url", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("not a valid absolute URI", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await connection.StartAsync("not-a-valid-url", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
     public async Task TestStartAsyncThrowsForNonWebSocketUrl()
     {
         WebSocketConnection connection = new();
-        Assert.Contains("The URI scheme must be 'ws' or 'wss'; received 'http'", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await connection.StartAsync("http://localhost:8080", cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.Contains("The URI scheme must be 'ws' or 'wss'; received 'http'", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await connection.StartAsync("http://localhost:8080", TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -714,7 +712,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         // We expect this to fail with a timeout, but it verifies that the connection
         // attempts to connect to the correct URL and that the URL is accepted as valid.
-        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.StartAsync($"wss://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.StartAsync($"wss://localhost:{server.Port}", TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -725,7 +723,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        Assert.StartsWith($"The WebSocket has not been initialized", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.SendDataAsync("This send should fail"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        Assert.StartsWith($"The WebSocket has not been initialized", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.SendDataAsync("This send should fail"u8.ToArray(), TestContext.Current.CancellationToken))).Message);
     }
 
     [Fact]
@@ -746,10 +744,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         server.IgnoreCloseConnectionRequest(registeredConnectionId, true);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         // With ShutdownTimeout=Zero, CloseClientWebSocketAsync may throw OperationCanceledException
         // before logging "Client state is X". At minimum we get "Closing connection".
@@ -771,19 +769,19 @@ public class WebSocketConnectionTests : IAsyncDisposable
             DataSendDelay = TimeSpan.FromMilliseconds(100),
             DataTimeout = TimeSpan.FromMilliseconds(20),
         };
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
 
-        ManualResetEventSlim syncEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.DataSendStarting += (sender, e) =>
         {
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         };
 
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        _ = Task.Run(() => connection.SendDataAsync("first data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
-        syncEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal("Timed out waiting to access WebSocket for sending; only one send operation is permitted at a time.", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync("second data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken))).Message);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        _ = Task.Run(() => connection.SendDataAsync("first data"u8.ToArray(), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal("Timed out waiting to access WebSocket for sending; only one send operation is permitted at a time.", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync("second data"u8.ToArray(), TestContext.Current.CancellationToken))).Message);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -809,7 +807,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         await connection.DisposeAsync();
         await connection.DisposeAsync();
@@ -832,9 +830,9 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
     }
 
@@ -846,7 +844,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         await connection.DisposeAsync();
         Assert.False(connection.IsActive);
@@ -865,7 +863,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.ThrowOnStop = true;
         connection.BypassStop = false;
@@ -885,14 +883,14 @@ public class WebSocketConnectionTests : IAsyncDisposable
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.SendDataAsync("Hello world"u8.ToArray(), TestContext.Current.CancellationToken);
         this.WaitForServerToReceiveData(TimeSpan.FromSeconds(3));
 
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
         await connection.DisposeAsync();
     }
 
@@ -902,7 +900,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
-        ManualResetEventSlim closeReturned = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new()
         {
             BypassStart = false,
@@ -920,15 +918,15 @@ public class WebSocketConnectionTests : IAsyncDisposable
                 return await Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, endOfMessage: true));
             }
 
-            closeReturned.Set();
+            taskCompletionSource.TrySetResult();
             await Task.Delay(Timeout.Infinite, token);
             throw new OperationCanceledException(token);
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        closeReturned.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -937,7 +935,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
-        ManualResetEventSlim exceptionThrown = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TestWebSocketConnection connection = new()
         {
             BypassStart = false,
@@ -950,14 +948,14 @@ public class WebSocketConnectionTests : IAsyncDisposable
                 return Task.FromResult(new WebSocketReceiveResult(10, WebSocketMessageType.Text, endOfMessage: false));
             }
 
-            exceptionThrown.Set();
+            taskCompletionSource.TrySetResult();
             throw new OperationCanceledException();
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        exceptionThrown.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -972,10 +970,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
                 return count <= 1;
             },
         };
-        await connection.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         connection.BypassStart = false;
 
-        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync("data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync("data"u8.ToArray(), TestContext.Current.CancellationToken));
         Assert.Equal("The WebSocket connection was closed before the send could be completed", exception.Message);
     }
 
@@ -987,10 +985,10 @@ public class WebSocketConnectionTests : IAsyncDisposable
             IsActiveOverride = () => true,
             SendWebSocketDataOverride = _ => throw new WebSocketException("Simulated WebSocket failure"),
         };
-        await connection.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         connection.BypassStart = false;
 
-        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync("data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync("data"u8.ToArray(), TestContext.Current.CancellationToken));
         Assert.Contains("Simulated WebSocket failure", exception.Message);
         Assert.IsType<WebSocketException>(exception.InnerException);
     }
@@ -1025,7 +1023,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
-        ManualResetEventSlim remoteDisconnectedEvent = new(false);
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         WebSocketConnection connection = new()
         {
             StartupTimeout = TimeSpan.FromSeconds(1),
@@ -1035,20 +1033,19 @@ public class WebSocketConnectionTests : IAsyncDisposable
         connection.OnRemoteDisconnected.AddObserver((ConnectionDisconnectedEventArgs e) =>
         {
             receivedEventArgs = e with { };
-            remoteDisconnectedEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.clientDisconnectedObserver = server.OnClientDisconnected.AddObserver(_ => { });
 
         await server.DisconnectAsync(registeredConnectionId);
 
-        bool disconnected = remoteDisconnectedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
-        Assert.True(disconnected);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.NotNull(receivedEventArgs);
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1066,9 +1063,9 @@ public class WebSocketConnectionTests : IAsyncDisposable
         });
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StartAsync($"ws://localhost:{server.Port}", TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains(connectionLog, s => s.StartsWith("Opening connection to URL "));
         Assert.Contains("Connection opened", connectionLog);

--- a/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
@@ -10,8 +10,7 @@ using System.Threading;
 using PinchHitter;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
-public class WebSocketConnectionTests
+public class WebSocketConnectionTests : IAsyncDisposable
 {
     private string lastServerReceivedData = string.Empty;
     private byte[] lastConnectionReceivedData = [];
@@ -22,9 +21,7 @@ public class WebSocketConnectionTests
     private ServerEventObserver<ClientConnectionEventArgs>? clientConnectedObserver;
     private ServerEventObserver<ClientConnectionEventArgs>? clientDisconnectedObserver;
     private ServerEventObserver<ServerDataReceivedEventArgs>? serverDataReceivedObserver;
-
-    [SetUp]
-    public async Task InitializeServer()
+    public WebSocketConnectionTests()
     {
         this.connectionId = string.Empty;
         this.lastServerReceivedData = string.Empty;
@@ -33,9 +30,7 @@ public class WebSocketConnectionTests
         this.serverReceiveSyncEvent.Reset();
         this.connectionSyncEvent.Reset();
     }
-
-    [TearDown]
-    public async Task DisposeServerAsync()
+    public async ValueTask DisposeAsync()
     {
         this.serverDataReceivedObserver?.Unobserve();
         this.serverDataReceivedObserver = null;
@@ -47,14 +42,14 @@ public class WebSocketConnectionTests
         this.clientDisconnectedObserver = null;
     }
 
-    [Test]
-    public void TestConnectionType()
+    [Fact]
+    public async Task TestConnectionType()
     {
         WebSocketConnection connection = new();
-        Assert.That(connection.ConnectionType, Is.EqualTo(ConnectionType.WebSocket));
+        Assert.Equal(ConnectionType.WebSocket, connection.ConnectionType);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionFailure()
     {
         // Find an available port by briefly binding to port 0, then release it
@@ -75,53 +70,53 @@ public class WebSocketConnectionTests
         {
             StartupTimeout = TimeSpan.FromMilliseconds(50)
         };
-        Assert.That(async () => await connection.StartAsync($"ws://localhost:{port}"), Throws.InstanceOf<WebDriverBiDiTimeoutException>().With.Message.Contains($"{0.05} seconds"));
+        Assert.Contains($"{0.05} seconds", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.StartAsync($"ws://localhost:{port}", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionCanSendData()
     {
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Hello world"u8.ToArray());
+        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         string dataReceivedByServer = this.WaitForServerToReceiveData(TimeSpan.FromSeconds(3));
 
-        Assert.That(dataReceivedByServer, Is.EqualTo("Hello world"));
-        await connection.StopAsync();
+        Assert.Equal("Hello world", dataReceivedByServer);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionCanReceiveData()
     {
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
 
-        Assert.That(dataReceivedByConnection, Is.EqualTo("Hello back"u8.ToArray()));
-        await connection.StopAsync();
+        Assert.Equal("Hello back"u8.ToArray(), dataReceivedByConnection);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionReceivesDataOnBufferBoundary()
     {
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
@@ -130,18 +125,18 @@ public class WebSocketConnectionTests
         await server.SendWebSocketDataAsync(registeredConnectionId, data);
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
 
-        Assert.That(dataReceivedByConnection, Is.EqualTo(Encoding.UTF8.GetBytes(data)));
-        await connection.StopAsync();
+        Assert.Equal(Encoding.UTF8.GetBytes(data), dataReceivedByConnection);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionReceivesDataOnVeryLongMessage()
     {
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
@@ -150,11 +145,11 @@ public class WebSocketConnectionTests
         await server.SendWebSocketDataAsync(registeredConnectionId, data);
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
 
-        Assert.That(dataReceivedByConnection, Is.EqualTo(Encoding.UTF8.GetBytes(data)));
-        await connection.StopAsync();
+        Assert.Equal(Encoding.UTF8.GetBytes(data), dataReceivedByConnection);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionLogIncludesSendAndRecvDebugMessages()
     {
         await using Server server = this.CreateServer();
@@ -168,23 +163,23 @@ public class WebSocketConnectionTests
             allLogs.Add(e);
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Hello world"u8.ToArray());
+        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToReceiveData(TimeSpan.FromSeconds(4));
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(4));
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(allLogs, Has.Some.Matches<LogMessageEventArgs>(
-            e => e.Message.StartsWith("SEND >>> ") && e.Level == WebDriverBiDiLogLevel.Debug));
-        Assert.That(allLogs, Has.Some.Matches<LogMessageEventArgs>(
-            e => e.Message.StartsWith("RECV <<< ") && e.Level == WebDriverBiDiLogLevel.Debug));
+        Assert.Contains(allLogs,
+            e => e.Message.StartsWith("SEND >>> ") && e.Level == WebDriverBiDiLogLevel.Debug);
+        Assert.Contains(allLogs,
+            e => e.Message.StartsWith("RECV <<< ") && e.Level == WebDriverBiDiLogLevel.Debug);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionLog()
     {
         await using Server server = this.CreateServer();
@@ -202,15 +197,15 @@ public class WebSocketConnectionTests
 
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
-        await connection.SendDataAsync("Hello world"u8.ToArray());
+        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToReceiveData(TimeSpan.FromSeconds(4));
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(4));
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         List<string> messages = [];
         foreach (LogMessageEventArgs logValue in logValues)
@@ -218,34 +213,32 @@ public class WebSocketConnectionTests
             messages.Add(logValue.Message);
         }
 
-        Assert.That(logValues, Has.Count.EqualTo(5), $"Actual values: {string.Join("\n", messages.ToArray())}");
+        Assert.Equal(5, logValues.Count);
         foreach (LogMessageEventArgs args in logValues)
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(args.Level, Is.EqualTo(WebDriverBiDiLogLevel.Info));
-                Assert.That(args.Message, Is.Not.Null);
-            }
+
+            Assert.Equal(WebDriverBiDiLogLevel.Info, args.Level);
+            Assert.NotNull(args.Message);
         }
     }
 
-    [Test]
+    [Fact]
     public async Task TestIsActiveProperty()
     {
         await using Server server = this.CreateServer();
         await server.StartAsync();
 
         WebSocketConnection connection = new();
-        Assert.That(connection.IsActive, Is.False);
+        Assert.False(connection.IsActive);
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        Assert.That(connection.IsActive, Is.True);
-        await connection.StopAsync();
-        Assert.That(connection.IsActive, Is.False);
+        Assert.True(connection.IsActive);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestUrlProperty()
     {
         await using Server server = this.CreateServer();
@@ -253,25 +246,25 @@ public class WebSocketConnectionTests
 
         string serverWebSocketUrl = $"ws://localhost:{server.Port}";
         WebSocketConnection connection = new();
-        Assert.That(connection.ConnectionString, Is.EqualTo(string.Empty));
+        Assert.Equal(string.Empty, connection.ConnectionString);
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync(serverWebSocketUrl);
+        await connection.StartAsync(serverWebSocketUrl, cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        Assert.That(connection.ConnectionString, Is.EqualTo(serverWebSocketUrl));
-        await connection.StopAsync();
-        Assert.That(connection.ConnectionString, Is.EqualTo(string.Empty));
+        Assert.Equal(serverWebSocketUrl, connection.ConnectionString);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(string.Empty, connection.ConnectionString);
     }
 
-    [Test]
+    [Fact]
     public async Task TestStopWithoutStart()
     {
         WebSocketConnection connection = new();
-        Assert.That(connection.IsActive, Is.False);
-        await connection.StopAsync();
-        Assert.That(connection.IsActive, Is.False);
+        Assert.False(connection.IsActive);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestStopWithoutStartLogsClientStateNone()
     {
         List<string> connectionLog = [];
@@ -281,17 +274,17 @@ public class WebSocketConnectionTests
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
         });
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         List<string> expectedLogEntries =
         [
             "Closing connection",
             "Client state is None"
         ];
-        Assert.That(connectionLog, Is.EquivalentTo(expectedLogEntries));
+        Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestStopForcesCancellationOfDataReceiveTask()
     {
         await using Server server = this.CreateServer();
@@ -302,21 +295,21 @@ public class WebSocketConnectionTests
             BypassStart = false,
             BypassStop = false
         };
-        Assert.That(connection.IsActive, Is.False);
+        Assert.False(connection.IsActive);
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        Assert.That(connection.IsActive, Is.True);
+        Assert.True(connection.IsActive);
 
         // Send data to the connection, which should force the receive data
         // task to enter a waiting state after receiving the first message.
         await server.SendWebSocketDataAsync(registeredConnectionId, "Hello back");
         byte[] dataReceivedByConnection = this.WaitForConnectionToReceiveData(TimeSpan.FromSeconds(3));
-        await connection.StopAsync();
-        Assert.That(connection.IsActive, Is.False);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionStopCanBeCalledMultipleTimes()
     {
         await using Server server = this.CreateServer();
@@ -330,20 +323,20 @@ public class WebSocketConnectionTests
             return Task.CompletedTask;
         });
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync();
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // First call: socket Open -> CloseClientWebSocketAsync -> "Client state is Closed"
         // Second call: socket Closed -> early-exit -> "Client state is Closed"
         // Also: "Ending processing loop in state Closed" from receive loop
-        Assert.That(connectionLog, Has.Exactly(2).EqualTo("Closing connection"));
-        Assert.That(connectionLog, Has.Exactly(2).EqualTo("Client state is Closed"));
-        Assert.That(connectionLog, Has.Some.EqualTo("Ending processing loop in state Closed"));
+        Assert.Equal(2, connectionLog.Count(item => item == "Closing connection"));
+        Assert.Equal(2, connectionLog.Count(item => item == "Client state is Closed"));
+        Assert.Contains("Ending processing loop in state Closed", connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionHandlesUnexpectedRemoteEndStop()
     {
         await using Server server = this.CreateServer();
@@ -375,7 +368,7 @@ public class WebSocketConnectionTests
             connectionLog.Add(e.Message);
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         await server.StopAsync();
 
@@ -383,13 +376,13 @@ public class WebSocketConnectionTests
         // before calling StopAsync. This ensures client.State is Aborted when StopAsync runs,
         // so we take the early-exit path and avoid calling CloseOutputAsync on an Aborted socket.
         bool clientDetectedError = clientDetectedErrorEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(clientDetectedError, Is.True, "Expected the client to detect the remote end stop within 1 second.");
+        Assert.True(clientDetectedError);
 
-        await connection.StopAsync();
-        Assert.That(connectionLog, Is.EquivalentTo(expectedLogEntries));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionStopWhileReceiveBlocked()
     {
         await using Server server = this.CreateServer();
@@ -431,16 +424,16 @@ public class WebSocketConnectionTests
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
 
         // Receive loop is blocked in ReceiveHandler; client.State is still Open.
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(connectionLog, Is.EquivalentTo(expectedLogEntries));
+        Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionInitiateWebSocketClose()
     {
         await using Server server = this.CreateServer();
@@ -463,13 +456,13 @@ public class WebSocketConnectionTests
             return Task.CompletedTask;
         });
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync();
-        Assert.That(connectionLog, Is.EquivalentTo(expectedLogEntries));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionHandlesDisconnectInitiatedByRemoteEnd()
     {
         await using Server server = this.CreateServer();
@@ -498,7 +491,7 @@ public class WebSocketConnectionTests
         });
 
         IReadOnlyList<string> serverLog = server.Log;
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         ManualResetEvent disconnectEvent = new(false);
         this.clientDisconnectedObserver = server.OnClientDisconnected.AddObserver((e) =>
@@ -513,11 +506,11 @@ public class WebSocketConnectionTests
         // close websocket message to be received by the client.
         await server.DisconnectAsync(registeredConnectionId);
         disconnectEvent.WaitOne(TimeSpan.FromSeconds(1));
-        await connection.StopAsync();
-        Assert.That(connectionLog, Is.EquivalentTo(expectedLogEntries));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionHandlesHungRemoteEnd()
     {
         await using Server server = this.CreateServer();
@@ -545,14 +538,14 @@ public class WebSocketConnectionTests
         });
 
         IReadOnlyList<string> serverLog = server.Log;
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         server.IgnoreCloseConnectionRequest(registeredConnectionId, true);
-        await connection.StopAsync();
-        Assert.That(connectionLog, Is.EquivalentTo(expectedLogEntries));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equivalent(expectedLogEntries, connectionLog);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionRaisesErrorEventOnWebSocketException()
     {
         await using Server server = this.CreateServer();
@@ -572,18 +565,18 @@ public class WebSocketConnectionTests
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         server.IgnoreCloseConnectionRequest(this.connectionId, true);
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3));
-        Assert.That(errorReceived, Is.True);
-        Assert.That(receivedErrorArgs, Is.Not.Null);
-        Assert.That(receivedErrorArgs.Exception, Is.InstanceOf<WebSocketException>());
+        bool errorReceived = errorReceivedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(errorReceived);
+        Assert.NotNull(receivedErrorArgs);
+        Assert.IsType<WebSocketException>(receivedErrorArgs.Exception);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionCanBeReusedAfterBeingShutDown()
     {
         await using Server server = this.CreateServer();
@@ -596,36 +589,36 @@ public class WebSocketConnectionTests
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         ServerEventObserver<ServerDataReceivedEventArgs> observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("First connection hello"u8.ToArray());
+        await connection.SendDataAsync("First connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         string serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
-        Assert.That(serverReceivedData, Is.EqualTo("First connection hello"));
+        Assert.Equal("First connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "First connection acknowledged");
         byte[] receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
-        await connection.StopAsync();
-        Assert.That(receivedData, Is.EqualTo("First connection acknowledged"u8.ToArray()));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("First connection acknowledged"u8.ToArray(), receivedData);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Second connection hello"u8.ToArray());
+        await connection.SendDataAsync("Second connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
-        Assert.That(serverReceivedData, Is.EqualTo("Second connection hello"));
+        Assert.Equal("Second connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Second connection acknowledged");
         receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
-        await connection.StopAsync();
-        Assert.That(receivedData, Is.EqualTo("Second connection acknowledged"u8.ToArray()));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Second connection acknowledged"u8.ToArray(), receivedData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionCanBeReusedAfterBeingAborted()
     {
         await using Server server = this.CreateServer();
@@ -638,37 +631,37 @@ public class WebSocketConnectionTests
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         ServerEventObserver<ServerDataReceivedEventArgs> observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("First connection hello"u8.ToArray());
+        await connection.SendDataAsync("First connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         string serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
-        Assert.That(serverReceivedData, Is.EqualTo("First connection hello"));
+        Assert.Equal("First connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "First connection acknowledged");
         byte[] receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
         server.IgnoreCloseConnectionRequest(registeredConnectionId, true);
-        await connection.StopAsync();
-        Assert.That(receivedData, Is.EqualTo("First connection acknowledged"u8.ToArray()));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("First connection acknowledged"u8.ToArray(), receivedData);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         observer = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Second connection hello"u8.ToArray());
+        await connection.SendDataAsync("Second connection hello"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         serverReceivedData = this.WaitForServerToReceiveData(TimeSpan.FromMilliseconds(250));
         observer.Unobserve();
-        Assert.That(serverReceivedData, Is.EqualTo("Second connection hello"));
+        Assert.Equal("Second connection hello", serverReceivedData);
 
         await server.SendWebSocketDataAsync(registeredConnectionId, "Second connection acknowledged");
         receivedData = this.WaitForConnectionToReceiveData(TimeSpan.FromMilliseconds(250));
-        await connection.StopAsync();
-        Assert.That(receivedData, Is.EqualTo("Second connection acknowledged"u8.ToArray()));
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Second connection acknowledged"u8.ToArray(), receivedData);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCannotStartAlreadyStartedConnection()
     {
         await using Server server = this.CreateServer();
@@ -679,26 +672,26 @@ public class WebSocketConnectionTests
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        Assert.That(async () => await connection.StartAsync($"ws://localhost:{server.Port}"), Throws.InstanceOf<WebDriverBiDiException>().With.Message.StartsWith($"The WebSocket is already connected to ws://localhost:{server.Port}"));
+        Assert.StartsWith($"The WebSocket is already connected to ws://localhost:{server.Port}", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
-    public void TestStartAsyncThrowsForInvalidUrl()
+    [Fact]
+    public async Task TestStartAsyncThrowsForInvalidUrl()
     {
         WebSocketConnection connection = new();
-        Assert.That(async () => await connection.StartAsync("not-a-valid-url"), Throws.InstanceOf<ArgumentException>().With.Message.Contains("not a valid absolute URI"));
+        Assert.Contains("not a valid absolute URI", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await connection.StartAsync("not-a-valid-url", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
-    public void TestStartAsyncThrowsForNonWebSocketUrl()
+    [Fact]
+    public async Task TestStartAsyncThrowsForNonWebSocketUrl()
     {
         WebSocketConnection connection = new();
-        Assert.That(async () => await connection.StartAsync("http://localhost:8080"), Throws.InstanceOf<ArgumentException>().With.Message.Contains("The URI scheme must be 'ws' or 'wss'; received 'http'"));
+        Assert.Contains("The URI scheme must be 'ws' or 'wss'; received 'http'", (await Assert.ThrowsAnyAsync<ArgumentException>(async () => await connection.StartAsync("http://localhost:8080", cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanStartWithSecuredWebSocketUrl()
     {
         using RSA rsa = RSA.Create(2048);
@@ -721,21 +714,21 @@ public class WebSocketConnectionTests
 
         // We expect this to fail with a timeout, but it verifies that the connection
         // attempts to connect to the correct URL and that the URL is accepted as valid.
-        Assert.That(async () => await connection.StartAsync($"wss://localhost:{server.Port}"), Throws.InstanceOf<WebDriverBiDiTimeoutException>());
+        await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.StartAsync($"wss://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken));
     }
 
-    [Test]
-    public void TestCannotSendDataOnAConnectionNotYetStarted()
+    [Fact]
+    public async Task TestCannotSendDataOnAConnectionNotYetStarted()
     {
         WebSocketConnection connection = new()
         {
             StartupTimeout = TimeSpan.FromSeconds(1),
             ShutdownTimeout = TimeSpan.FromSeconds(1),
         };
-        Assert.That(async () => await connection.SendDataAsync("This send should fail"u8.ToArray()), Throws.InstanceOf<WebDriverBiDiException>().With.Message.StartsWith($"The WebSocket has not been initialized"));
+        Assert.StartsWith($"The WebSocket has not been initialized", (await Assert.ThrowsAnyAsync<WebDriverBiDiException>(async () => await connection.SendDataAsync("This send should fail"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken))).Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanShutdownWhenCleanShutdownExceedsTimeout()
     {
         await using Server server = this.CreateServer();
@@ -753,18 +746,18 @@ public class WebSocketConnectionTests
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         server.IgnoreCloseConnectionRequest(registeredConnectionId, true);
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // With ShutdownTimeout=Zero, CloseClientWebSocketAsync may throw OperationCanceledException
         // before logging "Client state is X". At minimum we get "Closing connection".
-        Assert.That(connectionLog, Has.Some.EqualTo("Closing connection"));
-        Assert.That(connectionLog, Has.Count.GreaterThanOrEqualTo(1));
+        Assert.Contains("Closing connection", connectionLog);
+        Assert.True(connectionLog.Count >= 1);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDataSendOperationsAreSynchronized()
     {
         await using Server server = this.CreateServer();
@@ -778,7 +771,7 @@ public class WebSocketConnectionTests
             DataSendDelay = TimeSpan.FromMilliseconds(100),
             DataTimeout = TimeSpan.FromMilliseconds(20),
         };
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
 
         ManualResetEventSlim syncEvent = new(false);
         connection.DataSendStarting += (sender, e) =>
@@ -787,28 +780,28 @@ public class WebSocketConnectionTests
         };
 
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        _ = Task.Run(() => connection.SendDataAsync("first data"u8.ToArray()));
-        syncEvent.Wait();
-        Assert.That(async () => await connection.SendDataAsync("second data"u8.ToArray()), Throws.InstanceOf<WebDriverBiDiTimeoutException>().With.Message.EqualTo("Timed out waiting to access WebSocket for sending; only one send operation is permitted at a time."));
-        await connection.StopAsync();
+        _ = Task.Run(() => connection.SendDataAsync("first data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        syncEvent.Wait(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Timed out waiting to access WebSocket for sending; only one send operation is permitted at a time.", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync("second data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken))).Message);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncWithoutStarting()
     {
         WebSocketConnection connection = new();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeAsyncDoesNotThrow()
     {
         WebSocketConnection connection = new();
         await connection.DisposeAsync();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestDoubleDisposeAsyncAfterStartDoesNotThrow()
     {
         await using Server server = this.CreateServer();
@@ -816,22 +809,22 @@ public class WebSocketConnectionTests
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         await connection.DisposeAsync();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestIsDisposedPropertyIsSetAfterDispose()
     {
         TestWebSocketConnection connection = new();
-        Assert.That(connection.Disposed, Is.False);
+        Assert.False(connection.Disposed);
         await connection.DisposeAsync();
-        Assert.That(connection.Disposed, Is.True);
+        Assert.True(connection.Disposed);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncAfterStop()
     {
         await using Server server = this.CreateServer();
@@ -839,13 +832,13 @@ public class WebSocketConnectionTests
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncWithoutStoping()
     {
         await using Server server = this.CreateServer();
@@ -853,13 +846,13 @@ public class WebSocketConnectionTests
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
-        Assert.That(connection.IsActive, Is.False);
+        await connection.DisposeAsync();
+        Assert.False(connection.IsActive);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDisposeLogsExceptionFromStop()
     {
         await using Server server = this.CreateServer();
@@ -872,19 +865,19 @@ public class WebSocketConnectionTests
             logs.Add(e);
             return Task.CompletedTask;
         });
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         connection.ThrowOnStop = true;
         connection.BypassStop = false;
         await connection.DisposeAsync();
-        Assert.That(logs, Has.Some.Matches<LogMessageEventArgs>(
+        Assert.Contains(logs,
             log => log.Message.Contains("Unexpected exception during disposal")
                    && log.Message.Contains("Simulated stop failure")
                    && log.Level == WebDriverBiDiLogLevel.Warn
-                   && log.ComponentName == Connection.LoggerComponentName));
+                   && log.ComponentName == Connection.LoggerComponentName);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanDisposeAsyncStartedConnectionAfterStop()
     {
         await using Server server = this.CreateServer();
@@ -892,18 +885,18 @@ public class WebSocketConnectionTests
 
         WebSocketConnection connection = new();
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.serverDataReceivedObserver = server.OnDataReceived.AddObserver(this.OnSocketDataReceived);
 
-        await connection.SendDataAsync("Hello world"u8.ToArray());
+        await connection.SendDataAsync("Hello world"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToReceiveData(TimeSpan.FromSeconds(3));
 
-        await connection.StopAsync();
-        Assert.That(async () => await connection.DisposeAsync(), Throws.Nothing);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await connection.DisposeAsync();
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionDiscardsPartialFragmentedMessageOnClose()
     {
         await using Server server = this.CreateServer();
@@ -932,13 +925,13 @@ public class WebSocketConnectionTests
             throw new OperationCanceledException(token);
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        closeReturned.Wait(TimeSpan.FromSeconds(3));
-        await connection.StopAsync();
+        closeReturned.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionCleansUpPartialFragmentedMessageOnException()
     {
         await using Server server = this.CreateServer();
@@ -961,13 +954,13 @@ public class WebSocketConnectionTests
             throw new OperationCanceledException();
         };
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        exceptionThrown.Wait(TimeSpan.FromSeconds(3));
-        await connection.StopAsync();
+        exceptionThrown.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendDataThrowsWhenConnectionBecomesInactiveAfterSemaphoreAcquired()
     {
         int isActiveCallCount = 0;
@@ -979,16 +972,14 @@ public class WebSocketConnectionTests
                 return count <= 1;
             },
         };
-        await connection.StartAsync("ws:localhost");
+        await connection.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         connection.BypassStart = false;
 
-        Assert.That(
-            async () => await connection.SendDataAsync("data"u8.ToArray()),
-            Throws.InstanceOf<WebDriverBiDiConnectionException>()
-                .With.Message.EqualTo("The WebSocket connection was closed before the send could be completed"));
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync("data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal("The WebSocket connection was closed before the send could be completed", exception.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSendDataWrapsWebSocketExceptionInConnectionException()
     {
         TestWebSocketConnection connection = new()
@@ -996,17 +987,15 @@ public class WebSocketConnectionTests
             IsActiveOverride = () => true,
             SendWebSocketDataOverride = _ => throw new WebSocketException("Simulated WebSocket failure"),
         };
-        await connection.StartAsync("ws:localhost");
+        await connection.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         connection.BypassStart = false;
 
-        Assert.That(
-            async () => await connection.SendDataAsync("data"u8.ToArray()),
-            Throws.InstanceOf<WebDriverBiDiConnectionException>()
-                .With.Message.Contains("Simulated WebSocket failure")
-                .And.InnerException.InstanceOf<WebSocketException>());
+        WebDriverBiDiConnectionException exception = await Assert.ThrowsAnyAsync<WebDriverBiDiConnectionException>(async () => await connection.SendDataAsync("data"u8.ToArray(), cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("Simulated WebSocket failure", exception.Message);
+        Assert.IsType<WebSocketException>(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public async Task TestStartAsyncThrowsWhenCancellationTokenIsCanceledDuringConnectionRetry()
     {
         int port;
@@ -1024,13 +1013,13 @@ public class WebSocketConnectionTests
         };
 
         Task startTask = connection.StartAsync($"ws://localhost:{port}", cts.Token);
-        await Task.Delay(100);
+        await Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         cts.Cancel();
 
-        Assert.That(async () => await startTask, Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await startTask);
     }
 
-    [Test]
+    [Fact]
     public async Task TestConnectionRaisesOnRemoteDisconnectedWhenServerGracefullyCloses()
     {
         await using Server server = this.CreateServer();
@@ -1050,19 +1039,19 @@ public class WebSocketConnectionTests
             return Task.CompletedTask;
         });
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
         this.clientDisconnectedObserver = server.OnClientDisconnected.AddObserver(_ => { });
 
         await server.DisconnectAsync(registeredConnectionId);
 
-        bool disconnected = remoteDisconnectedEvent.Wait(TimeSpan.FromSeconds(3));
-        Assert.That(disconnected, Is.True, "Expected OnRemoteDisconnected to fire when server gracefully closes");
-        Assert.That(receivedEventArgs, Is.Not.Null);
-        await connection.StopAsync();
+        bool disconnected = remoteDisconnectedEvent.Wait(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(disconnected);
+        Assert.NotNull(receivedEventArgs);
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
-    [Test]
+    [Fact]
     public async Task TestAllLogOutputsAreProduced()
     {
         await using Server server = this.CreateServer();
@@ -1077,19 +1066,19 @@ public class WebSocketConnectionTests
         });
         connection.OnDataReceived.AddObserver(this.OnConnectionDataReceivedAsync);
 
-        await connection.StartAsync($"ws://localhost:{server.Port}");
+        await connection.StartAsync($"ws://localhost:{server.Port}", cancellationToken: TestContext.Current.CancellationToken);
         this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        await connection.StopAsync();
+        await connection.StopAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.That(connectionLog, Has.Some.Matches<string>(s => s.StartsWith("Opening connection to URL ")));
-        Assert.That(connectionLog, Has.Some.EqualTo("Connection opened"));
-        Assert.That(connectionLog, Has.Some.EqualTo("Closing connection"));
-        Assert.That(connectionLog, Has.Some.Matches<string>(s => s.StartsWith("Client state is ")));
-        Assert.That(connectionLog, Has.Some.Matches<string>(s => s.StartsWith("Ending processing loop in state ")));
+        Assert.Contains(connectionLog, s => s.StartsWith("Opening connection to URL "));
+        Assert.Contains("Connection opened", connectionLog);
+        Assert.Contains("Closing connection", connectionLog);
+        Assert.Contains(connectionLog, s => s.StartsWith("Client state is "));
+        Assert.Contains(connectionLog, s => s.StartsWith("Ending processing loop in state "));
     }
 
-    [Test]
-    public void TestSendDataThrowsWhenCancellationTokenIsCanceled()
+    [Fact]
+    public async Task TestSendDataThrowsWhenCancellationTokenIsCanceled()
     {
         TestWebSocketConnection connection = new()
         {
@@ -1099,7 +1088,7 @@ public class WebSocketConnectionTests
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        Assert.That(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("test"), cts.Token), Throws.InstanceOf<OperationCanceledException>());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("test"), cts.Token));
     }
 
     private Server CreateServer()

--- a/test/WebDriverBiDi.Tests/ReceivedDataDictionaryTests.cs
+++ b/test/WebDriverBiDi.Tests/ReceivedDataDictionaryTests.cs
@@ -4,10 +4,9 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using WebDriverBiDi.Internal;
 
-[TestFixture]
 public class ReceivedDataDictionaryTests
 {
-    [Test]
+    [Fact]
     public void TestCanWrapDictionary()
     {
         Dictionary<string, object?> dictionary = new()
@@ -36,23 +35,21 @@ public class ReceivedDataDictionaryTests
         ReceivedDataDictionary received = new(dictionary);
         IList<object?>? wrappedList = received["list"] as IList<object?>;
         IDictionary<string, object?>? wrappedDict = received["dictionary"] as IDictionary<string, object?>;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(received["string"], Is.EqualTo("myString"));
-            Assert.That(received["long"], Is.EqualTo(23));
-            Assert.That(received["bool"], Is.EqualTo(true));
-            Assert.That(received["null"], Is.Null);
-            Assert.That(wrappedList, Is.Not.Null);
-            Assert.That(wrappedList!, Is.InstanceOf<ReceivedDataList>());
-            Assert.That(() => wrappedList!.Add("foo"), Throws.InstanceOf<NotSupportedException>());
-            Assert.That(wrappedDict, Is.Not.Null);
-            Assert.That(wrappedDict, Is.InstanceOf<ReceivedDataDictionary>());
-            Assert.That(() => wrappedDict!["newKey"] = "newValue", Throws.InstanceOf<NotSupportedException>());
-            Assert.That(() => wrappedDict!["string"] = "newValue", Throws.InstanceOf<NotSupportedException>());
-        }
+
+        Assert.Equal("myString", received["string"]);
+        Assert.Equal(23, received["long"]);
+        Assert.Equal(true, received["bool"]);
+        Assert.Null(received["null"]);
+        Assert.NotNull(wrappedList);
+        Assert.IsType<ReceivedDataList>(wrappedList);
+        Assert.ThrowsAny<NotSupportedException>(() => wrappedList.Add("foo"));
+        Assert.NotNull(wrappedDict);
+        Assert.IsType<ReceivedDataDictionary>(wrappedDict);
+        Assert.ThrowsAny<NotSupportedException>(() => wrappedDict["newKey"] = "newValue");
+        Assert.ThrowsAny<NotSupportedException>(() => wrappedDict["string"] = "newValue");
     }
 
-    [Test]
+    [Fact]
     public void TestCanUnwrapDictionaryToCopy()
     {
         Dictionary<string, object?> dictionary = new()
@@ -82,34 +79,33 @@ public class ReceivedDataDictionaryTests
         IDictionary<string, object?> unwrapped = received.ToWritableCopy();
         IList<object?>? unwrappedList = unwrapped["list"] as IList<object?>;
         IDictionary<string, object?>? unwrappedDict = unwrapped["dictionary"] as IDictionary<string, object?>;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unwrapped["string"], Is.EqualTo("myString"));
-            Assert.That(unwrapped["long"], Is.EqualTo(23));
-            Assert.That(unwrapped["bool"], Is.EqualTo(true));
-            Assert.That(unwrapped["null"], Is.Null);
-            Assert.That(unwrappedList, Is.Not.Null);
-            Assert.That(unwrappedList!, Is.InstanceOf<List<object?>>());
-            Assert.That(unwrappedDict, Is.Not.Null);
-            Assert.That(unwrappedDict, Is.InstanceOf<Dictionary<string, object?>>());
-        }
 
-        unwrappedList!.Add("foo");
-        unwrappedDict!["bar"] = "baz";
+        Assert.Equal("myString", unwrapped["string"]);
+        Assert.Equal(23, unwrapped["long"]);
+        Assert.Equal(true, unwrapped["bool"]);
+        Assert.Null(unwrapped["null"]);
+        Assert.NotNull(unwrappedList);
+        Assert.IsType<List<object?>>(unwrappedList);
+        Assert.NotNull(unwrappedDict);
+        Assert.IsType<Dictionary<string, object?>>(unwrappedDict);
+
+        unwrappedList.Add("foo");
+        unwrappedDict["bar"] = "baz";
     }
 
-    [Test]
+    [Fact]
     public void TestEmptyDictionary()
     {
-        Assert.That(ReceivedDataDictionary.EmptyDictionary, Is.Empty);
+        Assert.Empty(ReceivedDataDictionary.EmptyDictionary);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateFromDeserializedData()
     {
         string json = @"{ ""stringProperty"": ""stringValue"", ""intValue"": 123, ""floatValue"": 456.78, ""trueBoolValue"": true, ""falseBoolValue"": false, ""nullValue"": null, ""listValue"": [ ""listString"", 901, true, null ], ""objectValue"": { ""objectProperty"": ""objectValue"" } }";
         OnlyOverflowData? deserializedValue = JsonSerializer.Deserialize<OnlyOverflowData>(json);
-        Assert.That(deserializedValue!.ReceivedData, Has.Count.EqualTo(8));
+        Assert.NotNull(deserializedValue);
+        Assert.Equal(8, deserializedValue.ReceivedData.Count);
     }
 
     private class OnlyOverflowData

--- a/test/WebDriverBiDi.Tests/ReceivedDataListTests.cs
+++ b/test/WebDriverBiDi.Tests/ReceivedDataListTests.cs
@@ -1,9 +1,8 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class ReceivedDataListTests
 {
-    [Test]
+    [Fact]
     public void TestCanWrapList()
     {
         List<object?> list =
@@ -30,23 +29,21 @@ public class ReceivedDataListTests
         ReceivedDataList received = new(list);
         IList<object?>? wrappedList = received[4] as IList<object?>;
         IDictionary<string, object?>? wrappedDict = received[5] as IDictionary<string, object?>;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(received[0], Is.EqualTo("myString"));
-            Assert.That(received[1], Is.EqualTo(23));
-            Assert.That(received[2], Is.EqualTo(true));
-            Assert.That(received[3], Is.Null);
-            Assert.That(wrappedList, Is.Not.Null);
-            Assert.That(wrappedList!, Is.InstanceOf<ReceivedDataList>());
-            Assert.That(() => wrappedList!.Add("foo"), Throws.InstanceOf<NotSupportedException>());
-            Assert.That(wrappedDict, Is.Not.Null);
-            Assert.That(wrappedDict, Is.InstanceOf<ReceivedDataDictionary>());
-            Assert.That(() => wrappedDict!["newKey"] = "newValue", Throws.InstanceOf<NotSupportedException>());
-            Assert.That(() => wrappedDict!["string"] = "newValue", Throws.InstanceOf<NotSupportedException>());
-        }
+
+        Assert.Equal("myString", received[0]);
+        Assert.Equal(23, received[1]);
+        Assert.Equal(true, received[2]);
+        Assert.Null(received[3]);
+        Assert.NotNull(wrappedList);
+        Assert.IsType<ReceivedDataList>(wrappedList);
+        Assert.ThrowsAny<NotSupportedException>(() => wrappedList.Add("foo"));
+        Assert.NotNull(wrappedDict);
+        Assert.IsType<ReceivedDataDictionary>(wrappedDict);
+        Assert.ThrowsAny<NotSupportedException>(() => wrappedDict["newKey"] = "newValue");
+        Assert.ThrowsAny<NotSupportedException>(() => wrappedDict["string"] = "newValue");
     }
 
-    [Test]
+    [Fact]
     public void TestCanUnwrapListToCopy()
     {
         List<object?> list =
@@ -74,25 +71,23 @@ public class ReceivedDataListTests
         List<object?> unwrapped = received.ToWritableCopy();
         IList<object?>? unwrappedList = unwrapped[4] as IList<object?>;
         IDictionary<string, object?>? unwrappedDict = unwrapped[5] as IDictionary<string, object?>;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(unwrapped[0], Is.EqualTo("myString"));
-            Assert.That(unwrapped[1], Is.EqualTo(23));
-            Assert.That(unwrapped[2], Is.EqualTo(true));
-            Assert.That(unwrapped[3], Is.Null);
-            Assert.That(unwrappedList, Is.Not.Null);
-            Assert.That(unwrappedList!, Is.InstanceOf<List<object?>>());
-            Assert.That(unwrappedDict, Is.Not.Null);
-            Assert.That(unwrappedDict, Is.InstanceOf<Dictionary<string, object?>>());
-        }
 
-        unwrappedList!.Add("foo");
-        unwrappedDict!["bar"] = "baz";
+        Assert.Equal("myString", unwrapped[0]);
+        Assert.Equal(23, unwrapped[1]);
+        Assert.Equal(true, unwrapped[2]);
+        Assert.Null(unwrapped[3]);
+        Assert.NotNull(unwrappedList);
+        Assert.IsType<List<object?>>(unwrappedList);
+        Assert.NotNull(unwrappedDict);
+        Assert.IsType<Dictionary<string, object?>>(unwrappedDict);
+
+        unwrappedList.Add("foo");
+        unwrappedDict["bar"] = "baz";
     }
 
-    [Test]
+    [Fact]
     public void TestEmptyDictionary()
     {
-        Assert.That(ReceivedDataList.EmptyList, Is.Empty);
+        Assert.Empty(ReceivedDataList.EmptyList);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/AddPreloadScriptCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/AddPreloadScriptCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class AddPreloadScriptCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         AddPreloadScriptCommandParameters properties = new("myFunctionDeclaration");
-        Assert.That(properties.MethodName, Is.EqualTo("script.addPreloadScript"));
+        Assert.Equal("script.addPreloadScript", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeProperties()
     {
         AddPreloadScriptCommandParameters properties = new("myFunctionDeclaration");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["functionDeclaration"]!.Value<string>(), Is.EqualTo("myFunctionDeclaration"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+        Assert.Equal("myFunctionDeclaration", functionDeclaration.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithSandbox()
     {
         AddPreloadScriptCommandParameters properties = new("myFunctionDeclaration")
@@ -37,19 +36,22 @@ public class AddPreloadScriptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["functionDeclaration"]!.Value<string>(), Is.EqualTo("myFunctionDeclaration"));
-            Assert.That(serialized, Contains.Key("sandbox"));
-            Assert.That(serialized["sandbox"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sandbox"]!.Value<string>(), Is.EqualTo("mySandbox"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+        Assert.Equal("myFunctionDeclaration", functionDeclaration.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sandbox"));
+        JToken? sandbox = serialized["sandbox"];
+        Assert.NotNull(sandbox);
+        Assert.Equal(JTokenType.String, sandbox.Type);
+        Assert.Equal("mySandbox", sandbox.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithArguments()
     {
         AddPreloadScriptCommandParameters properties = new("myFunctionDeclaration")
@@ -61,32 +63,44 @@ public class AddPreloadScriptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["functionDeclaration"]!.Value<string>(), Is.EqualTo("myFunctionDeclaration"));
-            Assert.That(serialized, Contains.Key("arguments"));
-            Assert.That(serialized["arguments"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? argsArray = serialized["arguments"]!.Value<JArray>();
-            Assert.That(argsArray, Has.Count.EqualTo(1));
-            Assert.That(argsArray![0].Type, Is.EqualTo(JTokenType.Object));
-            JObject? argObject = argsArray[0].Value<JObject>();
-            Assert.That(argObject, Has.Count.EqualTo(2));
-            Assert.That(argObject, Contains.Key("type"));
-            Assert.That(argObject!["type"]!.Value<string>(), Is.EqualTo("channel"));
-            Assert.That(argObject, Contains.Key("value"));
-            Assert.That(argObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? argValue = argObject["value"]!.Value<JObject>();
-            Assert.That(argValue!.Value<JObject>(), Has.Count.EqualTo(1));
-            Assert.That(argValue, Contains.Key("channel"));
-            Assert.That(argValue!["channel"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(argValue!["channel"]!.Value<string>(), Is.EqualTo("myChannel"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+        Assert.Equal("myFunctionDeclaration", functionDeclaration.Value<string>());
+
+        Assert.True(serialized.ContainsKey("arguments"));
+        JToken? argumentsToken = serialized["arguments"];
+        Assert.NotNull(argumentsToken);
+        Assert.Equal(JTokenType.Array, argumentsToken.Type);
+        JArray? argsArray = argumentsToken as JArray;
+        Assert.NotNull(argsArray);
+        Assert.Single(argsArray);
+        Assert.Equal(JTokenType.Object, argsArray[0].Type);
+        JObject? argObject = argsArray[0] as JObject;
+        Assert.NotNull(argObject);
+        Assert.Equal(2, argObject.Count);
+        Assert.True(argObject.ContainsKey("type"));
+        JToken? argType = argObject["type"];
+        Assert.NotNull(argType);
+        Assert.Equal("channel", argType.Value<string>());
+        Assert.True(argObject.ContainsKey("value"));
+        JToken? argValueToken = argObject["value"];
+        Assert.NotNull(argValueToken);
+        Assert.Equal(JTokenType.Object, argValueToken.Type);
+        JObject? argValue = argValueToken as JObject;
+        Assert.NotNull(argValue);
+        Assert.Single(argValue);
+        Assert.True(argValue.ContainsKey("channel"));
+        JToken? channel = argValue["channel"];
+        Assert.NotNull(channel);
+        Assert.Equal(JTokenType.String, channel.Type);
+        Assert.Equal("myChannel", channel.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         AddPreloadScriptCommandParameters properties = new("myFunctionDeclaration")
@@ -99,24 +113,28 @@ public class AddPreloadScriptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["functionDeclaration"]!.Value<string>(), Is.EqualTo("myFunctionDeclaration"));
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+        Assert.Equal("myFunctionDeclaration", functionDeclaration.Value<string>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken as JArray;
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         AddPreloadScriptCommandParameters properties = new("myFunctionDeclaration")
@@ -129,20 +147,24 @@ public class AddPreloadScriptCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["functionDeclaration"]!.Value<string>(), Is.EqualTo("myFunctionDeclaration"));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+        Assert.Equal("myFunctionDeclaration", functionDeclaration.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken as JArray;
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/AddPreloadScriptCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/AddPreloadScriptCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class AddPreloadScriptCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeAddLoadScriptCommandResult()
     {
         string json = """
@@ -14,11 +13,11 @@ public class AddPreloadScriptCommandResultTests
                       }
                       """;
         AddPreloadScriptCommandResult? result = JsonSerializer.Deserialize<AddPreloadScriptCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result!.PreloadScriptId, Is.EqualTo("myLoadScript"));
+        Assert.NotNull(result);
+        Assert.Equal("myLoadScript", result.PreloadScriptId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,8 +26,8 @@ public class AddPreloadScriptCommandResultTests
                       }
                       """;
         AddPreloadScriptCommandResult? result = JsonSerializer.Deserialize<AddPreloadScriptCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         AddPreloadScriptCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/BigIntegerRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/BigIntegerRemoteValueTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Script;
 using System.Numerics;
 using System.Text.Json;
 
-[TestFixture]
 public class BigIntegerRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeBigIntegerRemoteValue()
     {
         string json = """
@@ -18,12 +17,12 @@ public class BigIntegerRemoteValueTests
 
         BigIntegerRemoteValue? result = JsonSerializer.Deserialize<BigIntegerRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.BigInt));
-        Assert.That(result.Value, Is.EqualTo(BigInteger.Parse("123456789012345678901234567890")));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.BigInt, result.Type);
+        Assert.Equal(BigInteger.Parse("123456789012345678901234567890"), result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -35,15 +34,15 @@ public class BigIntegerRemoteValueTests
 
         BigIntegerRemoteValue? result = JsonSerializer.Deserialize<BigIntegerRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("bigint"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<BigInteger>());
-        Assert.That(argumentLocalValue.Value, Is.EqualTo(BigInteger.Parse("123456789012345678901234567890")));
+        Assert.Equal("bigint", argumentLocalValue.Type);
+        Assert.IsType<BigInteger>(argumentLocalValue.Value);
+        Assert.Equal(BigInteger.Parse("123456789012345678901234567890"), argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBigIntegerRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -52,10 +51,10 @@ public class BigIntegerRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBigIntegerRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -65,10 +64,10 @@ public class BigIntegerRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBigIntegerRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -78,10 +77,10 @@ public class BigIntegerRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBigIntegerRemoteValueWithInvalidValueThrows()
     {
         string json = """
@@ -91,10 +90,10 @@ public class BigIntegerRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BigIntegerRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -105,9 +104,9 @@ public class BigIntegerRemoteValueTests
                       """;
 
         BigIntegerRemoteValue? result = JsonSerializer.Deserialize<BigIntegerRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         BigIntegerRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/BooleanRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/BooleanRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class BooleanRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeBooleanRemoteValueWithTrue()
     {
         string json = """
@@ -17,12 +16,12 @@ public class BooleanRemoteValueTests
 
         BooleanRemoteValue? result = JsonSerializer.Deserialize<BooleanRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Boolean));
-        Assert.That(result.Value, Is.True);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Boolean, result.Type);
+        Assert.True(result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeBooleanRemoteValueWithFalse()
     {
         string json = """
@@ -34,12 +33,12 @@ public class BooleanRemoteValueTests
 
         BooleanRemoteValue? result = JsonSerializer.Deserialize<BooleanRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Boolean));
-        Assert.That(result.Value, Is.False);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Boolean, result.Type);
+        Assert.False(result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -51,15 +50,15 @@ public class BooleanRemoteValueTests
 
         BooleanRemoteValue? result = JsonSerializer.Deserialize<BooleanRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("boolean"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<bool>());
-        Assert.That(argumentLocalValue.Value, Is.True);
+        Assert.Equal("boolean", argumentLocalValue.Type);
+        Assert.IsType<bool>(argumentLocalValue.Value);
+        Assert.True((bool)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToBool()
     {
         string json = """
@@ -71,12 +70,12 @@ public class BooleanRemoteValueTests
 
         BooleanRemoteValue? result = JsonSerializer.Deserialize<BooleanRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         bool boolValue = result;
-        Assert.That(boolValue, Is.True);
+        Assert.True(boolValue);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBooleanRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -85,10 +84,10 @@ public class BooleanRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BooleanRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BooleanRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBooleanRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -98,10 +97,10 @@ public class BooleanRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BooleanRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BooleanRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingBooleanRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -111,10 +110,10 @@ public class BooleanRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<BooleanRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<BooleanRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -125,9 +124,9 @@ public class BooleanRemoteValueTests
                       """;
 
         BooleanRemoteValue? result = JsonSerializer.Deserialize<BooleanRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         BooleanRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/CallFunctionCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/CallFunctionCommandParametersTests.cs
@@ -3,35 +3,40 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CallFunctionCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         CallFunctionCommandParameters properties = new("myFunction", new RealmTarget("myRealm"), true);
-        Assert.That(properties.MethodName, Is.EqualTo("script.callFunction"));
+        Assert.Equal("script.callFunction", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         CallFunctionCommandParameters properties = new("myFunction", new RealmTarget("myRealm"), true);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("target"));
-            Assert.That(serialized["target"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("awaitPromise"));
-            Assert.That(serialized["awaitPromise"]!.Type, Is.EqualTo(JTokenType.Boolean));
-        }
+
+        Assert.Equal(3, serialized.Count);
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+
+        Assert.True(serialized.ContainsKey("target"));
+        JToken? target = serialized["target"];
+        Assert.NotNull(target);
+        Assert.Equal(JTokenType.Object, target.Type);
+
+        Assert.True(serialized.ContainsKey("awaitPromise"));
+        JToken? awaitPromise = serialized["awaitPromise"];
+        Assert.NotNull(awaitPromise);
+        Assert.Equal(JTokenType.Boolean, awaitPromise.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalValues()
     {
         CallFunctionCommandParameters properties = new("myFunction", new RealmTarget("myRealm"), true);
@@ -45,29 +50,50 @@ public class CallFunctionCommandParametersTests
         properties.UserActivation = true;
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(8));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("functionDeclaration"));
-            Assert.That(serialized["functionDeclaration"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("target"));
-            Assert.That(serialized["target"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("awaitPromise"));
-            Assert.That(serialized["awaitPromise"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized, Contains.Key("arguments"));
-            Assert.That(serialized["arguments"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized, Contains.Key("this"));
-            Assert.That(serialized["this"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("resultOwnership"));
-            Assert.That(serialized["resultOwnership"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("serializationOptions"));
-            Assert.That(serialized["serializationOptions"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("userActivation"));
-            Assert.That(serialized["userActivation"]!.Type, Is.EqualTo(JTokenType.Boolean));
-        }
+        Assert.Equal(8, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("functionDeclaration"));
+        JToken? functionDeclaration = serialized["functionDeclaration"];
+        Assert.NotNull(functionDeclaration);
+        Assert.Equal(JTokenType.String, functionDeclaration.Type);
+
+        Assert.True(serialized.ContainsKey("target"));
+        JToken? target = serialized["target"];
+        Assert.NotNull(target);
+        Assert.Equal(JTokenType.Object, target.Type);
+
+        Assert.True(serialized.ContainsKey("awaitPromise"));
+        JToken? awaitPromise = serialized["awaitPromise"];
+        Assert.NotNull(awaitPromise);
+        Assert.Equal(JTokenType.Boolean, awaitPromise.Type);
+
+        Assert.True(serialized.ContainsKey("arguments"));
+        JToken? arguments = serialized["arguments"];
+        Assert.NotNull(arguments);
+        Assert.Equal(JTokenType.Array, arguments.Type);
+
+        Assert.True(serialized.ContainsKey("this"));
+        JToken? thisToken = serialized["this"];
+        Assert.NotNull(thisToken);
+        Assert.Equal(JTokenType.Object, thisToken.Type);
+
+        Assert.True(serialized.ContainsKey("resultOwnership"));
+        JToken? resultOwnership = serialized["resultOwnership"];
+        Assert.NotNull(resultOwnership);
+        Assert.Equal(JTokenType.String, resultOwnership.Type);
+
+        Assert.True(serialized.ContainsKey("serializationOptions"));
+        JToken? serializationOptions = serialized["serializationOptions"];
+        Assert.NotNull(serializationOptions);
+        Assert.Equal(JTokenType.Object, serializationOptions.Type);
+
+        Assert.True(serialized.ContainsKey("userActivation"));
+        JToken? userActivation = serialized["userActivation"];
+        Assert.NotNull(userActivation);
+        Assert.Equal(JTokenType.Boolean, userActivation.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithChannelValueArgument()
     {
         // This test verifies that ChannelValue can be serialized as an ArgumentValue
@@ -83,20 +109,33 @@ public class CallFunctionCommandParametersTests
         JObject serialized = JObject.Parse(json);
         Assert.Multiple(() =>
         {
-            Assert.That(serialized, Contains.Key("arguments"));
-            Assert.That(serialized["arguments"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray args = (JArray)serialized["arguments"]!;
-            Assert.That(args, Has.Count.EqualTo(1));
-            JObject channelArg = (JObject)args[0]!;
-            Assert.That(channelArg, Contains.Key("type"));
-            Assert.That(channelArg["type"]!.Value<string>(), Is.EqualTo("channel"));
-            Assert.That(channelArg, Contains.Key("value"));
-            Assert.That(channelArg["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject channelValue = (JObject)channelArg["value"]!;
-            Assert.That(channelValue, Contains.Key("channel"));
-            Assert.That(channelValue["channel"]!.Value<string>(), Is.EqualTo("myChannel"));
-            Assert.That(channelValue, Contains.Key("ownership"));
-            Assert.That(channelValue["ownership"]!.Value<string>(), Is.EqualTo("root"));
+            Assert.True(serialized.ContainsKey("arguments"));
+            JToken? argumentsToken = serialized["arguments"];
+            Assert.NotNull(argumentsToken);
+            Assert.Equal(JTokenType.Array, argumentsToken.Type);
+            JArray? args = argumentsToken as JArray;
+            Assert.NotNull(args);
+            Assert.Single(args);
+            JObject? channelArg = args[0] as JObject;
+            Assert.NotNull(channelArg);
+            Assert.True(channelArg.ContainsKey("type"));
+            JToken? channelArgType = channelArg["type"];
+            Assert.NotNull(channelArgType);
+            Assert.Equal("channel", channelArgType.Value<string>());
+            Assert.True(channelArg.ContainsKey("value"));
+            JToken? channelArgValueToken = channelArg["value"];
+            Assert.NotNull(channelArgValueToken);
+            Assert.Equal(JTokenType.Object, channelArgValueToken.Type);
+            JObject? channelValue = channelArgValueToken as JObject;
+            Assert.NotNull(channelValue);
+            Assert.True(channelValue.ContainsKey("channel"));
+            JToken? channelName = channelValue["channel"];
+            Assert.NotNull(channelName);
+            Assert.Equal("myChannel", channelName.Value<string>());
+            Assert.True(channelValue.ContainsKey("ownership"));
+            JToken? ownership = channelValue["ownership"];
+            Assert.NotNull(ownership);
+            Assert.Equal("root", ownership.Value<string>());
         });
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/ChannelPropertiesTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ChannelPropertiesTests.cs
@@ -3,24 +3,23 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ChannelPropertiesTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeChannelProperties()
     {
         ChannelProperties properties = new("myChannel");
         string json = JsonSerializer.Serialize(properties);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(1));
-            Assert.That(parsed, Contains.Key("channel"));
-            Assert.That(parsed["channel"]!.Value<string>(), Is.EqualTo("myChannel"));
-        }
+
+        Assert.Single(parsed);
+        Assert.True(parsed.ContainsKey("channel"));
+        JToken? channel = parsed["channel"];
+        Assert.NotNull(channel);
+        Assert.Equal("myChannel", channel.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeChannelPropertiesWithOptionalOwnership()
     {
         ChannelProperties properties = new("myChannel")
@@ -29,19 +28,22 @@ public class ChannelPropertiesTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("channel"));
-            Assert.That(parsed["channel"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["channel"]!.Value<string>(), Is.EqualTo("myChannel"));
-            Assert.That(parsed, Contains.Key("ownership"));
-            Assert.That(parsed["ownership"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["ownership"]!.Value<string>(), Is.EqualTo("root"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("channel"));
+        JToken? channel = parsed["channel"];
+        Assert.NotNull(channel);
+        Assert.Equal(JTokenType.String, channel.Type);
+        Assert.Equal("myChannel", channel.Value<string>());
+
+        Assert.True(parsed.ContainsKey("ownership"));
+        JToken? ownership = parsed["ownership"];
+        Assert.NotNull(ownership);
+        Assert.Equal(JTokenType.String, ownership.Type);
+        Assert.Equal("root", ownership.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeChannelPropertiesWithOptionalSerializationOptions()
     {
         // Note that SerializationOptions serialization is tested elsewhere.
@@ -51,15 +53,20 @@ public class ChannelPropertiesTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("channel"));
-            Assert.That(parsed["channel"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["channel"]!.Value<string>(), Is.EqualTo("myChannel"));
-            Assert.That(parsed, Contains.Key("serializationOptions"));
-            Assert.That(parsed["serializationOptions"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(parsed["serializationOptions"]!.Value<JObject>(), Is.Empty);
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("channel"));
+        JToken? channel = parsed["channel"];
+        Assert.NotNull(channel);
+        Assert.Equal(JTokenType.String, channel.Type);
+        Assert.Equal("myChannel", channel.Value<string>());
+
+        Assert.True(parsed.ContainsKey("serializationOptions"));
+        JToken? serializationOptionsToken = parsed["serializationOptions"];
+        Assert.NotNull(serializationOptionsToken);
+        Assert.Equal(JTokenType.Object, serializationOptionsToken.Type);
+        JObject? serializationOptions = serializationOptionsToken.Value<JObject>();
+        Assert.NotNull(serializationOptions);
+        Assert.Empty(serializationOptions);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/ChannelValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ChannelValueTests.cs
@@ -3,32 +3,34 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ChannelValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeChannelValue()
     {
         // Note that serialization of ChannelProperties (value property) is tested elsewhere.
         ChannelValue value = new(new ChannelProperties("myChannel"));
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("channel"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
+
+        Assert.Equal(2, parsed.Count);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("channel", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Object, parsedValue.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         // Note that serialization of ChannelProperties (value property) is tested elsewhere.
         ChannelValue value = new(new ChannelProperties("myChannel"));
         ChannelValue copy = value with { };
-        Assert.That(copy, Is.EqualTo(value));
+        Assert.Equal(value, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/CollectionRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/CollectionRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CollectionRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeCollectionRemoteValue()
     {
         string json = """
@@ -21,15 +20,15 @@ public class CollectionRemoteValueTests
         // that can be deserialized into a CollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Array));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value, Is.Empty);
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Array, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Empty(result.Value);
+        Assert.Null(result.Handle);
+        Assert.Null(result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCollectionRemoteValueWithValues()
     {
         string json = """
@@ -50,15 +49,15 @@ public class CollectionRemoteValueTests
         // that can be deserialized into a CollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Array));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value, Has.Count.EqualTo(1));
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Array, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
+        Assert.Null(result.Handle);
+        Assert.Null(result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCollectionRemoteValueWithHandle()
     {
         string json = """
@@ -76,15 +75,15 @@ public class CollectionRemoteValueTests
         // that can be deserialized into a CollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Array));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value, Is.Empty);
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Array, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Empty(result.Value);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeCollectionRemoteValueWithNoValue()
     {
         string json = """
@@ -101,14 +100,14 @@ public class CollectionRemoteValueTests
         // that can be deserialized into a CollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Array));
-        Assert.That(result.Value, Is.Null);
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Array, result.Type);
+        Assert.Null(result.Value);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertArrayToLocalValue()
     {
         string json = """
@@ -125,15 +124,15 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("array"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<IEnumerable<LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Has.Count.EqualTo(1));
+        Assert.Equal("array", argumentLocalValue.Type);
+        Assert.IsType<IEnumerable<LocalValue>>(argumentLocalValue.Value, exactMatch: false);
+        Assert.Single((IEnumerable<LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertSetToLocalValue()
     {
         string json = """
@@ -150,15 +149,15 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("set"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<IEnumerable<LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Has.Count.EqualTo(1));
+        Assert.Equal("set", argumentLocalValue.Type);
+        Assert.IsType<IEnumerable<LocalValue>>(argumentLocalValue.Value, exactMatch: false);
+        Assert.Single((IEnumerable<LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertHtmlCollectionToLocalValue()
     {
         string json = """
@@ -170,15 +169,15 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("array"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<IEnumerable<LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Is.Empty);
+        Assert.Equal("array", argumentLocalValue.Type);
+        Assert.IsType<IEnumerable<LocalValue>>(argumentLocalValue.Value, exactMatch: false);
+        Assert.Empty((IEnumerable<LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertNodeListToLocalValue()
     {
         string json = """
@@ -190,15 +189,15 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("array"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<IEnumerable<LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Is.Empty);
+        Assert.Equal("array", argumentLocalValue.Type);
+        Assert.IsType<IEnumerable<LocalValue>>(argumentLocalValue.Value, exactMatch: false);
+        Assert.Empty((IEnumerable<LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -211,13 +210,13 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingCollectionRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -227,10 +226,10 @@ public class CollectionRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<CollectionRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CollectionRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingCollectionRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -240,10 +239,10 @@ public class CollectionRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<CollectionRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CollectionRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToLocalValueWithNullValueThrows()
     {
         string json = """
@@ -254,11 +253,11 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToLocalValue(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToLocalValue());
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -270,11 +269,11 @@ public class CollectionRemoteValueTests
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -285,9 +284,9 @@ public class CollectionRemoteValueTests
                       """;
 
         CollectionRemoteValue? result = JsonSerializer.Deserialize<CollectionRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CollectionRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/DateRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/DateRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DateRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeDateRemoteValue()
     {
         DateTime expectedDate = new(2020, 7, 19, 23, 47, 19, 856, DateTimeKind.Utc);
@@ -18,12 +17,12 @@ public class DateRemoteValueTests
 
         DateRemoteValue? result = JsonSerializer.Deserialize<DateRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Date));
-        Assert.That(result.Value, Is.EqualTo(expectedDate));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Date, result.Type);
+        Assert.Equal(expectedDate, result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         DateTime expectedDate = new(2020, 7, 19, 23, 47, 19, 856, DateTimeKind.Utc);
@@ -36,15 +35,15 @@ public class DateRemoteValueTests
 
         DateRemoteValue? result = JsonSerializer.Deserialize<DateRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("date"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<DateTime>());
-        Assert.That(argumentLocalValue.Value, Is.EqualTo(expectedDate));
+        Assert.Equal("date", argumentLocalValue.Type);
+        Assert.IsType<DateTime>(argumentLocalValue.Value);
+        Assert.Equal(expectedDate, argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -58,13 +57,13 @@ public class DateRemoteValueTests
 
         DateRemoteValue? result = JsonSerializer.Deserialize<DateRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToDateTime()
     {
         DateTime expectedDate = new(2020, 7, 19, 23, 47, 19, 856, DateTimeKind.Utc);
@@ -77,12 +76,12 @@ public class DateRemoteValueTests
 
         DateRemoteValue? result = JsonSerializer.Deserialize<DateRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         DateTime dateTimeValue = result;
-        Assert.That(dateTimeValue, Is.EqualTo(expectedDate));
+        Assert.Equal(expectedDate, dateTimeValue);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDateRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -91,10 +90,10 @@ public class DateRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<DateRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DateRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDateRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -104,10 +103,10 @@ public class DateRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<DateRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DateRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDateRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -117,10 +116,10 @@ public class DateRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<DateRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DateRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidHandleTypeThrows()
     {
         string json = """
@@ -132,10 +131,10 @@ public class DateRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidInternalIdTypeThrows()
     {
         string json = """
@@ -147,10 +146,10 @@ public class DateRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -162,11 +161,11 @@ public class DateRemoteValueTests
 
         DateRemoteValue? result = JsonSerializer.Deserialize<DateRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -177,9 +176,9 @@ public class DateRemoteValueTests
                       """;
 
         DateRemoteValue? result = JsonSerializer.Deserialize<DateRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         DateRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/DisownCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/DisownCommandParametersTests.cs
@@ -3,47 +3,52 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class DisownCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         DisownCommandParameters properties = new(new RealmTarget("myRealm"));
-        Assert.That(properties.MethodName, Is.EqualTo("script.disown"));
+        Assert.Equal("script.disown", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         DisownCommandParameters properties = new(new RealmTarget("myRealm"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("target"));
-            Assert.That(serialized["target"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("handles"));
-            Assert.That(serialized["handles"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["handles"]!.Count, Is.EqualTo(0));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("target"));
+        JToken? target = serialized["target"];
+        Assert.NotNull(target);
+        Assert.Equal(JTokenType.Object, target.Type);
+
+        Assert.True(serialized.ContainsKey("handles"));
+        JToken? handles = serialized["handles"];
+        Assert.NotNull(handles);
+        Assert.Equal(JTokenType.Array, handles.Type);
+        Assert.Empty(handles);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithHandles()
     {
         DisownCommandParameters properties = new(new RealmTarget("myRealm"), "myHandle");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("target"));
-            Assert.That(serialized["target"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("handles"));
-            Assert.That(serialized["handles"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["handles"]!.Count, Is.EqualTo(1));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("target"));
+        JToken? target = serialized["target"];
+        Assert.NotNull(target);
+        Assert.Equal(JTokenType.Object, target.Type);
+
+        Assert.True(serialized.ContainsKey("handles"));
+        JToken? handles = serialized["handles"];
+        Assert.NotNull(handles);
+        Assert.Equal(JTokenType.Array, handles.Type);
+        Assert.Single(handles);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/DisownCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/DisownCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DisownCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DisownCommandResult? result = JsonSerializer.Deserialize<DisownCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DisownCommandResult? result = JsonSerializer.Deserialize<DisownCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         DisownCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/EvaluateCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/EvaluateCommandParametersTests.cs
@@ -3,35 +3,40 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class EvaluateCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         EvaluateCommandParameters properties = new("myExpression", new RealmTarget("myRealm"), true);
-        Assert.That(properties.MethodName, Is.EqualTo("script.evaluate"));
+        Assert.Equal("script.evaluate", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         EvaluateCommandParameters properties = new("myExpression", new RealmTarget("myRealm"), true);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("expression"));
-            Assert.That(serialized["expression"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("target"));
-            Assert.That(serialized["target"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("awaitPromise"));
-            Assert.That(serialized["awaitPromise"]!.Type, Is.EqualTo(JTokenType.Boolean));
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("expression"));
+        JToken? expression = serialized["expression"];
+        Assert.NotNull(expression);
+        Assert.Equal(JTokenType.String, expression.Type);
+
+        Assert.True(serialized.ContainsKey("target"));
+        JToken? target = serialized["target"];
+        Assert.NotNull(target);
+        Assert.Equal(JTokenType.Object, target.Type);
+
+        Assert.True(serialized.ContainsKey("awaitPromise"));
+        JToken? awaitPromise = serialized["awaitPromise"];
+        Assert.NotNull(awaitPromise);
+        Assert.Equal(JTokenType.Boolean, awaitPromise.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalValues()
     {
         EvaluateCommandParameters properties = new("myExpression", new RealmTarget("myRealm"), true)
@@ -45,21 +50,36 @@ public class EvaluateCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(6));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("expression"));
-            Assert.That(serialized["expression"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("target"));
-            Assert.That(serialized["target"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("awaitPromise"));
-            Assert.That(serialized["awaitPromise"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized, Contains.Key("resultOwnership"));
-            Assert.That(serialized["resultOwnership"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized, Contains.Key("serializationOptions"));
-            Assert.That(serialized["serializationOptions"]!.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Contains.Key("userActivation"));
-            Assert.That(serialized["userActivation"]!.Type, Is.EqualTo(JTokenType.Boolean));
-        }
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("expression"));
+        JToken? expression = serialized["expression"];
+        Assert.NotNull(expression);
+        Assert.Equal(JTokenType.String, expression.Type);
+
+        Assert.True(serialized.ContainsKey("target"));
+        JToken? target = serialized["target"];
+        Assert.NotNull(target);
+        Assert.Equal(JTokenType.Object, target.Type);
+
+        Assert.True(serialized.ContainsKey("awaitPromise"));
+        JToken? awaitPromise = serialized["awaitPromise"];
+        Assert.NotNull(awaitPromise);
+        Assert.Equal(JTokenType.Boolean, awaitPromise.Type);
+
+        Assert.True(serialized.ContainsKey("resultOwnership"));
+        JToken? resultOwnership = serialized["resultOwnership"];
+        Assert.NotNull(resultOwnership);
+        Assert.Equal(JTokenType.String, resultOwnership.Type);
+
+        Assert.True(serialized.ContainsKey("serializationOptions"));
+        JToken? serializationOptions = serialized["serializationOptions"];
+        Assert.NotNull(serializationOptions);
+        Assert.Equal(JTokenType.Object, serializationOptions.Type);
+
+        Assert.True(serialized.ContainsKey("userActivation"));
+        JToken? userActivation = serialized["userActivation"];
+        Assert.NotNull(userActivation);
+        Assert.Equal(JTokenType.Boolean, userActivation.Type);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/EvalulateResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/EvalulateResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class EvaluateResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeScriptEvaluateResultSuccess()
     {
         string json = """
@@ -19,18 +18,16 @@ public class EvaluateResultTests
                       }
                       """;
         EvaluateResult? result = JsonSerializer.Deserialize<EvaluateResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.InstanceOf<EvaluateResultSuccess>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultSuccess>(result);
         EvaluateResultSuccess successResult = (EvaluateResultSuccess)result;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(successResult.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(successResult.Result.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(successResult.Result.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myResult"));
-        }
+
+        Assert.Equal("myRealm", successResult.RealmId);
+        Assert.Equal(RemoteValueType.String, successResult.Result.Type);
+        Assert.Equal("myResult", successResult.Result.ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeScriptEvaluateResultException()
     {
         string json = """
@@ -52,21 +49,19 @@ public class EvaluateResultTests
                       }
                       """;
         EvaluateResult? result = JsonSerializer.Deserialize<EvaluateResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.InstanceOf<EvaluateResultException>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultException>(result);
         EvaluateResultException exceptionResult = (EvaluateResultException)result;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exceptionResult.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(exceptionResult.ExceptionDetails.Text, Is.EqualTo("exception thrown"));
-            Assert.That(exceptionResult.ExceptionDetails.LineNumber, Is.EqualTo(1));
-            Assert.That(exceptionResult.ExceptionDetails.ColumnNumber, Is.EqualTo(5));
-            Assert.That(exceptionResult.ExceptionDetails.StackTrace.CallFrames, Has.Count.EqualTo(0));
-            Assert.That(exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("exception value"));
-        }
+
+        Assert.Equal("myRealm", exceptionResult.RealmId);
+        Assert.Equal("exception thrown", exceptionResult.ExceptionDetails.Text);
+        Assert.Equal(1, exceptionResult.ExceptionDetails.LineNumber);
+        Assert.Equal(5, exceptionResult.ExceptionDetails.ColumnNumber);
+        Assert.Empty(exceptionResult.ExceptionDetails.StackTrace.CallFrames);
+        Assert.Equal("exception value", exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public void TestEvaluateResultSuccessCopySemantics()
     {
         string json = """
@@ -80,14 +75,14 @@ public class EvaluateResultTests
                       }
                       """;
         EvaluateResult? result = JsonSerializer.Deserialize<EvaluateResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.InstanceOf<EvaluateResultSuccess>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultSuccess>(result);
         EvaluateResultSuccess successResult = (EvaluateResultSuccess)result;
         EvaluateResultSuccess copy = successResult with { };
-        Assert.That(copy, Is.EqualTo(successResult));
+        Assert.Equal(successResult, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestEvaluateResultExceptionCopySemantics()
     {
         string json = """
@@ -109,14 +104,14 @@ public class EvaluateResultTests
                       }
                       """;
         EvaluateResult? result = JsonSerializer.Deserialize<EvaluateResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.InstanceOf<EvaluateResultException>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultException>(result);
         EvaluateResultException exceptionResult = (EvaluateResultException)result;
         EvaluateResultException copy = exceptionResult with { };
-        Assert.That(copy, Is.EqualTo(exceptionResult));
+        Assert.Equal(exceptionResult, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeScriptEvaluateResultWithInvalidTypePropertyValueThrows()
     {
         string json = """
@@ -126,10 +121,10 @@ public class EvaluateResultTests
                        "noWoman": "noCry"
                      }
                      """;
-        Assert.That(() => JsonSerializer.Deserialize<EvaluateResult>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'EvaluateResult' type property contains unknown value 'invalid'"));
+        Assert.Contains("JSON for 'EvaluateResult' type property contains unknown value 'invalid'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<EvaluateResult>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeScriptEvaluateResultWithMissingTypePropertyThrows()
     {
         string json = """
@@ -138,10 +133,10 @@ public class EvaluateResultTests
                        "noWoman": "noCry"
                      }
                      """;
-        Assert.That(() => JsonSerializer.Deserialize<EvaluateResult>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'EvaluateResult' must contain a 'type' property"));
+        Assert.Contains("JSON for 'EvaluateResult' must contain a 'type' property", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<EvaluateResult>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeScriptEvaluateResultWithInvalidTypePropertyObjectThrows()
     {
         string json = """
@@ -153,10 +148,10 @@ public class EvaluateResultTests
                        "noWoman": "noCry"
                      }
                      """;
-        Assert.That(() => JsonSerializer.Deserialize<EvaluateResult>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON 'type' property must be a string"));
+        Assert.Contains("JSON 'type' property must be a string", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<EvaluateResult>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeScriptEvaluateResultWithMissingRealmValueThrows()
     {
         string json = """
@@ -168,10 +163,10 @@ public class EvaluateResultTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<EvaluateResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<EvaluateResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeScriptEvaluateResultWithInvalidRealmValueTypeThrows()
     {
         string json = """
@@ -186,13 +181,13 @@ public class EvaluateResultTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<EvaluateResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<EvaluateResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeScriptResultWithNonObjectThrows()
     {
         string json = @"[ ""invalid script result"" ]";
-        Assert.That(() => JsonSerializer.Deserialize<EvaluateResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<EvaluateResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/ExceptionDetailsTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ExceptionDetailsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ExceptionDetailsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -23,18 +22,16 @@ public class ExceptionDetailsTests
                       }
                       """;
         ExceptionDetails? exceptionDetails = JsonSerializer.Deserialize<ExceptionDetails>(json);
-        Assert.That(exceptionDetails, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exceptionDetails.Text, Is.EqualTo("exception message"));
-            Assert.That(exceptionDetails.LineNumber, Is.EqualTo(1));
-            Assert.That(exceptionDetails.ColumnNumber, Is.EqualTo(5));
-            Assert.That(exceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myException"));
-            Assert.That(exceptionDetails.StackTrace.CallFrames, Is.Empty);
-        }
+        Assert.NotNull(exceptionDetails);
+
+        Assert.Equal("exception message", exceptionDetails.Text);
+        Assert.Equal(1, exceptionDetails.LineNumber);
+        Assert.Equal(5, exceptionDetails.ColumnNumber);
+        Assert.Equal("myException", exceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
+        Assert.Empty(exceptionDetails.StackTrace.CallFrames);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -52,12 +49,12 @@ public class ExceptionDetailsTests
                       }
                       """;
         ExceptionDetails? exceptionDetails = JsonSerializer.Deserialize<ExceptionDetails>(json);
-        Assert.That(exceptionDetails, Is.Not.Null);
+        Assert.NotNull(exceptionDetails);
         ExceptionDetails copy = exceptionDetails with { };
-        Assert.That(copy, Is.EqualTo(exceptionDetails));
+        Assert.Equal(exceptionDetails, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingTextThrows()
     {
         string json = """
@@ -73,10 +70,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidTextTypeThrows()
     {
         string json = """
@@ -93,10 +90,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingLineNumberThrows()
     {
         string json = """
@@ -112,10 +109,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidLineNumberTypeThrows()
     {
         string json = """
@@ -132,10 +129,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingColumnNumberThrows()
     {
         string json = """
@@ -151,10 +148,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidColumnNumberTypeThrows()
     {
         string json = """
@@ -171,10 +168,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingExceptionThrows()
     {
         string json = """
@@ -187,10 +184,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidExceptionTypeThrows()
     {
         string json = """
@@ -204,10 +201,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingStackTraceThrows()
     {
         string json = """
@@ -221,10 +218,10 @@ public class ExceptionDetailsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidStackTraceTypeThrows()
     {
         string json = """
@@ -239,6 +236,6 @@ public class ExceptionDetailsTests
                         "stackTrace": "stacktrace"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ExceptionDetails>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ExceptionDetails>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/GetRealmsCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/GetRealmsCommandParametersTests.cs
@@ -3,26 +3,25 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GetRealmsCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         GetRealmsCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("script.getRealms"));
+        Assert.Equal("script.getRealms", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         GetRealmsCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalWindowRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -31,16 +30,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("window"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("window", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalWorkerRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -49,16 +48,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("worker"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("worker", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalDedicatedWorkerRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -67,16 +66,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("dedicated-worker"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("dedicated-worker", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalServiceWorkerRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -85,16 +84,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("service-worker"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("service-worker", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalSharedWorkerRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -103,16 +102,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("shared-worker"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("shared-worker", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalWorkletRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -121,16 +120,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("worklet"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("worklet", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalPaintWorkletRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -139,16 +138,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("paint-worklet"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("paint-worklet", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalAudioWorkletRealmTypeValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -157,16 +156,16 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("audio-worklet"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("audio-worklet", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithOptionalBrowsingContextValue()
     {
         GetRealmsCommandParameters properties = new()
@@ -175,12 +174,12 @@ public class GetRealmsCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("contextId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("contextId", context.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/GetRealmsCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/GetRealmsCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class GetRealmsCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeGetRealmsCommandResult()
     {
         string json = """
@@ -14,11 +13,11 @@ public class GetRealmsCommandResultTests
                       }
                       """;
         GetRealmsCommandResult? result = JsonSerializer.Deserialize<GetRealmsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Realms, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.Realms);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,12 +26,12 @@ public class GetRealmsCommandResultTests
                       }
                       """;
         GetRealmsCommandResult? result = JsonSerializer.Deserialize<GetRealmsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         GetRealmsCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeGetRealmsCommandResultWithWindowRealmInfo()
     {
         string json = """
@@ -48,19 +47,17 @@ public class GetRealmsCommandResultTests
                       }
                       """;
         GetRealmsCommandResult? result = JsonSerializer.Deserialize<GetRealmsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Realms, Has.Count.EqualTo(1));
-        Assert.That(result.Realms[0], Is.TypeOf<WindowRealmInfo>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Realms[0].RealmId, Is.EqualTo("realmId"));
-            Assert.That(result.Realms[0].Origin, Is.EqualTo("myOrigin"));
-            Assert.That(result.Realms[0].Type, Is.EqualTo(RealmType.Window));
-            Assert.That(((WindowRealmInfo)result.Realms[0]).BrowsingContext, Is.EqualTo("contextId"));
-        }
+        Assert.NotNull(result);
+        Assert.Single(result.Realms);
+        Assert.IsType<WindowRealmInfo>(result.Realms[0]);
+
+        Assert.Equal("realmId", result.Realms[0].RealmId);
+        Assert.Equal("myOrigin", result.Realms[0].Origin);
+        Assert.Equal(RealmType.Window, result.Realms[0].Type);
+        Assert.Equal("contextId", ((WindowRealmInfo)result.Realms[0]).BrowsingContext);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeGetRealmsCommandResultWithNonWindowRealmInfo()
     {
         string json = """
@@ -75,14 +72,12 @@ public class GetRealmsCommandResultTests
                       }
                       """;
         GetRealmsCommandResult? result = JsonSerializer.Deserialize<GetRealmsCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Realms, Has.Count.EqualTo(1));
-        Assert.That(result.Realms[0], Is.Not.TypeOf<WindowRealmInfo>());
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Realms[0].RealmId, Is.EqualTo("realmId"));
-            Assert.That(result.Realms[0].Origin, Is.EqualTo("myOrigin"));
-            Assert.That(result.Realms[0].Type, Is.EqualTo(RealmType.Worker));
-        }
+        Assert.NotNull(result);
+        Assert.Single(result.Realms);
+        Assert.IsNotType<WindowRealmInfo>(result.Realms[0]);
+
+        Assert.Equal("realmId", result.Realms[0].RealmId);
+        Assert.Equal("myOrigin", result.Realms[0].Origin);
+        Assert.Equal(RealmType.Worker, result.Realms[0].Type);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/ITypeSafeRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ITypeSafeRemoteValueTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Script;
 using System.Numerics;
 using System.Text.Json;
 
-[TestFixture]
 public class ITypeSafeRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeStringRemoteValue()
     {
         string json = """
@@ -16,16 +15,17 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<StringRemoteValue>());
+        Assert.IsType<StringRemoteValue>(remoteValue);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
-        Assert.That(stringValue, Is.InstanceOf<ValueHoldingRemoteValue<string>>());
-        Assert.That(stringValue.Value, Is.EqualTo("myValue"));
-        Assert.That(stringValue.ValueObject, Is.EqualTo("myValue"));
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
+        Assert.IsType<ValueHoldingRemoteValue<string>>(stringValue, exactMatch: false);
+        Assert.Equal("myValue", stringValue.Value);
+        Assert.Equal("myValue", stringValue.ValueObject);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertStringRemoteValueToLocalValue()
     {
         string json = """
@@ -35,18 +35,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<StringRemoteValue>());
+        Assert.IsType<StringRemoteValue>(remoteValue);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
         LocalValue localValue = stringValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue, exactMatch: false);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("string"));
-        Assert.That(argumentValue.Value, Is.EqualTo("myValue"));
+        Assert.Equal("string", argumentValue.Type);
+        Assert.Equal("myValue", argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeDoubleRemoteValue()
     {
         string json = """
@@ -56,15 +57,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NumberRemoteValue? doubleValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(doubleValue, Is.Not.Null);
-        Assert.That(doubleValue, Is.InstanceOf<ValueHoldingRemoteValue<double>>());
-        Assert.That(doubleValue.Value, Is.EqualTo(3.14));
+        Assert.True(conversionResult);
+        Assert.NotNull(doubleValue);
+        Assert.IsType<ValueHoldingRemoteValue<double>>(doubleValue, exactMatch: false);
+        Assert.Equal(3.14, doubleValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestStringRemoteValueCopySemantics()
     {
         string json = """
@@ -74,15 +76,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<StringRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<StringRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
         StringRemoteValue copy = stringValue with { };
-        Assert.That(copy, Is.EqualTo(stringValue));
+        Assert.Equal(stringValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertDoubleRemoteValueToLocalValue()
     {
         string json = """
@@ -92,18 +95,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NumberRemoteValue? doubleValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(doubleValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(doubleValue);
         LocalValue localValue = doubleValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("number"));
-        Assert.That(argumentValue.Value, Is.EqualTo(3.14));
+        Assert.Equal("number", argumentValue.Type);
+        Assert.Equal(3.14, argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDoubleRemoteValueCopySemantics()
     {
         string json = """
@@ -113,15 +117,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NumberRemoteValue? doubleValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(doubleValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(doubleValue);
         NumberRemoteValue copy = doubleValue with { };
-        Assert.That(copy, Is.EqualTo(doubleValue));
+        Assert.Equal(doubleValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeLongRemoteValue()
     {
         string json = """
@@ -131,14 +136,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NumberRemoteValue? longValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(longValue, Is.Not.Null);
-        Assert.That(longValue.Value, Is.EqualTo(123));
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
+        Assert.Equal(123, longValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertLongRemoteValueToLocalValue()
     {
         string json = """
@@ -148,18 +154,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NumberRemoteValue? longValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(longValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
         LocalValue localValue = longValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("number"));
-        Assert.That(argumentValue.Value, Is.EqualTo(123));
+        Assert.Equal("number", argumentValue.Type);
+        Assert.Equal(123.0, argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestLongRemoteValueCopySemantics()
     {
         string json = """
@@ -169,15 +176,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NumberRemoteValue? longValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(longValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
         NumberRemoteValue copy = longValue with { };
-        Assert.That(copy, Is.EqualTo(longValue));
+        Assert.Equal(longValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeBooleanRemoteValue()
     {
         string json = """
@@ -187,14 +195,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<BooleanRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<BooleanRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out BooleanRemoteValue? booleanValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(booleanValue, Is.Not.Null);
-        Assert.That(booleanValue.Value, Is.True);
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
+        Assert.True(booleanValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertBooleanRemoteValueToLocalValue()
     {
         string json = """
@@ -204,18 +213,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<BooleanRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<BooleanRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out BooleanRemoteValue? booleanValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(booleanValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
         LocalValue localValue = booleanValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("boolean"));
-        Assert.That(argumentValue.Value, Is.EqualTo(true));
+        Assert.Equal("boolean", argumentValue.Type);
+        Assert.Equal(true, argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestBooleanRemoteValueCopySemantics()
     {
         string json = """
@@ -225,15 +235,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<BooleanRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<BooleanRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out BooleanRemoteValue? booleanValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(booleanValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
         BooleanRemoteValue copy = booleanValue with { };
-        Assert.That(copy, Is.EqualTo(booleanValue));
+        Assert.Equal(booleanValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeBigIntRemoteValue()
     {
         string json = """
@@ -243,14 +254,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<BigIntegerRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<BigIntegerRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out BigIntegerRemoteValue? bigIntegerValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(bigIntegerValue, Is.Not.Null);
-        Assert.That(bigIntegerValue.Value, Is.EqualTo(new BigInteger(123)));
+        Assert.True(conversionResult);
+        Assert.NotNull(bigIntegerValue);
+        Assert.Equal(new BigInteger(123), bigIntegerValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertBigIntRemoteValueToLocalValue()
     {
         string json = """
@@ -260,18 +272,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<BigIntegerRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<BigIntegerRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out BigIntegerRemoteValue? bigIntegerValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(bigIntegerValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(bigIntegerValue);
         LocalValue localValue = bigIntegerValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("bigint"));
-        Assert.That(argumentValue.Value, Is.EqualTo(new BigInteger(123)));
+        Assert.Equal("bigint", argumentValue.Type);
+        Assert.Equal(new BigInteger(123), argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestBigIntRemoteValueCopySemantics()
     {
         string json = """
@@ -281,15 +294,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<BigIntegerRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<BigIntegerRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out BigIntegerRemoteValue? bigIntegerValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(bigIntegerValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(bigIntegerValue);
         BigIntegerRemoteValue copy = bigIntegerValue with { };
-        Assert.That(copy, Is.EqualTo(bigIntegerValue));
+        Assert.Equal(bigIntegerValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeDateRemoteValue()
     {
         string json = """
@@ -299,14 +313,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<DateRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<DateRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out DateRemoteValue? dateValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(dateValue, Is.Not.Null);
-        Assert.That(dateValue.Value, Is.EqualTo(DateTime.Parse("2020-07-19T23:47:26.056Z").ToUniversalTime()));
+        Assert.True(conversionResult);
+        Assert.NotNull(dateValue);
+        Assert.Equal(DateTime.Parse("2020-07-19T23:47:26.056Z").ToUniversalTime(), dateValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertDateRemoteValueToLocalValue()
     {
         string json = """
@@ -316,18 +331,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<DateRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<DateRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out DateRemoteValue? dateValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(dateValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(dateValue);
         LocalValue localValue = dateValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("date"));
-        Assert.That(argumentValue.Value, Is.EqualTo(DateTime.Parse("2020-07-19T23:47:26.056Z").ToUniversalTime()));
+        Assert.Equal("date", argumentValue.Type);
+        Assert.Equal(DateTime.Parse("2020-07-19T23:47:26.056Z").ToUniversalTime(), argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDateRemoteValueCopySemantics()
     {
         string json = """
@@ -337,20 +353,21 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.InstanceOf<DateRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<DateRemoteValue>(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out DateRemoteValue? dateValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(dateValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(dateValue);
         DateRemoteValue copy = dateValue with { };
-        Assert.That(copy, Is.EqualTo(dateValue));
+        Assert.Equal(dateValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeRegularExpressionRemoteValue()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern", "gi");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -363,19 +380,19 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out RegExpRemoteValue? regexRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(regexRemoteValue, Is.Not.Null);
-        Assert.That(regexRemoteValue.Value, Is.EqualTo(expectedRegexValue));
+        Assert.True(conversionResult);
+        Assert.NotNull(regexRemoteValue);
+        Assert.Equal(expectedRegexValue, regexRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertRegularExpressionRemoteValueToLocalValue()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern", "gi");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -388,18 +405,18 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out RegExpRemoteValue? regexRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(regexRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(regexRemoteValue);
         LocalValue localValue = regexRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("regexp"));
-        Assert.That(argumentValue.Value, Is.EqualTo(expectedRegexValue));
+        Assert.Equal("regexp", argumentValue.Type);
+        Assert.Equal(expectedRegexValue, argumentValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestRegularExpressionRemoteValueCopySemantics()
     {
         string json = """
@@ -412,15 +429,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out RegExpRemoteValue? regexRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(regexRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(regexRemoteValue);
         RegExpRemoteValue copy = regexRemoteValue with { };
-        Assert.That(copy, Is.EqualTo(regexRemoteValue));
+        Assert.Equal(regexRemoteValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNodeRemoteValue()
     {
         string json = """
@@ -434,18 +451,18 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NodeRemoteValue? nodeRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(nodeRemoteValue, Is.Not.Null);
-        Assert.That(nodeRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(nodeRemoteValue);
+        Assert.NotNull(nodeRemoteValue.Value);
         NodeProperties nodeProperties = nodeRemoteValue.Value;
-        Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-        Assert.That(nodeProperties.NodeValue, Is.EqualTo(string.Empty));
-        Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(string.Empty, nodeProperties.NodeValue);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertNodeRemoteValueToLocalValue()
     {
         string json = """
@@ -460,17 +477,17 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NodeRemoteValue? nodeRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(nodeRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(nodeRemoteValue);
         LocalValue localValue = nodeRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<SharedReference>());
+        Assert.IsType<SharedReference>(localValue);
         SharedReference sharedReference = (SharedReference)localValue;
-        Assert.That(sharedReference.SharedId, Is.EqualTo("mySharedId"));
+        Assert.Equal("mySharedId", sharedReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestNodeRemoteValueCopySemantics()
     {
         string json = """
@@ -484,15 +501,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NodeRemoteValue? nodeRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(nodeRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(nodeRemoteValue);
         NodeRemoteValue copy = nodeRemoteValue with { };
-        Assert.That(copy, Is.EqualTo(nodeRemoteValue));
+        Assert.Equal(nodeRemoteValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeArrayRemoteValue()
     {
         string json = """
@@ -515,29 +532,32 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out CollectionRemoteValue? listRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(listRemoteValue, Is.Not.Null);
-        Assert.That(listRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(listRemoteValue);
+        Assert.NotNull(listRemoteValue.Value);
         RemoteValueList arrayValue = listRemoteValue.Value;
-        Assert.That(arrayValue, Is.Not.Null);
-        Assert.That(arrayValue, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            conversionResult = arrayValue[0].TryConvertTo(out StringRemoteValue? stringValue);
-            Assert.That(conversionResult, Is.True);
-            Assert.That(stringValue!.Value, Is.EqualTo("stringValue"));
-            conversionResult = arrayValue[1].TryConvertTo(out NumberRemoteValue? longValue);
-            Assert.That(conversionResult, Is.True);
-            Assert.That(longValue!.Value, Is.EqualTo(123));
-            conversionResult = arrayValue[2].TryConvertTo(out BooleanRemoteValue? booleanValue);
-            Assert.That(conversionResult, Is.True);
-            Assert.That(booleanValue!.Value, Is.EqualTo(true));
-        }
+        Assert.NotNull(arrayValue);
+        Assert.Equal(3, arrayValue.Count);
+
+        conversionResult = arrayValue[0].TryConvertTo(out StringRemoteValue? stringValue);
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
+        Assert.Equal("stringValue", stringValue.Value);
+
+        conversionResult = arrayValue[1].TryConvertTo(out NumberRemoteValue? longValue);
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
+        Assert.Equal(123, longValue.Value);
+
+        conversionResult = arrayValue[2].TryConvertTo(out BooleanRemoteValue? booleanValue);
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
+        Assert.True(booleanValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertArrayRemoteValueToLocalValue()
     {
         string json = """
@@ -560,20 +580,21 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out CollectionRemoteValue? listRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(listRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(listRemoteValue);
         LocalValue localValue = listRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("array"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<List<LocalValue>>());
+        Assert.Equal("array", argumentValue.Type);
+        Assert.IsType<List<LocalValue>>(argumentValue.Value);
+        Assert.NotNull(argumentValue.Value);
         List<LocalValue> localValueList = (List<LocalValue>)argumentValue.Value;
-        Assert.That(localValueList, Has.Count.EqualTo(3));
+        Assert.Equal(3, localValueList.Count);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeSetRemoteValue()
     {
         string json = """
@@ -596,32 +617,32 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out CollectionRemoteValue? listRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(listRemoteValue, Is.Not.Null);
-        Assert.That(listRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(listRemoteValue);
+        Assert.NotNull(listRemoteValue.Value);
         RemoteValueList arrayValue = listRemoteValue.Value;
-        Assert.That(arrayValue, Is.Not.Null);
-        Assert.That(arrayValue, Has.Count.EqualTo(3));
+        Assert.NotNull(arrayValue);
+        Assert.Equal(3, arrayValue.Count);
 
         conversionResult = arrayValue[0].TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
+        Assert.Equal("stringValue", stringValue.Value);
 
         conversionResult = arrayValue[1].TryConvertTo(out NumberRemoteValue? longValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(longValue, Is.Not.Null);
-        Assert.That(longValue.Value, Is.EqualTo(123));
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
+        Assert.Equal(123, longValue.Value);
 
         conversionResult = arrayValue[2].TryConvertTo(out BooleanRemoteValue? booleanValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(booleanValue, Is.Not.Null);
-        Assert.That(booleanValue.Value, Is.EqualTo(true));
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
+        Assert.True(booleanValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertSetRemoteValueToLocalValue()
     {
         string json = """
@@ -644,20 +665,21 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out CollectionRemoteValue? listRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(listRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(listRemoteValue);
         LocalValue localValue = listRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("set"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<List<LocalValue>>());
+        Assert.Equal("set", argumentValue.Type);
+        Assert.IsType<List<LocalValue>>(argumentValue.Value);
+        Assert.NotNull(argumentValue.Value);
         List<LocalValue> localValueList = (List<LocalValue>)argumentValue.Value;
-        Assert.That(localValueList, Has.Count.EqualTo(3));
+        Assert.Equal(3, localValueList.Count);
     }
 
-    [Test]
+    [Fact]
     public void TestListRemoteValueCopySemantics()
     {
         string json = """
@@ -680,15 +702,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out CollectionRemoteValue? listRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(listRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(listRemoteValue);
         CollectionRemoteValue copy = listRemoteValue with { };
-        Assert.That(copy, Is.EqualTo(listRemoteValue));
+        Assert.Equal(listRemoteValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeMapRemoteValue()
     {
         string json = """
@@ -720,33 +742,33 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
-        Assert.That(mapRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
+        Assert.NotNull(mapRemoteValue.Value);
         RemoteValueDictionary dictionaryValue = mapRemoteValue.Value;
 
         RemoteValue stringPropertyValue = dictionaryValue["stringProperty"];
         conversionResult = stringPropertyValue.TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
+        Assert.Equal("stringValue", stringValue.Value);
 
         RemoteValue longPropertyValue = dictionaryValue["numberProperty"];
         conversionResult = longPropertyValue.TryConvertTo(out NumberRemoteValue? longValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(longValue, Is.Not.Null);
-        Assert.That(longValue.Value, Is.EqualTo(123));
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
+        Assert.Equal(123, longValue.Value);
 
         RemoteValue booleanPropertyValue = dictionaryValue["booleanProperty"];
         conversionResult = booleanPropertyValue.TryConvertTo(out BooleanRemoteValue? booleanValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(booleanValue, Is.Not.Null);
-        Assert.That(booleanValue.Value, Is.EqualTo(true));
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
+        Assert.True(booleanValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeMapRemoteValueWithObjectKeys()
     {
         string json = """
@@ -767,25 +789,25 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
-        Assert.That(mapRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
+        Assert.NotNull(mapRemoteValue.Value);
         RemoteValueDictionary dictionaryValue = mapRemoteValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(1));
+        Assert.Single(dictionaryValue);
         object keyValueObject = dictionaryValue.ElementAt(0).Key;
-        Assert.That(keyValueObject, Is.InstanceOf<ObjectReferenceRemoteValue>());
+        Assert.IsType<ObjectReferenceRemoteValue>(keyValueObject);
         ObjectReferenceRemoteValue key = (ObjectReferenceRemoteValue)keyValueObject;
-        Assert.That(key.Type, Is.EqualTo(RemoteValueType.Symbol));
-        Assert.That(key.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal(RemoteValueType.Symbol, key.Type);
+        Assert.Equal("mySymbol", key.Handle);
         RemoteValue value = dictionaryValue[key];
-        Assert.That(value, Is.InstanceOf<StringRemoteValue>());
+        Assert.IsType<StringRemoteValue>(value);
         StringRemoteValue stringValue = (StringRemoteValue)value;
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.Equal("stringValue", stringValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeMapRemoteValueWithMixedKeys()
     {
         string json = """
@@ -813,31 +835,31 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
-        Assert.That(mapRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
+        Assert.NotNull(mapRemoteValue.Value);
         RemoteValueDictionary dictionaryValue = mapRemoteValue.Value;
 
         RemoteValue stringPropertyValue = dictionaryValue["stringProperty"];
         conversionResult = stringPropertyValue.TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
+        Assert.Equal("stringValue", stringValue.Value);
 
         object keyValueObject = dictionaryValue.ElementAt(1).Key;
-        Assert.That(keyValueObject, Is.InstanceOf<ObjectReferenceRemoteValue>());
+        Assert.IsType<ObjectReferenceRemoteValue>(keyValueObject);
         ObjectReferenceRemoteValue key = (ObjectReferenceRemoteValue)keyValueObject;
-        Assert.That(key.Type, Is.EqualTo(RemoteValueType.Symbol));
-        Assert.That(key.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal(RemoteValueType.Symbol, key.Type);
+        Assert.Equal("mySymbol", key.Handle);
         RemoteValue value = dictionaryValue[key];
-        Assert.That(value, Is.InstanceOf<StringRemoteValue>());
+        Assert.IsType<StringRemoteValue>(value);
         StringRemoteValue symbolStringValue = (StringRemoteValue)value;
-        Assert.That(symbolStringValue.Value, Is.EqualTo("symbolValue"));
+        Assert.Equal("symbolValue", symbolStringValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertMapRemoteValueToLocalValue()
     {
         string json = """
@@ -869,30 +891,31 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         LocalValue localValue = mapRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("map"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
+        Assert.Equal("map", argumentValue.Type);
+        Assert.NotNull(argumentValue.Value);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentValue.Value);
         Dictionary<object, LocalValue> dictionaryValue = (Dictionary<object, LocalValue>)argumentValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(3));
-        Assert.That(dictionaryValue, Contains.Key("stringProperty"));
-        Assert.That(dictionaryValue["stringProperty"], Is.InstanceOf<LocalArgumentValue>());
-        Assert.That(((LocalArgumentValue)dictionaryValue["stringProperty"]).Type, Is.EqualTo("string"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["stringProperty"]).Value, Is.EqualTo("stringValue"));
-        Assert.That(dictionaryValue, Contains.Key("numberProperty"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["numberProperty"]).Type, Is.EqualTo("number"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["numberProperty"]).Value, Is.EqualTo(123));
-        Assert.That(dictionaryValue, Contains.Key("booleanProperty"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["booleanProperty"]).Type, Is.EqualTo("boolean"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["booleanProperty"]).Value, Is.EqualTo(true));
+        Assert.Equal(3, dictionaryValue.Count);
+        Assert.True(dictionaryValue.ContainsKey("stringProperty"));
+        Assert.IsType<LocalArgumentValue>(dictionaryValue["stringProperty"]);
+        Assert.Equal("string", ((LocalArgumentValue)dictionaryValue["stringProperty"]).Type);
+        Assert.Equal("stringValue", ((LocalArgumentValue)dictionaryValue["stringProperty"]).Value);
+        Assert.True(dictionaryValue.ContainsKey("numberProperty"));
+        Assert.Equal("number", ((LocalArgumentValue)dictionaryValue["numberProperty"]).Type);
+        Assert.Equal(123.0, ((LocalArgumentValue)dictionaryValue["numberProperty"]).Value);
+        Assert.True(dictionaryValue.ContainsKey("booleanProperty"));
+        Assert.Equal("boolean", ((LocalArgumentValue)dictionaryValue["booleanProperty"]).Type);
+        Assert.Equal(true, ((LocalArgumentValue)dictionaryValue["booleanProperty"]).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertMapRemoteValueWithObjectKeysToLocalValue()
     {
         string json = """
@@ -913,29 +936,30 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         LocalValue localValue = mapRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("map"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
+        Assert.Equal("map", argumentValue.Type);
+        Assert.NotNull(argumentValue.Value);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentValue.Value);
         Dictionary<object, LocalValue> dictionaryValue = (Dictionary<object, LocalValue>)argumentValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(1));
+        Assert.Single(dictionaryValue);
         object key = dictionaryValue.ElementAt(0).Key;
-        Assert.That(key, Is.InstanceOf<RemoteObjectReference>());
+        Assert.IsType<RemoteObjectReference>(key);
         RemoteObjectReference keyReference = (RemoteObjectReference)key;
-        Assert.That(keyReference.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal("mySymbol", keyReference.Handle);
         LocalValue value = dictionaryValue[key];
-        Assert.That(value, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(value);
         LocalArgumentValue stringValue = (LocalArgumentValue)value;
-        Assert.That(stringValue.Type, Is.EqualTo("string"));
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.Equal("string", stringValue.Type);
+        Assert.Equal("stringValue", stringValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertMapRemoteValueWithMixedKeysToLocalValue()
     {
         string json = """
@@ -963,37 +987,38 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         LocalValue localValue = mapRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("map"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
+        Assert.Equal("map", argumentValue.Type);
+        Assert.NotNull(argumentValue.Value);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentValue.Value);
         Dictionary<object, LocalValue> dictionaryValue = (Dictionary<object, LocalValue>)argumentValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(2));
+        Assert.Equal(2, dictionaryValue.Count);
         object key1 = dictionaryValue.ElementAt(0).Key;
-        Assert.That(key1, Is.InstanceOf<string>());
-        Assert.That((string)key1, Is.EqualTo("stringProperty"));
+        Assert.IsType<string>(key1);
+        Assert.Equal("stringProperty", (string)key1);
         LocalValue value1 = dictionaryValue[key1];
-        Assert.That(value1, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(value1);
         LocalArgumentValue stringValue = (LocalArgumentValue)value1;
-        Assert.That(stringValue.Type, Is.EqualTo("string"));
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.Equal("string", stringValue.Type);
+        Assert.Equal("stringValue", stringValue.Value);
         object key2 = dictionaryValue.ElementAt(1).Key;
-        Assert.That(key2, Is.InstanceOf<RemoteObjectReference>());
+        Assert.IsType<RemoteObjectReference>(key2);
         RemoteObjectReference keyReference = (RemoteObjectReference)key2;
-        Assert.That(keyReference.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal("mySymbol", keyReference.Handle);
         LocalValue value2 = dictionaryValue[key2];
-        Assert.That(value2, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(value2);
         LocalArgumentValue symbolValue = (LocalArgumentValue)value2;
-        Assert.That(symbolValue.Type, Is.EqualTo("string"));
-        Assert.That(symbolValue.Value, Is.EqualTo("symbolValue"));
+        Assert.Equal("string", symbolValue.Type);
+        Assert.Equal("symbolValue", symbolValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeObjectRemoteValue()
     {
         string json = """
@@ -1025,34 +1050,34 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
-        Assert.That(mapRemoteValue.Value, Is.Not.Null);
-        Assert.That(mapRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
+        Assert.NotNull(mapRemoteValue.Value);
+        Assert.NotNull(mapRemoteValue.Value);
         RemoteValueDictionary dictionaryValue = mapRemoteValue.Value;
 
         RemoteValue stringPropertyValue = dictionaryValue["stringProperty"];
         conversionResult = stringPropertyValue.TryConvertTo(out StringRemoteValue? stringValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(stringValue, Is.Not.Null);
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.True(conversionResult);
+        Assert.NotNull(stringValue);
+        Assert.Equal("stringValue", stringValue.Value);
 
         RemoteValue longPropertyValue = dictionaryValue["numberProperty"];
         conversionResult = longPropertyValue.TryConvertTo(out NumberRemoteValue? longValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(longValue, Is.Not.Null);
-        Assert.That(longValue.Value, Is.EqualTo(123));
+        Assert.True(conversionResult);
+        Assert.NotNull(longValue);
+        Assert.Equal(123, longValue.Value);
 
         RemoteValue booleanPropertyValue = dictionaryValue["booleanProperty"];
         conversionResult = booleanPropertyValue.TryConvertTo(out BooleanRemoteValue? booleanValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(booleanValue, Is.Not.Null);
-        Assert.That(booleanValue.Value, Is.EqualTo(true));
+        Assert.True(conversionResult);
+        Assert.NotNull(booleanValue);
+        Assert.True(booleanValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeObjectRemoteValueWithObjectKeys()
     {
         string json = """
@@ -1073,25 +1098,25 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
-        Assert.That(mapRemoteValue.Value, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
+        Assert.NotNull(mapRemoteValue.Value);
         RemoteValueDictionary dictionaryValue = mapRemoteValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(1));
+        Assert.Single(dictionaryValue);
         object keyValueObject = dictionaryValue.ElementAt(0).Key;
-        Assert.That(keyValueObject, Is.InstanceOf<ObjectReferenceRemoteValue>());
+        Assert.IsType<ObjectReferenceRemoteValue>(keyValueObject);
         ObjectReferenceRemoteValue key = (ObjectReferenceRemoteValue)keyValueObject;
-        Assert.That(key.Type, Is.EqualTo(RemoteValueType.Symbol));
-        Assert.That(key.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal(RemoteValueType.Symbol, key.Type);
+        Assert.Equal("mySymbol", key.Handle);
         RemoteValue value = dictionaryValue[key];
-        Assert.That(value, Is.InstanceOf<StringRemoteValue>());
+        Assert.IsType<StringRemoteValue>(value);
         StringRemoteValue stringValue = (StringRemoteValue)value;
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.Equal("stringValue", stringValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertObjectRemoteValueToLocalValue()
     {
         string json = """
@@ -1123,30 +1148,31 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         LocalValue localValue = mapRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("object"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
+        Assert.Equal("object", argumentValue.Type);
+        Assert.NotNull(argumentValue.Value);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentValue.Value);
         Dictionary<object, LocalValue> dictionaryValue = (Dictionary<object, LocalValue>)argumentValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(3));
-        Assert.That(dictionaryValue, Contains.Key("stringProperty"));
-        Assert.That(dictionaryValue["stringProperty"], Is.InstanceOf<LocalArgumentValue>());
-        Assert.That(((LocalArgumentValue)dictionaryValue["stringProperty"]).Type, Is.EqualTo("string"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["stringProperty"]).Value, Is.EqualTo("stringValue"));
-        Assert.That(dictionaryValue, Contains.Key("numberProperty"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["numberProperty"]).Type, Is.EqualTo("number"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["numberProperty"]).Value, Is.EqualTo(123));
-        Assert.That(dictionaryValue, Contains.Key("booleanProperty"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["booleanProperty"]).Type, Is.EqualTo("boolean"));
-        Assert.That(((LocalArgumentValue)dictionaryValue["booleanProperty"]).Value, Is.EqualTo(true));
+        Assert.Equal(3, dictionaryValue.Count);
+        Assert.True(dictionaryValue.ContainsKey("stringProperty"));
+        Assert.IsType<LocalArgumentValue>(dictionaryValue["stringProperty"]);
+        Assert.Equal("string", ((LocalArgumentValue)dictionaryValue["stringProperty"]).Type);
+        Assert.Equal("stringValue", ((LocalArgumentValue)dictionaryValue["stringProperty"]).Value);
+        Assert.True(dictionaryValue.ContainsKey("numberProperty"));
+        Assert.Equal("number", ((LocalArgumentValue)dictionaryValue["numberProperty"]).Type);
+        Assert.Equal(123.0, ((LocalArgumentValue)dictionaryValue["numberProperty"]).Value);
+        Assert.True(dictionaryValue.ContainsKey("booleanProperty"));
+        Assert.Equal("boolean", ((LocalArgumentValue)dictionaryValue["booleanProperty"]).Type);
+        Assert.Equal(true, ((LocalArgumentValue)dictionaryValue["booleanProperty"]).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertObjectRemoteValueWithObjectKeysToLocalValue()
     {
         string json = """
@@ -1167,29 +1193,30 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         LocalValue localValue = mapRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("object"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
+        Assert.Equal("object", argumentValue.Type);
+        Assert.NotNull(argumentValue.Value);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentValue.Value);
         Dictionary<object, LocalValue> dictionaryValue = (Dictionary<object, LocalValue>)argumentValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(1));
+        Assert.Single(dictionaryValue);
         object key = dictionaryValue.ElementAt(0).Key;
-        Assert.That(key, Is.InstanceOf<RemoteObjectReference>());
+        Assert.IsType<RemoteObjectReference>(key);
         RemoteObjectReference keyReference = (RemoteObjectReference)key;
-        Assert.That(keyReference.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal("mySymbol", keyReference.Handle);
         LocalValue value = dictionaryValue[key];
-        Assert.That(value, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(value);
         LocalArgumentValue stringValue = (LocalArgumentValue)value;
-        Assert.That(stringValue.Type, Is.EqualTo("string"));
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.Equal("string", stringValue.Type);
+        Assert.Equal("stringValue", stringValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertObjectRemoteValueWithMixedKeysToLocalValue()
     {
         string json = """
@@ -1217,37 +1244,38 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         LocalValue localValue = mapRemoteValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("object"));
-        Assert.That(argumentValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
+        Assert.Equal("object", argumentValue.Type);
+        Assert.NotNull(argumentValue.Value);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentValue.Value);
         Dictionary<object, LocalValue> dictionaryValue = (Dictionary<object, LocalValue>)argumentValue.Value;
-        Assert.That(dictionaryValue, Has.Count.EqualTo(2));
+        Assert.Equal(2, dictionaryValue.Count);
         object key1 = dictionaryValue.ElementAt(0).Key;
-        Assert.That(key1, Is.InstanceOf<string>());
-        Assert.That((string)key1, Is.EqualTo("stringProperty"));
+        Assert.IsType<string>(key1);
+        Assert.Equal("stringProperty", (string)key1);
         LocalValue value1 = dictionaryValue[key1];
-        Assert.That(value1, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(value1);
         LocalArgumentValue stringValue = (LocalArgumentValue)value1;
-        Assert.That(stringValue.Type, Is.EqualTo("string"));
-        Assert.That(stringValue.Value, Is.EqualTo("stringValue"));
+        Assert.Equal("string", stringValue.Type);
+        Assert.Equal("stringValue", stringValue.Value);
         object key2 = dictionaryValue.ElementAt(1).Key;
-        Assert.That(key2, Is.InstanceOf<RemoteObjectReference>());
+        Assert.IsType<RemoteObjectReference>(key2);
         RemoteObjectReference keyReference = (RemoteObjectReference)key2;
-        Assert.That(keyReference.Handle, Is.EqualTo("mySymbol"));
+        Assert.Equal("mySymbol", keyReference.Handle);
         LocalValue value2 = dictionaryValue[key2];
-        Assert.That(value2, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(value2);
         LocalArgumentValue symbolValue = (LocalArgumentValue)value2;
-        Assert.That(symbolValue.Type, Is.EqualTo("string"));
-        Assert.That(symbolValue.Value, Is.EqualTo("symbolValue"));
+        Assert.Equal("string", symbolValue.Type);
+        Assert.Equal("symbolValue", symbolValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestKeyValuePairRemoteValueCopySemantics()
     {
         string json = """
@@ -1279,15 +1307,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out KeyValuePairCollectionRemoteValue? mapRemoteValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(mapRemoteValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(mapRemoteValue);
         KeyValuePairCollectionRemoteValue copy = mapRemoteValue with { };
-        Assert.That(copy, Is.EqualTo(mapRemoteValue));
+        Assert.Equal(mapRemoteValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWindowProxyRemoteValue()
     {
         string json = """
@@ -1301,16 +1329,16 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out WindowProxyRemoteValue? windowProxyValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(windowProxyValue, Is.Not.Null);
-        Assert.That(windowProxyValue.Value.Context, Is.EqualTo("myContext"));
-        Assert.That(windowProxyValue.Handle, Is.EqualTo("myHandle"));
-        Assert.That(windowProxyValue.InternalId, Is.EqualTo("123"));
+        Assert.True(conversionResult);
+        Assert.NotNull(windowProxyValue);
+        Assert.Equal("myContext", windowProxyValue.Value.Context);
+        Assert.Equal("myHandle", windowProxyValue.Handle);
+        Assert.Equal("123", windowProxyValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertWindowProxyRemoteValueToLocalValue()
     {
         string json = """
@@ -1324,17 +1352,17 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out WindowProxyRemoteValue? windowProxyValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(windowProxyValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(windowProxyValue);
         LocalValue localValue = windowProxyValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<RemoteObjectReference>());
+        Assert.IsType<RemoteObjectReference>(localValue);
         RemoteObjectReference argumentValue = (RemoteObjectReference)localValue;
-        Assert.That(argumentValue.Handle, Is.EqualTo("myHandle"));
+        Assert.Equal("myHandle", argumentValue.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestWindowProxyRemoteValueCopySemantics()
     {
         string json = """
@@ -1348,15 +1376,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out WindowProxyRemoteValue? windowProxyValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(windowProxyValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(windowProxyValue);
         WindowProxyRemoteValue copy = windowProxyValue with { };
-        Assert.That(copy, Is.EqualTo(windowProxyValue));
+        Assert.Equal(windowProxyValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNullRemoteValue()
     {
         string json = """
@@ -1365,13 +1393,13 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NullRemoteValue? nullValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(nullValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(nullValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertNullRemoteValueToLocalValue()
     {
         string json = """
@@ -1380,17 +1408,17 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NullRemoteValue? nullValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(nullValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(nullValue);
         LocalValue localValue = nullValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("null"));
+        Assert.Equal("null", argumentValue.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestNullRemoteValueCopySemantics()
     {
         string json = """
@@ -1399,15 +1427,15 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out NullRemoteValue? nullValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(nullValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(nullValue);
         NullRemoteValue copy = nullValue with { };
-        Assert.That(copy, Is.EqualTo(nullValue));
+        Assert.Equal(nullValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUndefinedRemoteValue()
     {
         string json = """
@@ -1416,13 +1444,13 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out UndefinedRemoteValue? undefinedValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(undefinedValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(undefinedValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertUndefinedRemoteValueToLocalValue()
     {
         string json = """
@@ -1431,17 +1459,17 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out UndefinedRemoteValue? undefinedValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(undefinedValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(undefinedValue);
         LocalValue localValue = undefinedValue.ToLocalValue();
-        Assert.That(localValue, Is.InstanceOf<LocalArgumentValue>());
+        Assert.IsType<LocalArgumentValue>(localValue);
         LocalArgumentValue argumentValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentValue.Type, Is.EqualTo("undefined"));
+        Assert.Equal("undefined", argumentValue.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestUndefinedRemoteValueCopySemantics()
     {
         string json = """
@@ -1450,11 +1478,11 @@ public class ITypeSafeRemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         bool conversionResult = remoteValue.TryConvertTo(out UndefinedRemoteValue? undefinedValue);
-        Assert.That(conversionResult, Is.True);
-        Assert.That(undefinedValue, Is.Not.Null);
+        Assert.True(conversionResult);
+        Assert.NotNull(undefinedValue);
         UndefinedRemoteValue copy = undefinedValue with { };
-        Assert.That(copy, Is.EqualTo(undefinedValue));
+        Assert.Equal(undefinedValue, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/KeyValuePairCollectionRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/KeyValuePairCollectionRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class KeyValuePairCollectionRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeKeyValuePairCollectionRemoteValue()
     {
         string json = """
@@ -21,15 +20,15 @@ public class KeyValuePairCollectionRemoteValueTests
         // that can be deserialized into a KeyValuePairCollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Map));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value, Is.Empty);
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Map, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Empty(result.Value);
+        Assert.Null(result.Handle);
+        Assert.Null(result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeKeyValuePairCollectionRemoteValueWithValueContainingStringKeys()
     {
         string json = """
@@ -49,12 +48,13 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Map));
-        Assert.That(result.Value, Has.Count.EqualTo(1));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Map, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeKeyValuePairCollectionRemoteValueWithValueContainingObjectKeys()
     {
         string json = """
@@ -77,12 +77,13 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Map));
-        Assert.That(result.Value, Has.Count.EqualTo(1));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Map, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeKeyValuePairCollectionRemoteValueWithHandle()
     {
         string json = """
@@ -100,15 +101,15 @@ public class KeyValuePairCollectionRemoteValueTests
         // that can be deserialized into a KeyValuePairCollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Map));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value, Is.Empty);
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Map, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Empty(result.Value);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeKeyValuePairCollectionRemoteValueWithNoValue()
     {
         string json = """
@@ -125,14 +126,14 @@ public class KeyValuePairCollectionRemoteValueTests
         // that can be deserialized into a KeyValuePairCollectionRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Map));
-        Assert.That(result.Value, Is.Null);
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Map, result.Type);
+        Assert.Null(result.Value);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertMapWithStringKeysToLocalValue()
     {
         string json = """
@@ -152,15 +153,15 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("map"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Has.Count.EqualTo(1));
+        Assert.Equal("map", argumentLocalValue.Type);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentLocalValue.Value);
+        Assert.Single((Dictionary<object, LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertMapWithObjectKeysToLocalValue()
     {
         string json = """
@@ -183,15 +184,15 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("map"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Has.Count.EqualTo(1));
+        Assert.Equal("map", argumentLocalValue.Type);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentLocalValue.Value);
+        Assert.Single((Dictionary<object, LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertObjectToLocalValue()
     {
         string json = """
@@ -214,15 +215,15 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("object"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<Dictionary<object, LocalValue>>());
-        Assert.That(argumentLocalValue.Value, Has.Count.EqualTo(1));
+        Assert.Equal("object", argumentLocalValue.Type);
+        Assert.IsType<Dictionary<object, LocalValue>>(argumentLocalValue.Value);
+        Assert.Single((Dictionary<object, LocalValue>)argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -235,13 +236,13 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingKeyValuePairCollectionRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -251,10 +252,10 @@ public class KeyValuePairCollectionRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingCollectionRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -264,10 +265,10 @@ public class KeyValuePairCollectionRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<CollectionRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CollectionRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToLocalValueWithNullValueThrows()
     {
         string json = """
@@ -278,11 +279,11 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToLocalValue(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToLocalValue());
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -294,11 +295,11 @@ public class KeyValuePairCollectionRemoteValueTests
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -309,9 +310,9 @@ public class KeyValuePairCollectionRemoteValueTests
                       """;
 
         KeyValuePairCollectionRemoteValue? result = JsonSerializer.Deserialize<KeyValuePairCollectionRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         KeyValuePairCollectionRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/LocalValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/LocalValueTests.cs
@@ -3,330 +3,379 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class LocalValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeUndefined()
     {
         LocalValue value = LocalValue.Undefined;
-        Assert.That(value, Is.InstanceOf<LocalArgumentValue>());
-        Assert.That(((LocalArgumentValue)value).Value, Is.Null);
+        Assert.IsType<LocalArgumentValue>(value);
+        Assert.Null(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(1));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("undefined"));
-        }
+
+        Assert.Single(parsed);
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("undefined", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeNull()
     {
         LocalValue value = LocalValue.Null;
-        Assert.That(((LocalArgumentValue)value).Value, Is.Null);
+        Assert.Null(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("null"));
-        }
+        Assert.Single(parsed);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("null", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeString()
     {
         LocalValue value = LocalValue.String("hello");
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("hello"));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("string", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.String, parsedValue.Type);
+        Assert.Equal("hello", parsedValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInteger()
     {
         LocalValue value = LocalValue.Number(123);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(parsed["value"]!.Value<long>(), Is.EqualTo(123));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Integer, parsedValue.Type);
+        Assert.Equal(123L, parsedValue.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeLong()
     {
         LocalValue value = LocalValue.Number(123L);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(parsed["value"]!.Value<long>(), Is.EqualTo(123));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Integer, parsedValue.Type);
+        Assert.Equal(123L, parsedValue.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeDecimal()
     {
         LocalValue value = LocalValue.Number(123.23m);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(parsed["value"]!.Value<double>(), Is.EqualTo(123.23));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Float, parsedValue.Type);
+        Assert.Equal(123.23, parsedValue.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeDouble()
     {
         LocalValue value = LocalValue.Number(3.14);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Float));
-            Assert.That(parsed["value"]!.Value<double>(), Is.EqualTo(3.14));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Float, parsedValue.Type);
+        Assert.Equal(3.14, parsedValue.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeNaN()
     {
         LocalValue value = LocalValue.NaN;
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("NaN"));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.String, parsedValue.Type);
+        Assert.Equal("NaN", parsedValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeInfinity()
     {
         LocalValue value = LocalValue.Infinity;
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("Infinity"));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.String, parsedValue.Type);
+        Assert.Equal("Infinity", parsedValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeNegativeInfinity()
     {
         LocalValue value = LocalValue.NegativeInfinity;
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("-Infinity"));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.String, parsedValue.Type);
+        Assert.Equal("-Infinity", parsedValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeNegativeZero()
     {
         LocalValue value = LocalValue.NegativeZero;
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("-0"));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.String, parsedValue.Type);
+        Assert.Equal("-0", parsedValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeZero()
     {
         LocalValue value = LocalValue.Number(0.0);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(parsed["value"]!.Value<double>(), Is.EqualTo(0.0));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("number", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Integer, parsedValue.Type);
+        Assert.Equal(0.0, parsedValue.Value<double>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeBoolean()
     {
         LocalValue value = LocalValue.Boolean(true);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("boolean"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(parsed["value"]!.Value<bool>(), Is.EqualTo(true));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("boolean", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Boolean, parsedValue.Type);
+        Assert.True(parsedValue.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeBigInt()
     {
         LocalValue value = LocalValue.BigInt(123);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("bigint"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("123"));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("bigint", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.String, parsedValue.Type);
+        Assert.Equal("123", parsedValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeDate()
     {
         DateTime actualValue = DateTime.Now;
         string expectedValue = actualValue.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
         LocalValue value = LocalValue.Date(actualValue);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("date"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Date));
-            Assert.That(parsed["value"]!.Value<DateTime>().ToString("yyyy-MM-ddTHH:mm:ss.fffZ"), Is.EqualTo(expectedValue));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("date", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Date, parsedValue.Type);
+        Assert.Equal(expectedValue, parsedValue.Value<DateTime>().ToString("yyyy-MM-ddTHH:mm:ss.fffZ"));
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeRegularExpression()
     {
         LocalValue value = LocalValue.RegExp("pattern.*");
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("regexp"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("regexp", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Object, parsedValue.Type);
+
         JObject? valueObject = parsed["value"] as JObject;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(valueObject!, Has.Count.EqualTo(1));
-            Assert.That(valueObject!, Contains.Key("pattern"));
-            Assert.That(valueObject!["pattern"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["pattern"]!.Value<string>(), Is.EqualTo("pattern.*"));
-        }
+        Assert.NotNull(valueObject);
+        Assert.Single(valueObject);
+        Assert.True(valueObject.ContainsKey("pattern"));
+        JToken? pattern = valueObject["pattern"];
+        Assert.NotNull(pattern);
+        Assert.Equal(JTokenType.String, pattern.Type);
+        Assert.Equal("pattern.*", pattern.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeRegularExpressionWithFlags()
     {
         LocalValue value = LocalValue.RegExp("pattern.*", "gi");
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("regexp"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("regexp", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Object, parsedValue.Type);
+
         JObject? valueObject = parsed["value"] as JObject;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(valueObject!, Has.Count.EqualTo(2));
-            Assert.That(valueObject!, Contains.Key("pattern"));
-            Assert.That(valueObject!["pattern"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["pattern"]!.Value<string>(), Is.EqualTo("pattern.*"));
-            Assert.That(valueObject, Contains.Key("flags"));
-            Assert.That(valueObject["flags"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(valueObject["flags"]!.Value<string>(), Is.EqualTo("gi"));
-        }
+        Assert.NotNull(valueObject);
+        Assert.Equal(2, valueObject.Count);
+        Assert.True(valueObject.ContainsKey("pattern"));
+        JToken? pattern = valueObject["pattern"];
+        Assert.NotNull(pattern);
+        Assert.Equal(JTokenType.String, pattern.Type);
+        Assert.Equal("pattern.*", pattern.Value<string>());
+
+        Assert.True(valueObject.ContainsKey("flags"));
+        JToken? flags = valueObject["flags"];
+        Assert.NotNull(flags);
+        Assert.Equal(JTokenType.String, flags.Type);
+        Assert.Equal("gi", flags.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeArray()
     {
         List<LocalValue> arrayList =
@@ -337,74 +386,89 @@ public class LocalValueTests
             LocalValue.Boolean(true)
         ];
         LocalValue value = LocalValue.Array(arrayList);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("array"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("array", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
+
         JArray? valueObject = parsed["value"] as JArray;
-        Assert.That(valueObject, Is.Not.Null);
-        Assert.That(valueObject, Has.Count.EqualTo(4));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(valueObject![0].Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? itemObject = valueObject![0] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(itemObject, Contains.Key("value"));
-            Assert.That(itemObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(itemObject["value"]!.Value<string>(), Is.EqualTo("hello"));
+        Assert.NotNull(valueObject);
+        Assert.Equal(4, valueObject.Count);
 
-            Assert.That(valueObject[1].Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.Equal(JTokenType.Object, valueObject[0].Type);
+
+        JObject? itemObject = valueObject[0] as JObject;
+        Assert.NotNull(itemObject);
+        Assert.Equal(2, itemObject.Count);
+
+        Assert.True(itemObject.ContainsKey("type"));
+        JToken? itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("string", itemType.Value<string>());
+
+        Assert.True(itemObject.ContainsKey("value"));
+        JToken? itemValue = itemObject["value"];
+        Assert.NotNull(itemValue);
+        Assert.Equal(JTokenType.String, itemValue.Type);
+        Assert.Equal("hello", itemValue.Value<string>());
+
+        Assert.Equal(JTokenType.Object, valueObject[1].Type);
+
         itemObject = valueObject[1] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(itemObject, Contains.Key("value"));
-            Assert.That(itemObject["value"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(itemObject["value"]!.Value<long>(), Is.EqualTo(123));
+        Assert.NotNull(itemObject);
+        Assert.Equal(2, itemObject.Count);
 
-            Assert.That(valueObject[2].Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.True(itemObject.ContainsKey("type"));
+        itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("number", itemType.Value<string>());
+
+        Assert.True(itemObject.ContainsKey("value"));
+        itemValue = itemObject["value"];
+        Assert.NotNull(itemValue);
+        Assert.Equal(JTokenType.Integer, itemValue.Type);
+        Assert.Equal(123L, itemValue.Value<long>());
+
+        Assert.Equal(JTokenType.Object, valueObject[2].Type);
+
         itemObject = valueObject[2] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("null"));
+        Assert.NotNull(itemObject);
+        Assert.Single(itemObject);
 
-            Assert.That(valueObject[3].Type, Is.EqualTo(JTokenType.Object));
-        }
+        Assert.True(itemObject.ContainsKey("type"));
+        itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("null", itemType.Value<string>());
+
+        Assert.Equal(JTokenType.Object, valueObject[3].Type);
+
         itemObject = valueObject[3] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("boolean"));
-            Assert.That(itemObject, Contains.Key("value"));
-            Assert.That(itemObject["value"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(itemObject["value"]!.Value<bool>(), Is.EqualTo(true));
-        }
+        Assert.NotNull(itemObject);
+        Assert.Equal(2, itemObject.Count);
+
+        Assert.True(itemObject.ContainsKey("type"));
+        itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("boolean", itemType.Value<string>());
+
+        Assert.True(itemObject.ContainsKey("value"));
+        itemValue = itemObject["value"];
+        Assert.NotNull(itemValue);
+        Assert.Equal(JTokenType.Boolean, itemValue.Type);
+        Assert.True(itemValue.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeSet()
     {
         List<LocalValue> arrayList =
@@ -415,72 +479,85 @@ public class LocalValueTests
             LocalValue.Boolean(true)
         ];
         LocalValue value = LocalValue.Set(arrayList);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("set"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("set", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
+
         JArray? valueObject = parsed["value"] as JArray;
-        Assert.That(valueObject, Is.Not.Null);
-        Assert.That(valueObject, Has.Count.EqualTo(4));
+        Assert.NotNull(valueObject);
+        Assert.Equal(4, valueObject.Count);
 
-        Assert.That(valueObject![0].Type, Is.EqualTo(JTokenType.Object));
+        Assert.Equal(JTokenType.Object, valueObject[0].Type);
         JObject? itemObject = valueObject[0] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(itemObject, Contains.Key("value"));
-            Assert.That(itemObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(itemObject["value"]!.Value<string>(), Is.EqualTo("hello"));
-        }
+        Assert.NotNull(itemObject);
+        Assert.Equal(2, itemObject.Count);
 
-        Assert.That(valueObject[1].Type, Is.EqualTo(JTokenType.Object));
+        Assert.True(itemObject.ContainsKey("type"));
+        JToken? itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("string", itemType.Value<string>());
+
+        Assert.True(itemObject.ContainsKey("value"));
+        JToken? itemValue = itemObject["value"];
+        Assert.NotNull(itemValue);
+        Assert.Equal(JTokenType.String, itemValue.Type);
+        Assert.Equal("hello", itemValue.Value<string>());
+
+        Assert.Equal(JTokenType.Object, valueObject[1].Type);
         itemObject = valueObject[1] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("number"));
-            Assert.That(itemObject, Contains.Key("value"));
-            Assert.That(itemObject["value"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(itemObject["value"]!.Value<long>(), Is.EqualTo(123));
-        }
+        Assert.NotNull(itemObject);
+        Assert.Equal(2, itemObject.Count);
 
-        Assert.That(valueObject[2].Type, Is.EqualTo(JTokenType.Object));
+        Assert.True(itemObject.ContainsKey("type"));
+        itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("number", itemType.Value<string>());
+
+        Assert.True(itemObject.ContainsKey("value"));
+        itemValue = itemObject["value"];
+        Assert.NotNull(itemValue);
+        Assert.Equal(JTokenType.Integer, itemValue.Type);
+        Assert.Equal(123L, itemValue.Value<long>());
+
+        Assert.Equal(JTokenType.Object, valueObject[2].Type);
         itemObject = valueObject[2] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("null"));
-        }
+        Assert.NotNull(itemObject);
+        Assert.Single(itemObject);
 
-        Assert.That(valueObject[3].Type, Is.EqualTo(JTokenType.Object));
+        Assert.True(itemObject.ContainsKey("type"));
+        itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("null", itemType.Value<string>());
+
+        Assert.Equal(JTokenType.Object, valueObject[3].Type);
         itemObject = valueObject[3] as JObject;
-        Assert.That(itemObject, Is.Not.Null);
-        Assert.That(itemObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(itemObject!, Contains.Key("type"));
-            Assert.That(itemObject!["type"]!.Value<string>(), Is.EqualTo("boolean"));
-            Assert.That(itemObject, Contains.Key("value"));
-            Assert.That(itemObject["value"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(itemObject["value"]!.Value<bool>(), Is.EqualTo(true));
-        }
+        Assert.NotNull(itemObject);
+        Assert.Equal(2, itemObject.Count);
+
+        Assert.True(itemObject.ContainsKey("type"));
+        itemType = itemObject["type"];
+        Assert.NotNull(itemType);
+        Assert.Equal("boolean", itemType.Value<string>());
+
+        Assert.True(itemObject.ContainsKey("value"));
+        itemValue = itemObject["value"];
+        Assert.NotNull(itemValue);
+        Assert.Equal(JTokenType.Boolean, itemValue.Type);
+        Assert.True(itemValue.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeMap()
     {
         Dictionary<string, LocalValue> dictionary = new()
@@ -492,43 +569,45 @@ public class LocalValueTests
         };
 
         LocalValue value = LocalValue.Map(dictionary);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("map"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("map", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
 
         // N.B., We are not validating the content of each object in the map
         // values; it should be sufficient that the serialization of individual
         // values works.
         JArray? valueArray = parsed["value"] as JArray;
-        Assert.That(valueArray, Is.Not.Null);
-        Assert.That(valueArray, Has.Count.EqualTo(dictionary.Count));
+        Assert.NotNull(valueArray);
+        Assert.Equal(dictionary.Count, valueArray.Count);
         List<string> foundStrings = [];
         for (int i = 0; i < dictionary.Count; i++)
         {
-            Assert.That(valueArray![i].Type, Is.EqualTo(JTokenType.Array));
+            Assert.Equal(JTokenType.Array, valueArray[i].Type);
             JArray? itemArray = valueArray[i] as JArray;
-            Assert.That(itemArray, Is.Not.Null);
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(itemArray, Has.Count.EqualTo(2));
-                Assert.That(itemArray![0].Type, Is.EqualTo(JTokenType.String));
-            }
-            foundStrings.Add(itemArray![0].Value<string>() ?? "");
-            Assert.That(itemArray[1].Type, Is.EqualTo(JTokenType.Object));
+            Assert.NotNull(itemArray);
+
+            Assert.Equal(2, itemArray.Count);
+            Assert.Equal(JTokenType.String, itemArray[0].Type);
+
+            foundStrings.Add(itemArray[0].Value<string>() ?? "");
+            Assert.Equal(JTokenType.Object, itemArray[1].Type);
         }
 
-        Assert.That(foundStrings, Is.EquivalentTo(dictionary.Keys));
+        Assert.Equivalent(dictionary.Keys, foundStrings);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeObject()
     {
         Dictionary<string, LocalValue> dictionary = new()
@@ -540,43 +619,45 @@ public class LocalValueTests
         };
 
         LocalValue value = LocalValue.Object(dictionary);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("object"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("object", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
 
         // N.B., We are not validating the content of each object in the map
         // values; it should be sufficient that the serialization of individual
         // values works.
         JArray? valueArray = parsed["value"] as JArray;
-        Assert.That(valueArray, Is.Not.Null);
-        Assert.That(valueArray, Has.Count.EqualTo(dictionary.Count));
+        Assert.NotNull(valueArray);
+        Assert.Equal(dictionary.Count, valueArray.Count);
         List<string> foundStrings = [];
         for (int i = 0; i < dictionary.Count; i++)
         {
-            Assert.That(valueArray![i].Type, Is.EqualTo(JTokenType.Array));
+            Assert.Equal(JTokenType.Array, valueArray[i].Type);
             JArray? itemArray = valueArray[i] as JArray;
-            Assert.That(itemArray, Is.Not.Null);
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(itemArray!, Has.Count.EqualTo(2));
-                Assert.That(itemArray![0].Type, Is.EqualTo(JTokenType.String));
-            }
-            foundStrings.Add(itemArray![0].Value<string>() ?? "");
-            Assert.That(itemArray[1].Type, Is.EqualTo(JTokenType.Object));
+            Assert.NotNull(itemArray);
+
+            Assert.Equal(2, itemArray.Count);
+            Assert.Equal(JTokenType.String, itemArray[0].Type);
+
+            foundStrings.Add(itemArray[0].Value<string>() ?? "");
+            Assert.Equal(JTokenType.Object, itemArray[1].Type);
         }
 
-        Assert.That(foundStrings, Is.EquivalentTo(dictionary.Keys));
+        Assert.Equivalent(dictionary.Keys, foundStrings);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeMapWithLocalValueAsKeys()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -590,39 +671,40 @@ public class LocalValueTests
         };
 
         LocalValue value = LocalValue.Map(dictionary);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("map"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("map", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
 
         // N.B., We are not validating the content of each object in the map
         // values; it should be sufficient that the serialization of individual
         // values works.
         JArray? valueArray = parsed["value"] as JArray;
-        Assert.That(valueArray, Is.Not.Null);
-        Assert.That(valueArray, Has.Count.EqualTo(dictionary.Count));
+        Assert.NotNull(valueArray);
+        Assert.Equal(dictionary.Count, valueArray.Count);
         for (int i = 0; i < dictionary.Count; i++)
         {
-            Assert.That(valueArray![i].Type, Is.EqualTo(JTokenType.Array));
+            Assert.Equal(JTokenType.Array, valueArray[i].Type);
             JArray? itemArray = valueArray[i] as JArray;
-            Assert.That(itemArray, Is.Not.Null);
-            Assert.That(itemArray, Has.Count.EqualTo(2));
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(itemArray![0].Type, Is.EqualTo(JTokenType.Object));
-                Assert.That(itemArray[1].Type, Is.EqualTo(JTokenType.Object));
-            }
+            Assert.NotNull(itemArray);
+            Assert.Equal(2, itemArray.Count);
+
+            Assert.Equal(JTokenType.Object, itemArray[0].Type);
+            Assert.Equal(JTokenType.Object, itemArray[1].Type);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeObjectWithLocalValueAsKeys()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -636,39 +718,40 @@ public class LocalValueTests
         };
 
         LocalValue value = LocalValue.Object(dictionary);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("object"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("object", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
 
         // N.B., We are not validating the content of each object in the map
         // values; it should be sufficient that the serialization of individual
         // values works.
         JArray? valueArray = parsed["value"] as JArray;
-        Assert.That(valueArray, Is.Not.Null);
-        Assert.That(valueArray, Has.Count.EqualTo(dictionary.Count));
+        Assert.NotNull(valueArray);
+        Assert.Equal(dictionary.Count, valueArray.Count);
         for (int i = 0; i < dictionary.Count; i++)
         {
-            Assert.That(valueArray![i].Type, Is.EqualTo(JTokenType.Array));
+            Assert.Equal(JTokenType.Array, valueArray[i].Type);
             JArray? itemArray = valueArray[i] as JArray;
-            Assert.That(itemArray, Is.Not.Null);
-            Assert.That(itemArray, Has.Count.EqualTo(2));
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(itemArray![0].Type, Is.EqualTo(JTokenType.Object));
-                Assert.That(itemArray[1].Type, Is.EqualTo(JTokenType.Object));
-            }
+            Assert.NotNull(itemArray);
+            Assert.Equal(2, itemArray.Count);
+
+            Assert.Equal(JTokenType.Object, itemArray[0].Type);
+            Assert.Equal(JTokenType.Object, itemArray[1].Type);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeMapWithMixedValuesAsKeys()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -682,39 +765,40 @@ public class LocalValueTests
         };
 
         LocalValue value = LocalValue.Map(dictionary);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("map"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("map", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
 
         // N.B., We are not validating the content of each object in the map
         // values; it should be sufficient that the serialization of individual
         // values works.
         JArray? valueArray = parsed["value"] as JArray;
-        Assert.That(valueArray, Is.Not.Null);
-        Assert.That(valueArray, Has.Count.EqualTo(dictionary.Count));
+        Assert.NotNull(valueArray);
+        Assert.Equal(dictionary.Count, valueArray.Count);
         for (int i = 0; i < dictionary.Count; i++)
         {
-            Assert.That(valueArray![i].Type, Is.EqualTo(JTokenType.Array));
+            Assert.Equal(JTokenType.Array, valueArray[i].Type);
             JArray? itemArray = valueArray[i] as JArray;
-            Assert.That(itemArray, Is.Not.Null);
-            Assert.That(itemArray, Has.Count.EqualTo(2));
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(itemArray![0].Type, Is.EqualTo(JTokenType.Object).Or.EqualTo(JTokenType.String));
-                Assert.That(itemArray[1].Type, Is.EqualTo(JTokenType.Object));
-            }
+            Assert.NotNull(itemArray);
+            Assert.Equal(2, itemArray.Count);
+
+            Assert.True(itemArray[0].Type == JTokenType.Object || itemArray[0].Type == JTokenType.String);
+            Assert.Equal(JTokenType.Object, itemArray[1].Type);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestCreatingMapWithInvalidKeyTypeThrows()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -724,10 +808,10 @@ public class LocalValueTests
             { 1, LocalValue.String("hello") },
         };
 
-        Assert.That(() => LocalValue.Map(dictionary), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.ThrowsAny<WebDriverBiDiException>(() => LocalValue.Map(dictionary));
     }
 
-    [Test]
+    [Fact]
     public void TestSerializingMapWithInvalidKeyTypeThrows()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -735,11 +819,11 @@ public class LocalValueTests
         Dictionary<object, LocalValue> dictionary = [];
         LocalValue value = LocalValue.Map(dictionary);
         dictionary[1] = LocalValue.String("hello");
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
-        Assert.That(() => JsonSerializer.Serialize(value), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(((LocalArgumentValue)value).Value);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => JsonSerializer.Serialize(value));
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeObjectWithMixedValuesAsKeys()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -753,39 +837,40 @@ public class LocalValueTests
         };
 
         LocalValue value = LocalValue.Object(dictionary);
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
+        Assert.NotNull(((LocalArgumentValue)value).Value);
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        Assert.That(parsed, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("object"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal("object", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? parsedValue = parsed["value"];
+        Assert.NotNull(parsedValue);
+        Assert.Equal(JTokenType.Array, parsedValue.Type);
 
         // N.B., We are not validating the content of each object in the map
         // values; it should be sufficient that the serialization of individual
         // values works.
         JArray? valueArray = parsed["value"] as JArray;
-        Assert.That(valueArray, Is.Not.Null);
-        Assert.That(valueArray, Has.Count.EqualTo(dictionary.Count));
+        Assert.NotNull(valueArray);
+        Assert.Equal(dictionary.Count, valueArray.Count);
         for (int i = 0; i < dictionary.Count; i++)
         {
-            Assert.That(valueArray![i].Type, Is.EqualTo(JTokenType.Array));
+            Assert.Equal(JTokenType.Array, valueArray[i].Type);
             JArray? itemArray = valueArray[i] as JArray;
-            Assert.That(itemArray, Is.Not.Null);
-            Assert.That(itemArray, Has.Count.EqualTo(2));
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(itemArray![0].Type, Is.EqualTo(JTokenType.Object).Or.EqualTo(JTokenType.String));
-                Assert.That(itemArray[1].Type, Is.EqualTo(JTokenType.Object));
-            }
+            Assert.NotNull(itemArray);
+            Assert.Equal(2, itemArray.Count);
+
+            Assert.True(itemArray[0].Type == JTokenType.Object || itemArray[0].Type == JTokenType.String);
+            Assert.Equal(JTokenType.Object, itemArray[1].Type);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestCreatingObjectWithInvalidKeyTypeThrows()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -795,10 +880,10 @@ public class LocalValueTests
             { 1, LocalValue.String("hello") },
         };
 
-        Assert.That(() => LocalValue.Object(dictionary), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.ThrowsAny<WebDriverBiDiException>(() => LocalValue.Object(dictionary));
     }
 
-    [Test]
+    [Fact]
     public void TestSerializingObjectWithInvalidKeyTypeThrows()
     {
         // N.B., this is an edge case, and we are doing no further validation
@@ -806,16 +891,16 @@ public class LocalValueTests
         Dictionary<object, LocalValue> dictionary = [];
         LocalValue value = LocalValue.Object(dictionary);
         dictionary[1] = LocalValue.String("hello");
-        Assert.That(((LocalArgumentValue)value).Value, Is.Not.Null);
-        Assert.That(() => JsonSerializer.Serialize(value), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(((LocalArgumentValue)value).Value);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => JsonSerializer.Serialize(value));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         LocalValue value = LocalValue.Undefined;
-        Assert.That(((LocalArgumentValue)value).Value, Is.Null);
+        Assert.Null(((LocalArgumentValue)value).Value);
         LocalValue copy = value with { };
-        Assert.That(copy, Is.EqualTo(value));
+        Assert.Equal(value, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/MessageEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/MessageEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class MessageEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -21,17 +20,15 @@ public class MessageEventArgsTests
                       }
                       """;
         MessageEventArgs? eventArgs = JsonSerializer.Deserialize<MessageEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.ChannelId, Is.EqualTo("myChannel"));
-            Assert.That(eventArgs.Data.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(eventArgs.Data.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myChannelValue"));
-            Assert.That(eventArgs.Source.RealmId, Is.EqualTo("myRealm"));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myChannel", eventArgs.ChannelId);
+        Assert.Equal(RemoteValueType.String, eventArgs.Data.Type);
+        Assert.Equal("myChannelValue", eventArgs.Data.ConvertTo<StringRemoteValue>().Value);
+        Assert.Equal("myRealm", eventArgs.Source.RealmId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -47,12 +44,12 @@ public class MessageEventArgsTests
                       }
                       """;
         MessageEventArgs? eventArgs = JsonSerializer.Deserialize<MessageEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         MessageEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingChannelValueThrows()
     {
         string json = """
@@ -66,10 +63,10 @@ public class MessageEventArgsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MessageEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<MessageEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidChannelValueThrows()
     {
         string json = """
@@ -84,10 +81,10 @@ public class MessageEventArgsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MessageEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<MessageEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingDataValueThrows()
     {
         string json = """
@@ -98,10 +95,10 @@ public class MessageEventArgsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MessageEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<MessageEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidDataValueThrows()
     {
         string json = """
@@ -113,10 +110,10 @@ public class MessageEventArgsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MessageEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<MessageEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingSourceValueThrows()
     {
         string json = """
@@ -128,10 +125,10 @@ public class MessageEventArgsTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MessageEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<MessageEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidSourceValueThrows()
     {
         string json = """
@@ -144,6 +141,6 @@ public class MessageEventArgsTests
                         "source": ""
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<MessageEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<MessageEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/NodePropertiesTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/NodePropertiesTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NodePropertiesTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -15,22 +14,20 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.Null(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -40,16 +37,14 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
+        Assert.NotNull(nodeProperties);
         NodeProperties copy = nodeProperties with { };
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(copy, Is.EqualTo(nodeProperties));
-            Assert.That(copy, Is.Not.SameAs(nodeProperties));
-        }
+
+        Assert.Equal(nodeProperties, copy);
+        Assert.NotSame(nodeProperties, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingNodeTypeThrows()
     {
         string json = """
@@ -57,10 +52,10 @@ public class NodePropertiesTests
                         "childNodeCount": 0
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidNodeTypeThrows()
     {
         string json = """
@@ -69,10 +64,10 @@ public class NodePropertiesTests
                         "childNodeCount": 0
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingChildNodeCountThrows()
     {
         string json = """
@@ -80,10 +75,10 @@ public class NodePropertiesTests
                         "nodeType": 1
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidChildNodeCountTypeThrows()
     {
         string json = """
@@ -92,10 +87,10 @@ public class NodePropertiesTests
                         "childNodeCount": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalNodeValue()
     {
         string json = """
@@ -106,22 +101,20 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.EqualTo("myNodeValue"));
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Equal("myNodeValue", nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.Null(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidNodeValueTypeThrows()
     {
         string json = """
@@ -131,10 +124,10 @@ public class NodePropertiesTests
                         "nodeValue": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalLocalName()
     {
         string json = """
@@ -145,22 +138,20 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.EqualTo("myLocalName"));
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Equal("myLocalName", nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.Null(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidLocalNameTypeThrows()
     {
         string json = """
@@ -170,10 +161,10 @@ public class NodePropertiesTests
                         "localName": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalNamespaceUri()
     {
         string json = """
@@ -184,22 +175,20 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.EqualTo("myNamespace"));
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Equal("myNamespace", nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.Null(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidNamespaceUriTypeThrows()
     {
         string json = """
@@ -209,10 +198,10 @@ public class NodePropertiesTests
                         "namespaceURI": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalAttributes()
     {
         string json = """
@@ -225,25 +214,23 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Not.Null);
-            Assert.That(nodeProperties.Attributes, Has.Count.EqualTo(1));
-            Assert.That(nodeProperties.Attributes, Contains.Key("attributeName"));
-            Assert.That(nodeProperties.Attributes!["attributeName"], Is.EqualTo("attributeValue"));
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.NotNull(nodeProperties.Attributes);
+        Assert.Single(nodeProperties.Attributes);
+        Assert.True(nodeProperties.Attributes.ContainsKey("attributeName"));
+        Assert.Equal("attributeValue", nodeProperties.Attributes["attributeName"]);
+        Assert.Null(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestAttributesPropertyCachesValue()
     {
         string json = """
@@ -256,20 +243,17 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
+        Assert.NotNull(nodeProperties);
 
         // Access Attributes property twice to verify caching behavior
         NodeAttributes? firstAccess = nodeProperties.Attributes;
         NodeAttributes? secondAccess = nodeProperties.Attributes;
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(firstAccess, Is.Not.Null);
-            Assert.That(secondAccess, Is.SameAs(firstAccess));
-        }
+        Assert.NotNull(firstAccess);
+        Assert.Same(firstAccess, secondAccess);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidAttributesTypeThrows()
     {
         string json = """
@@ -281,10 +265,10 @@ public class NodePropertiesTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidAttributeNameTypeThrows()
     {
         string json = """
@@ -296,10 +280,10 @@ public class NodePropertiesTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidAttributeValueTypeThrows()
     {
         string json = """
@@ -311,10 +295,10 @@ public class NodePropertiesTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalChildren()
     {
         string json = """
@@ -334,23 +318,21 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Not.Null);
-            Assert.That(nodeProperties.Children, Has.Count.EqualTo(1));
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.NotNull(nodeProperties.Children);
+        Assert.Single(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalEmptyChildren()
     {
         string json = """
@@ -361,23 +343,21 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Not.Null);
-            Assert.That(nodeProperties.Children!, Is.Empty);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.NotNull(nodeProperties.Children);
+        Assert.Empty(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidChildrenTypeThrows()
     {
         string json = """
@@ -387,10 +367,10 @@ public class NodePropertiesTests
                         "children": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidChildrenElementTypeThrows()
     {
         string json = """
@@ -400,10 +380,10 @@ public class NodePropertiesTests
                         "children": [ "invalid" ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalModeValue()
     {
         string json = """
@@ -414,22 +394,20 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.Mode, Is.EqualTo(ShadowRootMode.Open));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Equal(ShadowRootMode.Open, nodeProperties.Mode);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.Null(nodeProperties.Children);
+        Assert.Null(nodeProperties.ShadowRoot);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidModeValueTypeThrows()
     {
         string json = """
@@ -439,10 +417,10 @@ public class NodePropertiesTests
                         "mode": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidModeValueThrows()
     {
         string json = """
@@ -452,10 +430,10 @@ public class NodePropertiesTests
                         "mode": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalShadowRoot()
     {
         string json = """
@@ -473,22 +451,20 @@ public class NodePropertiesTests
                       }
                       """;
         NodeProperties? nodeProperties = JsonSerializer.Deserialize<NodeProperties>(json);
-        Assert.That(nodeProperties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-            Assert.That(nodeProperties.ChildNodeCount, Is.EqualTo(0));
-            Assert.That(nodeProperties.NodeValue, Is.Null);
-            Assert.That(nodeProperties.LocalName, Is.Null);
-            Assert.That(nodeProperties.NamespaceUri, Is.Null);
-            Assert.That(nodeProperties.Attributes, Is.Null);
-            Assert.That(nodeProperties.Children, Is.Null);
-            Assert.That(nodeProperties.ShadowRoot, Is.Not.Null);
-            Assert.That(nodeProperties.Mode, Is.Null);
-        }
+        Assert.NotNull(nodeProperties);
+
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
+        Assert.Null(nodeProperties.NodeValue);
+        Assert.Null(nodeProperties.LocalName);
+        Assert.Null(nodeProperties.NamespaceUri);
+        Assert.Null(nodeProperties.Attributes);
+        Assert.Null(nodeProperties.Children);
+        Assert.NotNull(nodeProperties.ShadowRoot);
+        Assert.Null(nodeProperties.Mode);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidShadowRootTypeThrows()
     {
         string json = """
@@ -498,6 +474,6 @@ public class NodePropertiesTests
                         "shadowRoot": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NodeProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeProperties>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/NodeRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/NodeRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NodeRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeNodeRemoteValue()
     {
         string json = """
@@ -20,17 +19,17 @@ public class NodeRemoteValueTests
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Node));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value.NodeType, Is.EqualTo(1));
-        Assert.That(result.Value.ChildNodeCount, Is.Zero);
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.Null);
-        Assert.That(result.SharedId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Node, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Equal(1u, result.Value.NodeType);
+        Assert.Equal(0u, result.Value.ChildNodeCount);
+        Assert.Null(result.Handle);
+        Assert.Null(result.InternalId);
+        Assert.Null(result.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNodeRemoteValueWithValue()
     {
         string json = """
@@ -45,17 +44,17 @@ public class NodeRemoteValueTests
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Node));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value.NodeType, Is.EqualTo(1));
-        Assert.That(result.Value.ChildNodeCount, Is.Zero);
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.Null);
-        Assert.That(result.SharedId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Node, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Equal(1u, result.Value.NodeType);
+        Assert.Equal(0u, result.Value.ChildNodeCount);
+        Assert.Null(result.Handle);
+        Assert.Null(result.InternalId);
+        Assert.Null(result.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNodeRemoteValueWithHandle()
     {
         string json = """
@@ -76,17 +75,17 @@ public class NodeRemoteValueTests
         // that can be deserialized into a NodeRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Node));
-        Assert.That(result.Value, Is.Not.Null);
-        Assert.That(result.Value.NodeType, Is.EqualTo(1));
-        Assert.That(result.Value.ChildNodeCount, Is.Zero);
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
-        Assert.That(result.SharedId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Node, result.Type);
+        Assert.NotNull(result.Value);
+        Assert.Equal(1u, result.Value.NodeType);
+        Assert.Equal(0u, result.Value.ChildNodeCount);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
+        Assert.Null(result.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNodeRemoteValueWithSharedId()
     {
         string json = """
@@ -104,15 +103,15 @@ public class NodeRemoteValueTests
         // that can be deserialized into a NodeRemoteValue is tested in
         // RemoteValueTests. Likewise, validation of collection members is also tested
         // there.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Node));
-        Assert.That(result.Value, Is.Null);
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
-        Assert.That(result.SharedId, Is.EqualTo("mySharedId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Node, result.Type);
+        Assert.Null(result.Value);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
+        Assert.Equal("mySharedId", result.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetNodeProperties()
     {
         string json = """
@@ -127,14 +126,14 @@ public class NodeRemoteValueTests
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Node));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Node, result.Type);
         NodeProperties nodeProperties = result.GetNodeProperties();
-        Assert.That(nodeProperties.NodeType, Is.EqualTo(1));
-        Assert.That(nodeProperties.ChildNodeCount, Is.Zero);
+        Assert.Equal(1u, nodeProperties.NodeType);
+        Assert.Equal(0u, nodeProperties.ChildNodeCount);
     }
 
-    [Test]
+    [Fact]
     public void TestGettingNodePropertiesWithNullValueThrows()
     {
         string json = """
@@ -144,11 +143,11 @@ public class NodeRemoteValueTests
                       """;
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.GetNodeProperties(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.GetNodeProperties());
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -164,14 +163,14 @@ public class NodeRemoteValueTests
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         SharedReference sharedReference = (SharedReference)localValue;
-        Assert.That(sharedReference.SharedId, Is.EqualTo("mySharedId"));
-        Assert.That(sharedReference.Handle, Is.Null);
+        Assert.Equal("mySharedId", sharedReference.SharedId);
+        Assert.Null(sharedReference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -184,14 +183,14 @@ public class NodeRemoteValueTests
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Value, Is.Null);
+        Assert.NotNull(result);
+        Assert.Null(result.Value);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNodeRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -201,10 +200,10 @@ public class NodeRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<NodeRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNodeRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -217,10 +216,10 @@ public class NodeRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<NodeRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NodeRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidHandleTypeThrows()
     {
         string json = """
@@ -235,10 +234,10 @@ public class NodeRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidInternalIdTypeThrows()
     {
         string json = """
@@ -253,10 +252,10 @@ public class NodeRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToLocalValueWithoutSharedIdThrows()
     {
         string json = """
@@ -265,18 +264,17 @@ public class NodeRemoteValueTests
                         "value": {
                           "nodeType": 1,
                           "childNodeCount": 0
-
                         }
                       }
                       """;
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToLocalValue(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToLocalValue());
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -285,18 +283,17 @@ public class NodeRemoteValueTests
                         "value": {
                           "nodeType": 1,
                           "childNodeCount": 0
-
                         }
                       }
                       """;
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -310,9 +307,9 @@ public class NodeRemoteValueTests
                       """;
 
         NodeRemoteValue? result = JsonSerializer.Deserialize<NodeRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         NodeRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/NullRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/NullRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NullRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeNullRemoteValue()
     {
         string json = """
@@ -16,11 +15,11 @@ public class NullRemoteValueTests
 
         NullRemoteValue? result = JsonSerializer.Deserialize<NullRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Null));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Null, result.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -31,14 +30,14 @@ public class NullRemoteValueTests
 
         NullRemoteValue? result = JsonSerializer.Deserialize<NullRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("null"));
-        Assert.That(argumentLocalValue.Value, Is.Null);
+        Assert.Equal("null", argumentLocalValue.Type);
+        Assert.Null(argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingStringRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -47,10 +46,10 @@ public class NullRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<NullRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NullRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -60,9 +59,9 @@ public class NullRemoteValueTests
                       """;
 
         NullRemoteValue? result = JsonSerializer.Deserialize<NullRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         NullRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/NumberRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/NumberRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NumberRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeNumberRemoteValue()
     {
         string json = """
@@ -17,12 +16,12 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Number));
-        Assert.That(result.Value, Is.EqualTo(3.14159));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Number, result.Type);
+        Assert.Equal(3.14159, result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNumberRemoteValueWithInteger()
     {
         string json = """
@@ -34,12 +33,12 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Number));
-        Assert.That(result.Value, Is.EqualTo(42));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Number, result.Type);
+        Assert.Equal(42, result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -51,15 +50,15 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("number"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<double>());
-        Assert.That(argumentLocalValue.Value, Is.EqualTo(3.14159));
+        Assert.Equal("number", argumentLocalValue.Type);
+        Assert.IsType<double>(argumentLocalValue.Value);
+        Assert.Equal(3.14159, argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLong()
     {
         string json = """
@@ -71,11 +70,11 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ToLong(), Is.EqualTo(42));
+        Assert.NotNull(result);
+        Assert.Equal(42, result.ToLong());
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToInt()
     {
         string json = """
@@ -87,11 +86,11 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ToInt(), Is.EqualTo(42));
+        Assert.NotNull(result);
+        Assert.Equal(42, result.ToInt());
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToInt()
     {
         string json = """
@@ -103,12 +102,12 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         int intValue = result;
-        Assert.That(intValue, Is.EqualTo(42));
+        Assert.Equal(42, intValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToLong()
     {
         string json = """
@@ -120,12 +119,12 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         long longValue = result;
-        Assert.That(longValue, Is.EqualTo(42));
+        Assert.Equal(42, longValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToDouble()
     {
         string json = """
@@ -137,12 +136,12 @@ public class NumberRemoteValueTests
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         double doubleValue = result;
-        Assert.That(doubleValue, Is.EqualTo(42));
+        Assert.Equal(42, doubleValue);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNumberRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -151,10 +150,10 @@ public class NumberRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<NumberRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NumberRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNumberRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -164,10 +163,10 @@ public class NumberRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<NumberRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NumberRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNumberRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -177,10 +176,10 @@ public class NumberRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<NumberRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NumberRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -191,9 +190,9 @@ public class NumberRemoteValueTests
                       """;
 
         NumberRemoteValue? result = JsonSerializer.Deserialize<NumberRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         NumberRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/ObjectReferenceRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ObjectReferenceRemoteValueTests.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 public class ObjectReferenceRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeObjectReferenceRemoteValue()
     {
         string json = """
@@ -20,13 +20,13 @@ public class ObjectReferenceRemoteValueTests
         // Note: Testing of the multiple types (symbol, function, promise, etc.)
         // that can be deserialized into a ObjectReferenceremoteValue is tested in
         // RemoteValueTests.
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Symbol));
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Symbol, result.Type);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeObjectReferenceRemoteValueWithMissingHandle()
     {
         string json = """
@@ -38,13 +38,13 @@ public class ObjectReferenceRemoteValueTests
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Symbol));
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Symbol, result.Type);
+        Assert.Null(result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeObjectReferenceRemoteValueWithMissingInternalId()
     {
         string json = """
@@ -56,13 +56,13 @@ public class ObjectReferenceRemoteValueTests
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Symbol));
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Symbol, result.Type);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Null(result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -74,14 +74,14 @@ public class ObjectReferenceRemoteValueTests
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         RemoteObjectReference remoteObjectReference = (RemoteObjectReference)localValue;
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -94,13 +94,13 @@ public class ObjectReferenceRemoteValueTests
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidHandleTypeThrows()
     {
         string json = """
@@ -110,10 +110,10 @@ public class ObjectReferenceRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidInternalIdTypeThrows()
     {
         string json = """
@@ -124,10 +124,10 @@ public class ObjectReferenceRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -137,10 +137,10 @@ public class ObjectReferenceRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToLocalValueWithoutHandleThrows()
     {
         string json = """
@@ -151,11 +151,11 @@ public class ObjectReferenceRemoteValueTests
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToLocalValue(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToLocalValue());
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -166,11 +166,11 @@ public class ObjectReferenceRemoteValueTests
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -181,9 +181,9 @@ public class ObjectReferenceRemoteValueTests
                       """;
 
         ObjectReferenceRemoteValue? result = JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ObjectReferenceRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RealmCreatedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RealmCreatedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RealmCreatedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithWindowRealmInfo()
     {
         string json = """
@@ -17,17 +16,15 @@ public class RealmCreatedEventArgsTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         RealmCreatedEventArgs eventArgs = new(info);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(eventArgs.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(eventArgs.Type, Is.EqualTo(RealmType.Window));
-        }
+
+        Assert.Equal("myRealm", eventArgs.RealmId);
+        Assert.Equal("myOrigin", eventArgs.Origin);
+        Assert.Equal(RealmType.Window, eventArgs.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithNonWindowRealmInfo()
     {
         string json = """
@@ -38,17 +35,15 @@ public class RealmCreatedEventArgsTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         RealmCreatedEventArgs eventArgs = new(info);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(eventArgs.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(eventArgs.Type, Is.EqualTo(RealmType.Worker));
-        }
+
+        Assert.Equal("myRealm", eventArgs.RealmId);
+        Assert.Equal("myOrigin", eventArgs.Origin);
+        Assert.Equal(RealmType.Worker, eventArgs.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCastToSpecificRealmType()
     {
         string json = """
@@ -60,18 +55,16 @@ public class RealmCreatedEventArgsTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         RealmCreatedEventArgs eventArgs = new(info);
         WindowRealmInfo castInfo = eventArgs.As<WindowRealmInfo>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(castInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(castInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(castInfo.Type, Is.EqualTo(RealmType.Window));
-        }
+
+        Assert.Equal("myRealm", castInfo.RealmId);
+        Assert.Equal("myOrigin", castInfo.Origin);
+        Assert.Equal(RealmType.Window, castInfo.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -83,10 +76,9 @@ public class RealmCreatedEventArgsTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
+        Assert.NotNull(info);
         RealmCreatedEventArgs eventArgs = new(info);
         RealmCreatedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
-
 }

--- a/test/WebDriverBiDi.Tests/Script/RealmDestroyedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RealmDestroyedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RealmDestroyedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class RealmDestroyedEventArgsTests
                       }
                       """;
         RealmDestroyedEventArgs? eventArgs = JsonSerializer.Deserialize<RealmDestroyedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        Assert.That(eventArgs.RealmId, Is.EqualTo("myRealmId"));
+        Assert.NotNull(eventArgs);
+        Assert.Equal("myRealmId", eventArgs.RealmId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class RealmDestroyedEventArgsTests
                       }
                       """;
         RealmDestroyedEventArgs? eventArgs = JsonSerializer.Deserialize<RealmDestroyedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         RealmDestroyedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingRealmValueThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<RealmDestroyedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmDestroyedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidRealmValueThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class RealmDestroyedEventArgsTests
                         "realm": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmDestroyedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmDestroyedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RealmInfoTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RealmInfoTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RealmInfoTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWorkerRealmInfo()
     {
         string json = """
@@ -16,18 +15,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<RealmInfo>());
-        RealmInfo realmInfo = info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Worker));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<WorkerRealmInfo>(info);
+
+        Assert.Equal("myRealm", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal(RealmType.Worker, info.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestRealmInfoCopySemantics()
     {
         string json = """
@@ -38,13 +34,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<RealmInfo>());
+        Assert.NotNull(info);
+        Assert.IsType<RealmInfo>(info, exactMatch: false);
         RealmInfo copy = info with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWorkletRealmInfo()
     {
         string json = """
@@ -55,18 +51,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<RealmInfo>());
-        RealmInfo realmInfo = info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Worklet));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<WorkletRealmInfo>(info);
+
+        Assert.Equal("myRealm", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal(RealmType.Worklet, info.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestWorkletRealmInfoCopySemantics()
     {
         string json = """
@@ -77,14 +70,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<WorkletRealmInfo>());
-        WorkletRealmInfo realmInfo = (WorkletRealmInfo)info;
+        Assert.NotNull(info);
+        WorkletRealmInfo realmInfo = Assert.IsType<WorkletRealmInfo>(info);
         WorkletRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWindowRealmInfo()
     {
         string json = """
@@ -96,20 +88,17 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<WindowRealmInfo>());
-        WindowRealmInfo realmInfo = (WindowRealmInfo)info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Window));
-            Assert.That(realmInfo.BrowsingContext, Is.EqualTo("myContext"));
-            Assert.That(realmInfo.Sandbox, Is.Null);
-        }
+        Assert.NotNull(info);
+        WindowRealmInfo realmInfo = Assert.IsType<WindowRealmInfo>(info);
+
+        Assert.Equal("myRealm", realmInfo.RealmId);
+        Assert.Equal("myOrigin", realmInfo.Origin);
+        Assert.Equal(RealmType.Window, realmInfo.Type);
+        Assert.Equal("myContext", realmInfo.BrowsingContext);
+        Assert.Null(realmInfo.Sandbox);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWindowRealmInfoWithUserContext()
     {
         string json = """
@@ -122,21 +111,18 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<WindowRealmInfo>());
-        WindowRealmInfo realmInfo = (WindowRealmInfo)info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Window));
-            Assert.That(realmInfo.BrowsingContext, Is.EqualTo("myContext"));
-            Assert.That(realmInfo.Sandbox, Is.Null);
-            Assert.That(realmInfo.UserContext, Is.EqualTo("myUserContext"));
-        }
+        Assert.NotNull(info);
+        WindowRealmInfo realmInfo = Assert.IsType<WindowRealmInfo>(info);
+
+        Assert.Equal("myRealm", realmInfo.RealmId);
+        Assert.Equal("myOrigin", realmInfo.Origin);
+        Assert.Equal(RealmType.Window, realmInfo.Type);
+        Assert.Equal("myContext", realmInfo.BrowsingContext);
+        Assert.Null(realmInfo.Sandbox);
+        Assert.Equal("myUserContext", realmInfo.UserContext);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWindowRealmInfoWithSandbox()
     {
         string json = """
@@ -149,20 +135,17 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<WindowRealmInfo>());
-        WindowRealmInfo realmInfo = (WindowRealmInfo)info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Window));
-            Assert.That(realmInfo.BrowsingContext, Is.EqualTo("myContext"));
-            Assert.That(realmInfo.Sandbox, Is.EqualTo("mySandbox"));
-        }
+        Assert.NotNull(info);
+        WindowRealmInfo realmInfo = Assert.IsType<WindowRealmInfo>(info);
+
+        Assert.Equal("myRealm", realmInfo.RealmId);
+        Assert.Equal("myOrigin", realmInfo.Origin);
+        Assert.Equal(RealmType.Window, realmInfo.Type);
+        Assert.Equal("myContext", realmInfo.BrowsingContext);
+        Assert.Equal("mySandbox", realmInfo.Sandbox);
     }
 
-    [Test]
+    [Fact]
     public void TestWindowRealmInfoCopySemantics()
     {
         string json = """
@@ -175,14 +158,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<WindowRealmInfo>());
-        WindowRealmInfo realmInfo = (WindowRealmInfo)info;
+        Assert.NotNull(info);
+        WindowRealmInfo realmInfo = Assert.IsType<WindowRealmInfo>(info);
         WindowRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeSpecializedWorkerRealmInfo()
     {
         string json = """
@@ -193,18 +175,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<RealmInfo>());
-        RealmInfo realmInfo = (RealmInfo)info!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Worker));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<WorkerRealmInfo>(info);
+
+        Assert.Equal("myRealm", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal(RealmType.Worker, info.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeDedicatedWorkerRealmInfo()
     {
         string json = """
@@ -216,20 +195,17 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<DedicatedWorkerRealmInfo>());
-        DedicatedWorkerRealmInfo realmInfo = (DedicatedWorkerRealmInfo)info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.DedicatedWorker));
-            Assert.That(realmInfo.Owners, Has.Count.EqualTo(1));
-            Assert.That(realmInfo.Owners[0], Is.EqualTo("ownerRealm"));
-        }
+        Assert.NotNull(info);
+        DedicatedWorkerRealmInfo realmInfo = Assert.IsType<DedicatedWorkerRealmInfo>(info);
+
+        Assert.Equal("myRealm", realmInfo.RealmId);
+        Assert.Equal("myOrigin", realmInfo.Origin);
+        Assert.Equal(RealmType.DedicatedWorker, realmInfo.Type);
+        Assert.Single(realmInfo.Owners);
+        Assert.Equal("ownerRealm", realmInfo.Owners[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestDedicatedWorkerRealmInfoCopySemantics()
     {
         string json = """
@@ -241,14 +217,14 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<DedicatedWorkerRealmInfo>());
+        Assert.NotNull(info);
+        Assert.IsType<DedicatedWorkerRealmInfo>(info);
         DedicatedWorkerRealmInfo realmInfo = (DedicatedWorkerRealmInfo)info;
         DedicatedWorkerRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeSharedWorkerRealmInfo()
     {
         string json = """
@@ -259,18 +235,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<SharedWorkerRealmInfo>());
-        SharedWorkerRealmInfo realmInfo = (SharedWorkerRealmInfo)info;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.SharedWorker));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<SharedWorkerRealmInfo>(info);
+
+        Assert.Equal("myRealm", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal(RealmType.SharedWorker, info.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestSharedWorkerRealmInfoCopySemantics()
     {
         string json = """
@@ -281,14 +254,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<SharedWorkerRealmInfo>());
-        SharedWorkerRealmInfo realmInfo = (SharedWorkerRealmInfo)info;
+        Assert.NotNull(info);
+        SharedWorkerRealmInfo realmInfo = Assert.IsType<SharedWorkerRealmInfo>(info);
         SharedWorkerRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeServiceWorkerRealmInfo()
     {
         string json = """
@@ -299,18 +271,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<ServiceWorkerRealmInfo>());
-        ServiceWorkerRealmInfo realmInfo = (ServiceWorkerRealmInfo)info!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.ServiceWorker));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<ServiceWorkerRealmInfo>(info);
+
+        Assert.Equal("myRealm", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal(RealmType.ServiceWorker, info.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestServiceWorkerRealmInfoCopySemantics()
     {
         string json = """
@@ -321,14 +290,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<ServiceWorkerRealmInfo>());
-        ServiceWorkerRealmInfo realmInfo = (ServiceWorkerRealmInfo)info;
+        Assert.NotNull(info);
+        ServiceWorkerRealmInfo realmInfo = Assert.IsType<ServiceWorkerRealmInfo>(info);
         ServiceWorkerRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(info));
+        Assert.Equal(info, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeSpecializedWorkletRealmInfo()
     {
         string json = """
@@ -339,18 +307,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<RealmInfo>());
-        RealmInfo realmInfo = (RealmInfo)info!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.Worklet));
-        }
+        Assert.NotNull(info);
+        Assert.IsType<WorkletRealmInfo>(info);
+
+        Assert.Equal("myRealm", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal(RealmType.Worklet, info.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializePaintWorkletRealmInfo()
     {
         string json = """
@@ -361,18 +326,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<PaintWorkletRealmInfo>());
-        PaintWorkletRealmInfo realmInfo = (PaintWorkletRealmInfo)info!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.PaintWorklet));
-        }
+        Assert.NotNull(info);
+        PaintWorkletRealmInfo realmInfo = Assert.IsType<PaintWorkletRealmInfo>(info);
+
+        Assert.Equal("myRealm", realmInfo.RealmId);
+        Assert.Equal("myOrigin", realmInfo.Origin);
+        Assert.Equal(RealmType.PaintWorklet, realmInfo.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestPaintWorkletRealmInfoCopySemantics()
     {
         string json = """
@@ -383,14 +345,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<PaintWorkletRealmInfo>());
-        PaintWorkletRealmInfo realmInfo = (PaintWorkletRealmInfo)info!;
+        Assert.NotNull(info);
+        PaintWorkletRealmInfo realmInfo = Assert.IsType<PaintWorkletRealmInfo>(info);
         PaintWorkletRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(realmInfo));
+        Assert.Equal(realmInfo, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeAudioWorkletRealmInfo()
     {
         string json = """
@@ -401,18 +362,15 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<AudioWorkletRealmInfo>());
-        AudioWorkletRealmInfo realmInfo = (AudioWorkletRealmInfo)info!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmInfo.RealmId, Is.EqualTo("myRealm"));
-            Assert.That(realmInfo.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(realmInfo.Type, Is.EqualTo(RealmType.AudioWorklet));
-        }
+        Assert.NotNull(info);
+        AudioWorkletRealmInfo realmInfo = Assert.IsType<AudioWorkletRealmInfo>(info);
+
+        Assert.Equal("myRealm", realmInfo.RealmId);
+        Assert.Equal("myOrigin", realmInfo.Origin);
+        Assert.Equal(RealmType.AudioWorklet, realmInfo.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestAudioWorkletRealmInfoCopySemantics()
     {
         string json = """
@@ -423,14 +381,13 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<AudioWorkletRealmInfo>());
-        AudioWorkletRealmInfo realmInfo = (AudioWorkletRealmInfo)info!;
+        Assert.NotNull(info);
+        AudioWorkletRealmInfo realmInfo = Assert.IsType<AudioWorkletRealmInfo>(info);
         AudioWorkletRealmInfo copy = realmInfo with { };
-        Assert.That(copy, Is.EqualTo(realmInfo));
+        Assert.Equal(realmInfo, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithMissingRealmThrows()
     {
         string json = """
@@ -439,10 +396,10 @@ public class RealmInfoTests
                         "type": "worker"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'realm'"));
+        Assert.Contains("missing required properties including: 'realm'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithInvalidRealmTypeThrows()
     {
         string json = """
@@ -452,10 +409,10 @@ public class RealmInfoTests
                         "type": "worker"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("could not be converted"));
+        Assert.Contains("could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithMissingOriginThrows()
     {
         string json = """
@@ -464,10 +421,10 @@ public class RealmInfoTests
                         "type": "worker"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'origin'"));
+        Assert.Contains("missing required properties including: 'origin'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithInvalidOriginTypeThrows()
     {
         string json = """
@@ -477,10 +434,10 @@ public class RealmInfoTests
                         "type": "worker"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("could not be converted"));
+        Assert.Contains("could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithMissingTypeThrows()
     {
         string json = """
@@ -489,10 +446,10 @@ public class RealmInfoTests
                         "origin": "myOrigin"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must contain a 'type' property"));
+        Assert.Contains("must contain a 'type' property", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithInvalidTypeThrows()
     {
         string json = """
@@ -502,10 +459,10 @@ public class RealmInfoTests
                         "type": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'RealmInfo' type property contains unknown value 'invalid'"));
+        Assert.Contains("JSON for 'RealmInfo' type property contains unknown value 'invalid'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithNonStringTypeThrows()
     {
         string json = """
@@ -515,10 +472,10 @@ public class RealmInfoTests
                         "type": null
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRealmInfoWithMissingContextThrows()
     {
         string json = """
@@ -528,10 +485,10 @@ public class RealmInfoTests
                         "type": "window"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'context'"));
+        Assert.Contains("missing required properties including: 'context'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRealmInfoWithInvalidContextTypeThrows()
     {
         string json = """
@@ -542,10 +499,10 @@ public class RealmInfoTests
                         "context": 123
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value could not be converted"));
+        Assert.Contains("value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRealmInfoWithInvalidSandboxTypeThrows()
     {
         string json = """
@@ -557,10 +514,10 @@ public class RealmInfoTests
                         "sandbox": 2
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value could not be converted"));
+        Assert.Contains("value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRealmInfoWithInvalidUserContextTypeThrows()
     {
         string json = """
@@ -572,10 +529,10 @@ public class RealmInfoTests
                         "userContext": 2
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value could not be converted"));
+        Assert.Contains("value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDedicatedWorkerRealmInfoWithMissingOwnersThrows()
     {
         string json = """
@@ -585,10 +542,10 @@ public class RealmInfoTests
                         "type": "dedicated-worker"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'owners'"));
+        Assert.Contains("missing required properties including: 'owners'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDedicatedWorkerRealmInfoWithInvalidOwnersTypeThrows()
     {
         string json = """
@@ -599,10 +556,10 @@ public class RealmInfoTests
                         "owners": ""
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value could not be converted"));
+        Assert.Contains("value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingDedicatedWorkerRealmInfoWithInvalidOwnersEntryTypeThrows()
     {
         string json = """
@@ -613,17 +570,17 @@ public class RealmInfoTests
                         "owners": [ 123 ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value could not be converted"));
+        Assert.Contains("value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRealmInfoWithNonObjectThrows()
     {
         string json = @"[ ""invalid realm info"" ]";
-        Assert.That(() => JsonSerializer.Deserialize<RealmInfo>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmInfo>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanCastToProperSubclassTypeOfRealmInfo()
     {
         string json = """
@@ -635,12 +592,12 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<ServiceWorkerRealmInfo>());
-        Assert.That(info.As<ServiceWorkerRealmInfo>(), Is.Not.Null);
+        Assert.NotNull(info);
+        Assert.IsType<ServiceWorkerRealmInfo>(info);
+        Assert.NotNull(info.As<ServiceWorkerRealmInfo>());
     }
 
-    [Test]
+    [Fact]
     public void TestCannotCastToImproperSubclassTypeOfRealmInfo()
     {
         string json = """
@@ -652,8 +609,8 @@ public class RealmInfoTests
                       }
                       """;
         RealmInfo? info = JsonSerializer.Deserialize<RealmInfo>(json);
-        Assert.That(info, Is.Not.Null);
-        Assert.That(info, Is.InstanceOf<ServiceWorkerRealmInfo>());
-        Assert.That(() => info.As<SharedWorkerRealmInfo>(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("cannot be cast"));
+        Assert.NotNull(info);
+        Assert.IsType<ServiceWorkerRealmInfo>(info);
+        Assert.Contains("cannot be cast", Assert.ThrowsAny<WebDriverBiDiException>(() => info.As<SharedWorkerRealmInfo>()).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RegExpRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RegExpRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RegExpRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeRegExpRemoteValue()
     {
         string json = """
@@ -20,13 +19,13 @@ public class RegExpRemoteValueTests
 
         RegExpRemoteValue? result = JsonSerializer.Deserialize<RegExpRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.RegExp));
-        Assert.That(result.Value.Pattern, Is.EqualTo("test"));
-        Assert.That(result.Value.Flags, Is.EqualTo("i"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.RegExp, result.Type);
+        Assert.Equal("test", result.Value.Pattern);
+        Assert.Equal("i", result.Value.Flags);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -41,17 +40,18 @@ public class RegExpRemoteValueTests
 
         RegExpRemoteValue? result = JsonSerializer.Deserialize<RegExpRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("regexp"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<RegularExpressionValue>());
+        Assert.Equal("regexp", argumentLocalValue.Type);
+        Assert.NotNull(argumentLocalValue.Value);
+        Assert.IsType<RegularExpressionValue>(argumentLocalValue.Value);
         RegularExpressionValue regexValue = (RegularExpressionValue)argumentLocalValue.Value;
-        Assert.That(regexValue.Pattern, Is.EqualTo("test"));
-        Assert.That(regexValue.Flags, Is.EqualTo("i"));
+        Assert.Equal("test", regexValue.Pattern);
+        Assert.Equal("i", regexValue.Flags);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -68,13 +68,13 @@ public class RegExpRemoteValueTests
 
         RegExpRemoteValue? result = JsonSerializer.Deserialize<RegExpRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToRegularExpressionValue()
     {
         string json = """
@@ -89,13 +89,13 @@ public class RegExpRemoteValueTests
 
         RegExpRemoteValue? result = JsonSerializer.Deserialize<RegExpRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RegularExpressionValue regexValue = result;
-        Assert.That(regexValue.Pattern, Is.EqualTo("test"));
-        Assert.That(regexValue.Flags, Is.EqualTo("i"));
+        Assert.Equal("test", regexValue.Pattern);
+        Assert.Equal("i", regexValue.Flags);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRegExpRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -104,10 +104,10 @@ public class RegExpRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<RegExpRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RegExpRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRegExpRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -117,10 +117,10 @@ public class RegExpRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<RegExpRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RegExpRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRegExpRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -133,10 +133,10 @@ public class RegExpRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<RegExpRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RegExpRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidHandleTypeThrows()
     {
         string json = """
@@ -151,10 +151,10 @@ public class RegExpRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectReferenceRemoteValueWithInvalidInternalIdTypeThrows()
     {
         string json = """
@@ -169,10 +169,10 @@ public class RegExpRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ObjectReferenceRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -187,11 +187,11 @@ public class RegExpRemoteValueTests
 
         RegExpRemoteValue? result = JsonSerializer.Deserialize<RegExpRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -205,9 +205,9 @@ public class RegExpRemoteValueTests
                       """;
 
         RegExpRemoteValue? result = JsonSerializer.Deserialize<RegExpRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RegExpRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RegularExpressionValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RegularExpressionValueTests.cs
@@ -1,12 +1,10 @@
 namespace WebDriverBiDi.Script;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
-[TestFixture]
 public class RegularExpressionValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -15,14 +13,12 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue regexProperties = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(regexProperties.Pattern, Is.EqualTo("myPattern"));
-            Assert.That(regexProperties.Flags, Is.Null);
-        }
+
+        Assert.Equal("myPattern", regexProperties.Pattern);
+        Assert.Null(regexProperties.Flags);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -32,17 +28,17 @@ public class RegularExpressionValueTests
                       """;
         RegularExpressionValue regexProperties = JsonSerializer.Deserialize<RegularExpressionValue>(json);
         RegularExpressionValue copy = regexProperties;
-        Assert.That(copy, Is.EqualTo(regexProperties));
+        Assert.Equal(regexProperties, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingPatternThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<RegularExpressionValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RegularExpressionValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidPatternTypeThrows()
     {
         string json = """
@@ -50,10 +46,10 @@ public class RegularExpressionValueTests
                         "pattern": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RegularExpressionValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RegularExpressionValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalFlags()
     {
         string json = """
@@ -63,15 +59,13 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue regexProperties = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(regexProperties.Pattern, Is.EqualTo("myPattern"));
-            Assert.That(regexProperties.Flags, Is.Not.Null);
-            Assert.That(regexProperties.Flags, Is.EqualTo("gi"));
-        }
+
+        Assert.Equal("myPattern", regexProperties.Pattern);
+        Assert.NotNull(regexProperties.Flags);
+        Assert.Equal("gi", regexProperties.Flags);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidFlagsTypeThrows()
     {
         string json = """
@@ -80,15 +74,15 @@ public class RegularExpressionValueTests
                         "flags": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RegularExpressionValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RegularExpressionValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestEquality()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern", "gi");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -98,15 +92,15 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue actualRegexValue = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        Assert.That(actualRegexValue, Is.EqualTo(expectedRegexValue));
+        Assert.Equal(expectedRegexValue, actualRegexValue);
     }
 
-    [Test]
+    [Fact]
     public void TestInequalityWithDifferingPatterns()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern", "gi");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -116,15 +110,15 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue actualRegexValue = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        Assert.That(actualRegexValue, Is.Not.EqualTo(expectedRegexValue));
+        Assert.NotEqual(expectedRegexValue, actualRegexValue);
     }
 
-    [Test]
+    [Fact]
     public void TestInequalityWithDifferingPatternsAndNullFlags()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -133,15 +127,15 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue actualRegexValue = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        Assert.That(actualRegexValue, Is.Not.EqualTo(expectedRegexValue));
+        Assert.NotEqual(expectedRegexValue, actualRegexValue);
     }
 
-    [Test]
+    [Fact]
     public void TestInequalityWithDifferingFlags()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern", "g");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -151,11 +145,10 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue actualRegexValue = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        Assert.That(actualRegexValue, Is.Not.EqualTo(expectedRegexValue));
+        Assert.NotEqual(expectedRegexValue, actualRegexValue);
     }
 
-    [Test]
-    [SuppressMessage("Assertion", "NUnit2010")]
+    [Fact]
     public void TestInequalityWithNull()
     {
         string json = """
@@ -165,11 +158,10 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue actualRegexValue = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        Assert.That(actualRegexValue.Equals(null), Is.False);
+        Assert.False(actualRegexValue.Equals(null));
     }
 
-    [Test]
-    [SuppressMessage("Assertion", "NUnit2010")]
+    [Fact]
     public void TestInequalityWithInvalidObjectType()
     {
         string json = """
@@ -179,6 +171,6 @@ public class RegularExpressionValueTests
                       }
                       """;
         RegularExpressionValue actualRegexValue = JsonSerializer.Deserialize<RegularExpressionValue>(json);
-        Assert.That(actualRegexValue.Equals("invalid"), Is.False);
+        Assert.False(actualRegexValue.Equals("invalid"));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RemoteObjectReferenceTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RemoteObjectReferenceTests.cs
@@ -3,24 +3,23 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class RemoteObjectReferenceTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeRemoteObjectReference()
     {
         RemoteObjectReference reference = new("myHandle");
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("handle"));
-            Assert.That(referenceObject["handle"]!.Value<string>(), Is.EqualTo("myHandle"));
-        }
+        Assert.Single(referenceObject);
+
+        Assert.True(referenceObject.ContainsKey("handle"));
+        JToken? handle = referenceObject["handle"];
+        Assert.NotNull(handle);
+        Assert.Equal("myHandle", handle.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanEditRemoteObjectReferenceHandle()
     {
         RemoteObjectReference reference = new("myHandle")
@@ -29,15 +28,15 @@ public class RemoteObjectReferenceTests
         };
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("handle"));
-            Assert.That(referenceObject["handle"]!.Value<string>(), Is.EqualTo("myNewHandle"));
-        }
+        Assert.Single(referenceObject);
+
+        Assert.True(referenceObject.ContainsKey("handle"));
+        JToken? handle = referenceObject["handle"];
+        Assert.NotNull(handle);
+        Assert.Equal("myNewHandle", handle.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeRemoteObjectReferenceWithSharedId()
     {
         RemoteObjectReference reference = new("myHandle")
@@ -46,54 +45,57 @@ public class RemoteObjectReferenceTests
         };
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("handle"));
-            Assert.That(referenceObject["handle"]!.Value<string>(), Is.EqualTo("myHandle"));
-            Assert.That(referenceObject, Contains.Key("sharedId"));
-            Assert.That(referenceObject["sharedId"]!.Value<string>(), Is.EqualTo("mySharedId"));
-        }
+        Assert.Equal(2, referenceObject.Count);
+
+        Assert.True(referenceObject.ContainsKey("handle"));
+        JToken? handle = referenceObject["handle"];
+        Assert.NotNull(handle);
+        Assert.Equal("myHandle", handle.Value<string>());
+
+        Assert.True(referenceObject.ContainsKey("sharedId"));
+        JToken? sharedId = referenceObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal("mySharedId", sharedId.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestRemoteObjectReferenceCopySemantics()
     {
         RemoteObjectReference reference = new("myHandle");
         RemoteObjectReference copy = reference with { };
-        Assert.That(copy, Is.EqualTo(reference));
+        Assert.Equal(reference, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestRemoteObjectReferenceHandleGetterReturnsValue()
     {
         RemoteObjectReference reference = new("myHandle");
-        Assert.That(reference.Handle, Is.EqualTo("myHandle"));
+        Assert.Equal("myHandle", reference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestRemoteObjectReferenceHandleSetterSetsValue()
     {
         RemoteObjectReference reference = new("myHandle");
         reference.Handle = "myNewHandle";
-        Assert.That(reference.Handle, Is.EqualTo("myNewHandle"));
+        Assert.Equal("myNewHandle", reference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingRemoteObjectReferenceSharedIdToNullThrows()
     {
         RemoteObjectReference reference = new("myHandle");
-        Assert.That(() => reference.Handle = null!, Throws.InstanceOf<ArgumentNullException>());
+        Assert.ThrowsAny<ArgumentNullException>(() => reference.Handle = null!);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRemoteObjectReferenceThrowsWhenHandleIsMissing()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteObjectReference>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteObjectReference>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRemoteObjectReferenceThrowsWhenHandleIsInvalidType()
     {
         string json = """
@@ -101,24 +103,27 @@ public class RemoteObjectReferenceTests
                         "handle": 123
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteObjectReference>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteObjectReference>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeRemoteObjectReferenceWithAdditionalProperties()
     {
         RemoteObjectReference reference = new("myHandle");
         reference.AdditionalData["myPropertyName"] = "myValue";
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("handle"));
-            Assert.That(referenceObject["handle"]!.Value<string>(), Is.EqualTo("myHandle"));
-            Assert.That(referenceObject, Contains.Key("myPropertyName"));
-            Assert.That(referenceObject["myPropertyName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(referenceObject["myPropertyName"]!.Value<string>(), Is.EqualTo("myValue"));
-        }
+        Assert.Equal(2, referenceObject.Count);
+
+        Assert.True(referenceObject.ContainsKey("handle"));
+        JToken? handle = referenceObject["handle"];
+        Assert.NotNull(handle);
+        Assert.Equal("myHandle", handle.Value<string>());
+
+        Assert.True(referenceObject.ContainsKey("myPropertyName"));
+        JToken? myPropertyName = referenceObject["myPropertyName"];
+        Assert.NotNull(myPropertyName);
+        Assert.Equal(JTokenType.String, myPropertyName.Type);
+        Assert.Equal("myValue", myPropertyName.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RemoteValueTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Script;
 using System.Numerics;
 using System.Text.Json;
 
-[TestFixture]
 public class RemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidStringRemoteValueThrows()
     {
         string json = """
@@ -15,10 +14,10 @@ public class RemoteValueTests
                         "value": 7
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNaNRemoteValue()
     {
         string json = """
@@ -28,16 +27,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Number));
-            Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)remoteValue).Value, Is.EqualTo(double.NaN));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Number, remoteValue.Type);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
+        Assert.Equal(double.NaN, ((NumberRemoteValue)remoteValue).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNegativeZeroRemoteValue()
     {
         string json = """
@@ -47,17 +44,15 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Number));
-            Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)remoteValue).Value, Is.EqualTo(double.NegativeZero));
-            Assert.That(double.IsNegative(((NumberRemoteValue)remoteValue).Value), Is.True);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Number, remoteValue.Type);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
+        Assert.Equal(double.NegativeZero, ((NumberRemoteValue)remoteValue).Value);
+        Assert.True(double.IsNegative(((NumberRemoteValue)remoteValue).Value));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeInfinityRemoteValue()
     {
         string json = """
@@ -67,16 +62,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Number));
-            Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)remoteValue).Value, Is.EqualTo(double.PositiveInfinity));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Number, remoteValue.Type);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
+        Assert.Equal(double.PositiveInfinity, ((NumberRemoteValue)remoteValue).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeNegativeInfinityRemoteValue()
     {
         string json = """
@@ -86,16 +79,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Number));
-            Assert.That(remoteValue, Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)remoteValue).Value, Is.EqualTo(double.NegativeInfinity));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Number, remoteValue.Type);
+        Assert.IsType<NumberRemoteValue>(remoteValue);
+        Assert.Equal(double.NegativeInfinity, ((NumberRemoteValue)remoteValue).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -105,12 +96,12 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
+        Assert.NotNull(remoteValue);
         RemoteValue copy = remoteValue with { };
-        Assert.That(copy, Is.EqualTo(remoteValue));
+        Assert.Equal(remoteValue, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidSpecialNumericRemoteValueThrows()
     {
         string json = """
@@ -119,10 +110,10 @@ public class RemoteValueTests
                         "value": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("Invalid value 'invalid' for 'value' property of number"));
+        Assert.Contains("Invalid value 'invalid' for 'value' property of number", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidNumericRemoteValueThrows()
     {
         string json = """
@@ -131,14 +122,14 @@ public class RemoteValueTests
                         "value": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("Expected String or Number"));
+        Assert.Contains("Expected String or Number", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
         json = """
                {
                  "type": "number",
                  "value": false
                }
                """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("Expected String or Number"));
+        Assert.Contains("Expected String or Number", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
         json = """
                {
                  "type": "number",
@@ -146,10 +137,10 @@ public class RemoteValueTests
                }
                """;
         json = @"{ ""type"": ""number"", ""value"": null }";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("Expected String or Number"));
+        Assert.Contains("Expected String or Number", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidBooleanRemoteValueThrows()
     {
         string json = """
@@ -158,10 +149,10 @@ public class RemoteValueTests
                         "value": "hello"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidBigIntRemoteValueThrows()
     {
         string json = """
@@ -170,10 +161,10 @@ public class RemoteValueTests
                         "value": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidBigIntValueRemoteValueThrows()
     {
         string json = """
@@ -182,10 +173,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("Cannot parse invalid value 'some value' for bigint"));
+        Assert.Contains("Cannot parse invalid value 'some value' for bigint", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidDateRemoteValueThrows()
     {
         string json = """
@@ -194,10 +185,10 @@ public class RemoteValueTests
                         "value": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidDateValueRemoteValueThrows()
     {
         string json = """
@@ -206,15 +197,15 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRegularExpressionWithNullFlagsRemoteValue()
     {
         LocalValue regexLocalValue = LocalValue.RegExp("myPattern");
         LocalArgumentValue primitiveValue = (LocalArgumentValue)regexLocalValue;
-        Assert.That(primitiveValue.Value, Is.Not.Null);
+        Assert.NotNull(primitiveValue.Value);
         RegularExpressionValue expectedRegexValue = (RegularExpressionValue)primitiveValue.Value;
 
         string json = """
@@ -226,19 +217,17 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.RegExp));
-            Assert.That(remoteValue, Is.InstanceOf<RegExpRemoteValue>());
-            RegExpRemoteValue regExpRemoteValue = (RegExpRemoteValue)remoteValue;
-            Assert.That(regExpRemoteValue.Handle, Is.Null);
-            Assert.That(regExpRemoteValue.InternalId, Is.Null);
-            Assert.That(regExpRemoteValue.Value, Is.EqualTo(expectedRegexValue));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.RegExp, remoteValue.Type);
+        Assert.IsType<RegExpRemoteValue>(remoteValue);
+        RegExpRemoteValue regExpRemoteValue = (RegExpRemoteValue)remoteValue;
+        Assert.Null(regExpRemoteValue.Handle);
+        Assert.Null(regExpRemoteValue.InternalId);
+        Assert.Equal(expectedRegexValue, regExpRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingRegularExpressionRemoteValueToRemoteReference()
     {
         string json = """
@@ -252,20 +241,18 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.RegExp));
-            Assert.That(remoteValue, Is.InstanceOf<RegExpRemoteValue>());
-            RegExpRemoteValue regExpRemoteValue = (RegExpRemoteValue)remoteValue;
-            Assert.That(regExpRemoteValue.Handle, Is.EqualTo("myHandle"));
-            Assert.That(regExpRemoteValue.InternalId, Is.Null);
-            RemoteObjectReference remoteReference = regExpRemoteValue.ToRemoteObjectReference();
-            Assert.That(remoteReference.Handle, Is.EqualTo("myHandle"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.RegExp, remoteValue.Type);
+        Assert.IsType<RegExpRemoteValue>(remoteValue);
+        RegExpRemoteValue regExpRemoteValue = (RegExpRemoteValue)remoteValue;
+        Assert.Equal("myHandle", regExpRemoteValue.Handle);
+        Assert.Null(regExpRemoteValue.InternalId);
+        RemoteObjectReference remoteReference = regExpRemoteValue.ToRemoteObjectReference();
+        Assert.Equal("myHandle", remoteReference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidRegularExpressionValueRemoteValueThrows()
     {
         string json = """
@@ -274,10 +261,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingRegularExpressionRemoteValueToRemoteReferenceWithoutHandleThrows()
     {
         string json = """
@@ -290,13 +277,13 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<RegExpRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<RegExpRemoteValue>(remoteValue);
         RegExpRemoteValue regExpRemoteValue = (RegExpRemoteValue)remoteValue;
-        Assert.That(() => regExpRemoteValue.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("must have a valid handle"));
+        Assert.Contains("must have a valid handle", Assert.ThrowsAny<WebDriverBiDiException>(() => regExpRemoteValue.ToRemoteObjectReference()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNodeRemoteValueWithInvalidSharedIdThrows()
     {
         string json = """
@@ -310,10 +297,10 @@ public class RemoteValueTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingSharedIdIsIgnoredForNotNodeRemoteValue()
     {
         string json = """
@@ -337,28 +324,26 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Array));
-            Assert.That(remoteValue, Is.InstanceOf<CollectionRemoteValue>());
-            CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
-            Assert.That(listRemoteValue.Handle, Is.Null);
-            Assert.That(listRemoteValue.InternalId, Is.Null);
-            Assert.That(listRemoteValue.Value, Is.Not.Null);
-            RemoteValueList arrayValue = listRemoteValue.Value!;
-            Assert.That(arrayValue, Is.Not.Null);
-            Assert.That(arrayValue, Has.Count.EqualTo(3));
-            Assert.That(arrayValue[0], Is.InstanceOf<StringRemoteValue>());
-            Assert.That(((StringRemoteValue)arrayValue[0]).Value, Is.EqualTo("stringValue"));
-            Assert.That(arrayValue[1], Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)arrayValue[1]).Value, Is.EqualTo(123));
-            Assert.That(arrayValue[2], Is.InstanceOf<BooleanRemoteValue>());
-            Assert.That(((BooleanRemoteValue)arrayValue[2]).Value, Is.True);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Array, remoteValue.Type);
+        Assert.IsType<CollectionRemoteValue>(remoteValue);
+        CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
+        Assert.Null(listRemoteValue.Handle);
+        Assert.Null(listRemoteValue.InternalId);
+        Assert.NotNull(listRemoteValue.Value);
+        RemoteValueList arrayValue = listRemoteValue.Value;
+        Assert.NotNull(arrayValue);
+        Assert.Equal(3, arrayValue.Count);
+        Assert.IsType<StringRemoteValue>(arrayValue[0]);
+        Assert.Equal("stringValue", ((StringRemoteValue)arrayValue[0]).Value);
+        Assert.IsType<NumberRemoteValue>(arrayValue[1]);
+        Assert.Equal(123, ((NumberRemoteValue)arrayValue[1]).Value);
+        Assert.IsType<BooleanRemoteValue>(arrayValue[2]);
+        Assert.True(((BooleanRemoteValue)arrayValue[2]).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidNodeValueRemoteValueThrows()
     {
         string json = """
@@ -367,10 +352,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingCollectionRemoteValueToRemoteObjectReference()
     {
         string json = """
@@ -394,14 +379,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<CollectionRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<CollectionRemoteValue>(remoteValue);
         CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
         RemoteObjectReference remoteReference = listRemoteValue.ToRemoteObjectReference();
-        Assert.That(remoteReference.Handle, Is.EqualTo("myHandle"));
+        Assert.Equal("myHandle", remoteReference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingCollectionRemoteValueToRemoteObjectReferenceWithMissingHandleThrows()
     {
         string json = """
@@ -424,13 +409,13 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<CollectionRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<CollectionRemoteValue>(remoteValue);
         CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
-        Assert.That(() => listRemoteValue.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("must have a valid handle"));
+        Assert.Contains("must have a valid handle", Assert.ThrowsAny<WebDriverBiDiException>(() => listRemoteValue.ToRemoteObjectReference()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidArrayValueRemoteValueThrows()
     {
         string json = """
@@ -439,10 +424,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidArrayElementValueRemoteValueThrows()
     {
         string json = """
@@ -455,10 +440,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'RemoteValue' must be an object"));
+        Assert.Contains("JSON for 'RemoteValue' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingSetRemoteValue()
     {
         string json = """
@@ -481,27 +466,25 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Set));
-            CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
-            Assert.That(listRemoteValue.Handle, Is.Null);
-            Assert.That(listRemoteValue.InternalId, Is.Null);
-            Assert.That(listRemoteValue.Value, Is.Not.Null);
-            RemoteValueList setValue = listRemoteValue.Value!;
-            Assert.That(setValue, Is.Not.Null);
-            Assert.That(setValue, Has.Count.EqualTo(3));
-            Assert.That(setValue[0], Is.InstanceOf<StringRemoteValue>());
-            Assert.That(((StringRemoteValue)setValue[0]).Value, Is.EqualTo("stringValue"));
-            Assert.That(setValue[1], Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)setValue[1]).Value, Is.EqualTo(123));
-            Assert.That(setValue[2], Is.InstanceOf<BooleanRemoteValue>());
-            Assert.That(((BooleanRemoteValue)setValue[2]).Value, Is.EqualTo(true));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Set, remoteValue.Type);
+        CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
+        Assert.Null(listRemoteValue.Handle);
+        Assert.Null(listRemoteValue.InternalId);
+        Assert.NotNull(listRemoteValue.Value);
+        RemoteValueList setValue = listRemoteValue.Value;
+        Assert.NotNull(setValue);
+        Assert.Equal(3, setValue.Count);
+        Assert.IsType<StringRemoteValue>(setValue[0]);
+        Assert.Equal("stringValue", ((StringRemoteValue)setValue[0]).Value);
+        Assert.IsType<NumberRemoteValue>(setValue[1]);
+        Assert.Equal(123, ((NumberRemoteValue)setValue[1]).Value);
+        Assert.IsType<BooleanRemoteValue>(setValue[2]);
+        Assert.True(((BooleanRemoteValue)setValue[2]).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidSetValueRemoteValueThrows()
     {
         string json = """
@@ -510,10 +493,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidSetElementValueRemoteValueThrows()
     {
         string json = """
@@ -526,10 +509,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'RemoteValue' must be an object"));
+        Assert.Contains("JSON for 'RemoteValue' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNodeListRemoteValue()
     {
         string json = """
@@ -547,25 +530,23 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.NodeList));
-            CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
-            Assert.That(listRemoteValue.Handle, Is.Null);
-            Assert.That(listRemoteValue.InternalId, Is.Null);
-            Assert.That(listRemoteValue.Value, Is.Not.Null);
-            RemoteValueList nodeListValue = listRemoteValue.Value!;
-            Assert.That(nodeListValue, Is.Not.Null);
-            Assert.That(nodeListValue, Has.Count.EqualTo(1));
-            Assert.That(nodeListValue[0], Is.InstanceOf<NodeRemoteValue>());
-            NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)nodeListValue[0];
-            Assert.That(nodeRemoteValue.Value, Is.Not.Null);
-            Assert.That(nodeRemoteValue.Value!.NodeType, Is.EqualTo(1));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.NodeList, remoteValue.Type);
+        CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
+        Assert.Null(listRemoteValue.Handle);
+        Assert.Null(listRemoteValue.InternalId);
+        Assert.NotNull(listRemoteValue.Value);
+        RemoteValueList nodeListValue = listRemoteValue.Value;
+        Assert.NotNull(nodeListValue);
+        Assert.Single(nodeListValue);
+        Assert.IsType<NodeRemoteValue>(nodeListValue[0]);
+        NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)nodeListValue[0];
+        Assert.NotNull(nodeRemoteValue.Value);
+        Assert.Equal(1u, nodeRemoteValue.Value.NodeType);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidNodeListValueRemoteValueThrows()
     {
         string json = """
@@ -574,10 +555,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidNodeListElementValueRemoteValueThrows()
     {
         string json = """
@@ -590,10 +571,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'RemoteValue' must be an object"));
+        Assert.Contains("JSON for 'RemoteValue' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingHtmlCollectionRemoteValue()
     {
         string json = """
@@ -611,25 +592,23 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.HtmlCollection));
-            CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
-            Assert.That(listRemoteValue.Handle, Is.Null);
-            Assert.That(listRemoteValue.InternalId, Is.Null);
-            Assert.That(listRemoteValue.Value, Is.Not.Null);
-            RemoteValueList htmlCollectionValue = listRemoteValue.Value!;
-            Assert.That(htmlCollectionValue, Is.Not.Null);
-            Assert.That(htmlCollectionValue, Has.Count.EqualTo(1));
-            Assert.That(htmlCollectionValue[0], Is.InstanceOf<NodeRemoteValue>());
-            NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)htmlCollectionValue[0];
-            Assert.That(nodeRemoteValue.Value, Is.Not.Null);
-            Assert.That(nodeRemoteValue.Value!.NodeType, Is.EqualTo(1));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.HtmlCollection, remoteValue.Type);
+        CollectionRemoteValue listRemoteValue = (CollectionRemoteValue)remoteValue;
+        Assert.Null(listRemoteValue.Handle);
+        Assert.Null(listRemoteValue.InternalId);
+        Assert.NotNull(listRemoteValue.Value);
+        RemoteValueList htmlCollectionValue = listRemoteValue.Value;
+        Assert.NotNull(htmlCollectionValue);
+        Assert.Single(htmlCollectionValue);
+        Assert.IsType<NodeRemoteValue>(htmlCollectionValue[0]);
+        NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)htmlCollectionValue[0];
+        Assert.NotNull(nodeRemoteValue.Value);
+        Assert.Equal(1u, nodeRemoteValue.Value.NodeType);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidHtmlCollectionValueRemoteValueThrows()
     {
         string json = """
@@ -638,10 +617,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidHtmlCollectionElementValueRemoteValueThrows()
     {
         string json = """
@@ -654,10 +633,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'RemoteValue' must be an object"));
+        Assert.Contains("JSON for 'RemoteValue' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithIntegerRemoteValueKey()
     {
         string json = """
@@ -678,27 +657,25 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)dictionaryItem.Key).Value, Is.EqualTo(2));
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<NumberRemoteValue>(dictionaryItem.Key);
+        Assert.Equal(2, ((NumberRemoteValue)dictionaryItem.Key).Value);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithBooleanRemoteValueKey()
     {
         string json = """
@@ -719,26 +696,25 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<BooleanRemoteValue>());
-            Assert.That(((BooleanRemoteValue)dictionaryItem.Key).Value, Is.True);
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<BooleanRemoteValue>(dictionaryItem.Key);
+        Assert.True(((BooleanRemoteValue)dictionaryItem.Key).Value);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithBigintRemoteValueKey()
     {
         string json = """
@@ -759,27 +735,25 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<BigIntegerRemoteValue>());
-            Assert.That(((BigIntegerRemoteValue)dictionaryItem.Key).Value, Is.EqualTo(new BigInteger(1234)));
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<BigIntegerRemoteValue>(dictionaryItem.Key);
+        Assert.Equal(new BigInteger(1234), ((BigIntegerRemoteValue)dictionaryItem.Key).Value);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithNullRemoteValueKey()
     {
         string json = """
@@ -799,26 +773,24 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<NullRemoteValue>());
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<NullRemoteValue>(dictionaryItem.Key);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithUndefinedRemoteValueKey()
     {
         string json = """
@@ -838,26 +810,24 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<UndefinedRemoteValue>());
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<UndefinedRemoteValue>(dictionaryItem.Key);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithDateRemoteValueKey()
     {
         string json = """
@@ -878,28 +848,26 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<DateRemoteValue>());
-            DateRemoteValue dateRemoteValue = (DateRemoteValue)dictionaryItem.Key;
-            Assert.That(dateRemoteValue.Value, Is.EqualTo(new DateTime(2020, 07, 19, 23, 47, 26, 56, DateTimeKind.Utc)));
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<DateRemoteValue>(dictionaryItem.Key);
+        DateRemoteValue dateRemoteValue = (DateRemoteValue)dictionaryItem.Key;
+        Assert.Equal(new DateTime(2020, 07, 19, 23, 47, 26, 56, DateTimeKind.Utc), dateRemoteValue.Value);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithComplexRemoteValueKeyContainingHandle()
     {
         string json = """
@@ -920,29 +888,27 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)dictionaryItem.Key;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.EqualTo("myHandle"));
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<ObjectReferenceRemoteValue>(dictionaryItem.Key);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)dictionaryItem.Key;
+        Assert.Equal("myHandle", objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithComplexRemoteValueKeyContainingInternalId()
     {
         string json = """
@@ -963,29 +929,27 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Map));
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(1));
-            KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
-            Assert.That(dictionaryItem.Key, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)dictionaryItem.Key;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.EqualTo("123"));
-            Assert.That(dictionaryItem.Value, Is.InstanceOf<StringRemoteValue>());
-            StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
-            Assert.That(stringRemoteValue.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(stringRemoteValue.Value, Is.EqualTo("stringValue"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Map, remoteValue.Type);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Single(dictionaryValue);
+        KeyValuePair<object, RemoteValue> dictionaryItem = dictionaryValue.ElementAt(0);
+        Assert.IsType<ObjectReferenceRemoteValue>(dictionaryItem.Key);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)dictionaryItem.Key;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Equal("123", objectReferenceRemoteValue.InternalId);
+        Assert.IsType<StringRemoteValue>(dictionaryItem.Value);
+        StringRemoteValue stringRemoteValue = (StringRemoteValue)dictionaryItem.Value;
+        Assert.Equal(RemoteValueType.String, stringRemoteValue.Type);
+        Assert.Equal("stringValue", stringRemoteValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingMapRemoteValueToRemoteObjectReference()
     {
         string json = """
@@ -1018,14 +982,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<KeyValuePairCollectionRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<KeyValuePairCollectionRemoteValue>(remoteValue);
         KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
         RemoteObjectReference remoteObjectReference = keyValuePairRemoteValue.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidMapValueRemoteValueThrows()
     {
         string json = """
@@ -1034,10 +998,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidMapElementValueRemoteValueThrows()
     {
         string json = """
@@ -1050,10 +1014,10 @@ public class RemoteValueTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithoutArrayElementsThrows()
     {
         string json = """
@@ -1066,10 +1030,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("RemoteValue array element for dictionary must be an array"));
+        Assert.Contains("RemoteValue array element for dictionary must be an array", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithInvalidArrayElementSizeThrows()
     {
         string json = """
@@ -1084,7 +1048,7 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("RemoteValue array element for dictionary must be an array"));
+        Assert.Contains("RemoteValue array element for dictionary must be an array", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
         json = """
                {
                  "type": "map",
@@ -1095,10 +1059,10 @@ public class RemoteValueTests
                  ]
                }
                """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("RemoteValue array element for dictionary must be an array"));
+        Assert.Contains("RemoteValue array element for dictionary must be an array", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithInvalidKeyTypeThrows()
     {
         string json = """
@@ -1112,10 +1076,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must have a first element (key) that is either a string or an object"));
+        Assert.Contains("must have a first element (key) that is either a string or an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingMapRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -1129,10 +1093,10 @@ public class RemoteValueTests
                         ]
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must have a second element (value) that is an object"));
+        Assert.Contains("must have a second element (value) that is an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingMapRemoteValueToRemoteObjectReferenceWithMissingHandleThrows()
     {
         string json = """
@@ -1164,13 +1128,13 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<KeyValuePairCollectionRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<KeyValuePairCollectionRemoteValue>(remoteValue);
         KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-        Assert.That(() => keyValuePairRemoteValue.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("must have a valid handle"));
+        Assert.Contains("must have a valid handle", Assert.ThrowsAny<WebDriverBiDiException>(() => keyValuePairRemoteValue.ToRemoteObjectReference()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingObjectRemoteValue()
     {
         string json = """
@@ -1202,30 +1166,28 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Object));
-            Assert.That(remoteValue, Is.InstanceOf<KeyValuePairCollectionRemoteValue>());
-            KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
-            Assert.That(keyValuePairRemoteValue.Handle, Is.Null);
-            Assert.That(keyValuePairRemoteValue.InternalId, Is.Null);
-            Assert.That(keyValuePairRemoteValue.Value, Is.Not.Null);
-            RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value!;
-            Assert.That(dictionaryValue, Has.Count.EqualTo(3));
-            Assert.That(dictionaryValue, Contains.Key("stringProperty"));
-            Assert.That(dictionaryValue["stringProperty"], Is.InstanceOf<StringRemoteValue>());
-            Assert.That(((StringRemoteValue)dictionaryValue["stringProperty"]).Value, Is.EqualTo("stringValue"));
-            Assert.That(dictionaryValue, Contains.Key("numberProperty"));
-            Assert.That(dictionaryValue["numberProperty"], Is.InstanceOf<NumberRemoteValue>());
-            Assert.That(((NumberRemoteValue)dictionaryValue["numberProperty"]).Value, Is.EqualTo(123));
-            Assert.That(dictionaryValue, Contains.Key("booleanProperty"));
-            Assert.That(dictionaryValue["booleanProperty"], Is.InstanceOf<BooleanRemoteValue>());
-            Assert.That(((BooleanRemoteValue)dictionaryValue["booleanProperty"]).Value, Is.EqualTo(true));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Object, remoteValue.Type);
+        Assert.IsType<KeyValuePairCollectionRemoteValue>(remoteValue);
+        KeyValuePairCollectionRemoteValue keyValuePairRemoteValue = (KeyValuePairCollectionRemoteValue)remoteValue;
+        Assert.Null(keyValuePairRemoteValue.Handle);
+        Assert.Null(keyValuePairRemoteValue.InternalId);
+        Assert.NotNull(keyValuePairRemoteValue.Value);
+        RemoteValueDictionary dictionaryValue = keyValuePairRemoteValue.Value;
+        Assert.Equal(3, dictionaryValue.Count);
+        Assert.True(dictionaryValue.ContainsKey("stringProperty"));
+        Assert.IsType<StringRemoteValue>(dictionaryValue["stringProperty"]);
+        Assert.Equal("stringValue", ((StringRemoteValue)dictionaryValue["stringProperty"]).Value);
+        Assert.True(dictionaryValue.ContainsKey("numberProperty"));
+        Assert.IsType<NumberRemoteValue>(dictionaryValue["numberProperty"]);
+        Assert.Equal(123, ((NumberRemoteValue)dictionaryValue["numberProperty"]).Value);
+        Assert.True(dictionaryValue.ContainsKey("booleanProperty"));
+        Assert.IsType<BooleanRemoteValue>(dictionaryValue["booleanProperty"]);
+        Assert.True(((BooleanRemoteValue)dictionaryValue["booleanProperty"]).Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidObjectValueRemoteValueThrows()
     {
         string json = """
@@ -1234,10 +1196,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidObjectElementValueRemoteValueThrows()
     {
         string json = """
@@ -1250,10 +1212,10 @@ public class RemoteValueTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingSymbolRemoteValue()
     {
         string json = """
@@ -1262,18 +1224,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Symbol));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Symbol, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingFunctionRemoteValue()
     {
         string json = """
@@ -1282,18 +1242,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Function));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Function, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWeakMapRemoteValue()
     {
         string json = """
@@ -1302,18 +1260,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.WeakMap));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.WeakMap, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWeakSetRemoteValue()
     {
         string json = """
@@ -1322,18 +1278,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.WeakSet));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.WeakSet, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingGeneratorRemoteValue()
     {
         string json = """
@@ -1342,18 +1296,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Generator));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Generator, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingErrorRemoteValue()
     {
         string json = """
@@ -1362,18 +1314,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Error));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Error, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingProxyRemoteValue()
     {
         string json = """
@@ -1382,18 +1332,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Proxy));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Proxy, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingPromiseRemoteValue()
     {
         string json = """
@@ -1402,18 +1350,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Promise));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Promise, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingTypedArrayRemoteValue()
     {
         string json = """
@@ -1422,18 +1368,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.TypedArray));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.TypedArray, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingArrayBufferRemoteValue()
     {
         string json = """
@@ -1442,18 +1386,16 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.ArrayBuffer));
-            Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
-            ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-            Assert.That(objectReferenceRemoteValue.Handle, Is.Null);
-            Assert.That(objectReferenceRemoteValue.InternalId, Is.Null);
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.ArrayBuffer, remoteValue.Type);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
+        ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
+        Assert.Null(objectReferenceRemoteValue.Handle);
+        Assert.Null(objectReferenceRemoteValue.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRemoteValue()
     {
         string json = """
@@ -1465,19 +1407,17 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Window));
-            Assert.That(remoteValue, Is.InstanceOf<WindowProxyRemoteValue>());
-            WindowProxyRemoteValue windowProxyRemoteValue = (WindowProxyRemoteValue)remoteValue;
-            Assert.That(windowProxyRemoteValue.Handle, Is.Null);
-            Assert.That(windowProxyRemoteValue.InternalId, Is.Null);
-            Assert.That(windowProxyRemoteValue.Value.Context, Is.EqualTo("myContext"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Window, remoteValue.Type);
+        Assert.IsType<WindowProxyRemoteValue>(remoteValue);
+        WindowProxyRemoteValue windowProxyRemoteValue = (WindowProxyRemoteValue)remoteValue;
+        Assert.Null(windowProxyRemoteValue.Handle);
+        Assert.Null(windowProxyRemoteValue.InternalId);
+        Assert.Equal("myContext", windowProxyRemoteValue.Value.Context);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRemoteValueWithHandleAndInternalId()
     {
         string json = """
@@ -1491,21 +1431,19 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(remoteValue.Type, Is.EqualTo(RemoteValueType.Window));
-            Assert.That(remoteValue, Is.InstanceOf<WindowProxyRemoteValue>());
-            WindowProxyRemoteValue windowProxyRemoteValue = (WindowProxyRemoteValue)remoteValue;
-            Assert.That(windowProxyRemoteValue.Handle, Is.Not.Null);
-            Assert.That(windowProxyRemoteValue.Handle, Is.EqualTo("myHandle"));
-            Assert.That(windowProxyRemoteValue.InternalId, Is.Not.Null);
-            Assert.That(windowProxyRemoteValue.InternalId, Is.EqualTo("123"));
-            Assert.That(windowProxyRemoteValue.Value.Context, Is.EqualTo("myContext"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal(RemoteValueType.Window, remoteValue.Type);
+        Assert.IsType<WindowProxyRemoteValue>(remoteValue);
+        WindowProxyRemoteValue windowProxyRemoteValue = (WindowProxyRemoteValue)remoteValue;
+        Assert.NotNull(windowProxyRemoteValue.Handle);
+        Assert.Equal("myHandle", windowProxyRemoteValue.Handle);
+        Assert.NotNull(windowProxyRemoteValue.InternalId);
+        Assert.Equal("123", windowProxyRemoteValue.InternalId);
+        Assert.Equal("myContext", windowProxyRemoteValue.Value.Context);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingInvalidWindowValueRemoteValueThrows()
     {
         string json = """
@@ -1514,10 +1452,10 @@ public class RemoteValueTests
                         "value": "some value"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON value could not be converted"));
+        Assert.Contains("JSON value could not be converted", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRemoteValueWithInvalidHandleTypeThrows()
     {
         string json = """
@@ -1530,10 +1468,10 @@ public class RemoteValueTests
                         "internalId": 123
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowRemoteValueWithInvalidInternalIdTypeThrows()
     {
         string json = """
@@ -1546,10 +1484,10 @@ public class RemoteValueTests
                         "internalId": 123.45
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRemoteValueWithMissingTypeThrows()
     {
         string json = """
@@ -1557,10 +1495,10 @@ public class RemoteValueTests
                         "value": "myValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must contain a 'type' property"));
+        Assert.Contains("must contain a 'type' property", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRemoteValueWithInvalidTypeThrows()
     {
         string json = """
@@ -1569,10 +1507,10 @@ public class RemoteValueTests
                         "value": "myValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("'type' property must be a string"));
+        Assert.Contains("'type' property must be a string", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -1581,10 +1519,10 @@ public class RemoteValueTests
                         "value": "myValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value 'invalid' is not valid for enum type RemoteValueType"));
+        Assert.Contains("value 'invalid' is not valid for enum type RemoteValueType", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingRemoteValueWithEmptyStringTypeThrows()
     {
         string json = """
@@ -1593,10 +1531,10 @@ public class RemoteValueTests
                         "value": "myValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("value '' is not valid for enum type RemoteValueType"));
+        Assert.Contains("value '' is not valid for enum type RemoteValueType", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestValueAsWithIncorrectType()
     {
         string json = """
@@ -1606,14 +1544,12 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => remoteValue.ConvertTo<StringRemoteValue>().Value, Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo($"RemoteValue of type '{remoteValue.Type}' cannot be converted to type 'StringRemoteValue'"));
-        }
+        Assert.NotNull(remoteValue);
+
+        Assert.Equal($"RemoteValue of type '{remoteValue.Type}' cannot be converted to type 'StringRemoteValue'", Assert.ThrowsAny<WebDriverBiDiException>(() => remoteValue.ConvertTo<StringRemoteValue>().Value).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestNullRemoteValueAsValueType()
     {
         string json = """
@@ -1622,18 +1558,18 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NullRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NullRemoteValue>(remoteValue);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingNonObjectThrows()
     {
         string json = @"[ ""invalid remote value"" ]";
-        Assert.That(() => JsonSerializer.Deserialize<RemoteValue>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'RemoteValue' must be an object"));
+        Assert.Contains("JSON for 'RemoteValue' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RemoteValue>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertToRemoteReference()
     {
         string json = """
@@ -1644,14 +1580,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
         ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
         RemoteReference reference = objectReferenceRemoteValue.ToRemoteObjectReference();
-        Assert.That(reference, Is.InstanceOf<RemoteObjectReference>());
+        Assert.IsType<RemoteObjectReference>(reference);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertToRemoteReferenceWithoutHandleThrows()
     {
         string json = """
@@ -1661,16 +1597,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<ObjectReferenceRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<ObjectReferenceRemoteValue>(remoteValue);
         ObjectReferenceRemoteValue objectReferenceRemoteValue = (ObjectReferenceRemoteValue)remoteValue;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => objectReferenceRemoteValue.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("must have a valid handle"));
-        }
+
+        Assert.Contains("must have a valid handle", Assert.ThrowsAny<WebDriverBiDiException>(() => objectReferenceRemoteValue.ToRemoteObjectReference()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertNodeRemoteValueToRemoteReference()
     {
         string json = """
@@ -1686,14 +1620,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)remoteValue;
         RemoteObjectReference reference = nodeRemoteValue.ToRemoteObjectReference();
-        Assert.That(reference.Handle, Is.EqualTo("myHandle"));
+        Assert.Equal("myHandle", reference.Handle);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertNodeRemoteValueWithoutHandleToRemoteReferenceThrows()
     {
         string json = """
@@ -1707,16 +1641,14 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)remoteValue;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => nodeRemoteValue.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("must have a valid handle"));
-        }
+
+        Assert.Contains("must have a valid handle", Assert.ThrowsAny<WebDriverBiDiException>(() => nodeRemoteValue.ToRemoteObjectReference()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertNodeRemoteValueToSharedReference()
     {
         string json = """
@@ -1731,13 +1663,13 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         SharedReference reference = ((NodeRemoteValue)remoteValue).ToSharedReference();
-        Assert.That(reference, Is.InstanceOf<SharedReference>());
+        Assert.IsType<SharedReference>(reference);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertNodeRemoteValueToSharedReferenceWithoutSharedIdThrows()
     {
         string json = """
@@ -1751,13 +1683,13 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue, Is.InstanceOf<NodeRemoteValue>());
+        Assert.NotNull(remoteValue);
+        Assert.IsType<NodeRemoteValue>(remoteValue);
         NodeRemoteValue nodeRemoteValue = (NodeRemoteValue)remoteValue;
-        Assert.That(() => nodeRemoteValue.ToSharedReference(), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("must have a valid shared ID"));
+        Assert.Contains("must have a valid shared ID", Assert.ThrowsAny<WebDriverBiDiException>(() => nodeRemoteValue.ToSharedReference()).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestConvertNonNodeRemoteValueToSharedReferenceThrows()
     {
         string json = """
@@ -1771,7 +1703,7 @@ public class RemoteValueTests
                       }
                       """;
         RemoteValue? remoteValue = JsonSerializer.Deserialize<RemoteValue>(json);
-        Assert.That(remoteValue, Is.Not.Null);
-        Assert.That(remoteValue.TryConvertTo(out NodeRemoteValue? _), Is.False);
+        Assert.NotNull(remoteValue);
+        Assert.False(remoteValue.TryConvertTo(out NodeRemoteValue? _));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RemovePreloadScriptCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RemovePreloadScriptCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class RemovePreloadScriptCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         RemovePreloadScriptCommandParameters properties = new("myLoadScriptId");
-        Assert.That(properties.MethodName, Is.EqualTo("script.removePreloadScript"));
+        Assert.Equal("script.removePreloadScript", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeProperties()
     {
         RemovePreloadScriptCommandParameters properties = new("myLoadScriptId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("script"));
-            Assert.That(serialized["script"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["script"]!.Value<string>(), Is.EqualTo("myLoadScriptId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("script"));
+        JToken? script = serialized["script"];
+        Assert.NotNull(script);
+        Assert.Equal(JTokenType.String, script.Type);
+        Assert.Equal("myLoadScriptId", script.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/RemovePreloadScriptCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/RemovePreloadScriptCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class RemovePreloadScriptCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         RemovePreloadScriptCommandResult? result = JsonSerializer.Deserialize<RemovePreloadScriptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         RemovePreloadScriptCommandResult? result = JsonSerializer.Deserialize<RemovePreloadScriptCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemovePreloadScriptCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
@@ -28,7 +28,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -78,7 +78,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -123,7 +123,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -173,7 +173,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -220,7 +220,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -259,7 +259,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -286,7 +286,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -301,7 +301,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveRealmCreatedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -337,7 +337,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveRealmCreatedEventForNonWindowRealm()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -371,7 +371,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveRealmDestroyedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -400,7 +400,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveMessageEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -456,7 +456,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -484,7 +484,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
@@ -305,16 +305,15 @@ public class ScriptModuleTests
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnRealmCreated.AddObserver((RealmCreatedEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnRealmCreated.AddObserver(e =>
         {
-
             Assert.Equal("myRealm", e.RealmId);
             Assert.Equal("myOrigin", e.Origin);
             Assert.Equal(RealmType.Window, e.Type);
             Assert.Equal("myContext", e.As<WindowRealmInfo>().BrowsingContext);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
@@ -331,8 +330,7 @@ public class ScriptModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -343,15 +341,14 @@ public class ScriptModuleTests
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnRealmCreated.AddObserver((RealmCreatedEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnRealmCreated.AddObserver(e =>
         {
-
             Assert.Equal("myRealm", e.RealmId);
             Assert.Equal("myOrigin", e.Origin);
             Assert.Equal(RealmType.Worker, e.Type);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
@@ -367,8 +364,7 @@ public class ScriptModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -379,11 +375,11 @@ public class ScriptModuleTests
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnRealmDestroyed.AddObserver((RealmDestroyedEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnRealmDestroyed.AddObserver(e =>
         {
             Assert.Equal("myRealm", e.RealmId);
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
@@ -397,8 +393,7 @@ public class ScriptModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -409,10 +404,9 @@ public class ScriptModuleTests
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnMessage.AddObserver((MessageEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnMessage.AddObserver(e =>
         {
-
             Assert.Equal("myChannel", e.ChannelId);
             Assert.NotNull(e.Data);
             Assert.Equal(RemoteValueType.String, e.Data.Type);
@@ -420,7 +414,7 @@ public class ScriptModuleTests
             Assert.NotNull(e.Source);
             Assert.Equal("myRealm", e.Source.RealmId);
 
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
             return Task.CompletedTask;
         });
 
@@ -441,8 +435,7 @@ public class ScriptModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Script;
 using TestUtilities;
 using WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class ScriptModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecuteCallFunctionCommand()
     {
         TestWebSocketConnection connection = new();
@@ -31,27 +30,24 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<EvaluateResult> task = module.CallFunctionAsync(new CallFunctionCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
-        task.Wait(TimeSpan.FromSeconds(1));
-        EvaluateResult result = task.Result;
+        Task<EvaluateResult> task = module.CallFunctionAsync(new CallFunctionCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true), cancellationToken: TestContext.Current.CancellationToken);
+        EvaluateResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.TypeOf<EvaluateResultSuccess>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultSuccess>(result);
         EvaluateResultSuccess? successResult = result as EvaluateResultSuccess;
-        Assert.That(successResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(successResult.RealmId, Is.EqualTo("myRealmId"));
-            Assert.That(successResult.ResultType, Is.EqualTo(EvaluateResultType.Success));
-            Assert.That(successResult.Result, Is.Not.Null);
-            Assert.That(successResult.Result.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(successResult.Result.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myStringValue"));
-        }
+        Assert.NotNull(successResult);
+
+        Assert.Equal("myRealmId", successResult.RealmId);
+        Assert.Equal(EvaluateResultType.Success, successResult.ResultType);
+        Assert.NotNull(successResult.Result);
+        Assert.Equal(RemoteValueType.String, successResult.Result.Type);
+        Assert.Equal("myStringValue", successResult.Result.ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteCallFunctionCommandReturningError()
     {
         TestWebSocketConnection connection = new();
@@ -84,30 +80,27 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<EvaluateResult> task = module.CallFunctionAsync(new CallFunctionCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
-        task.Wait(TimeSpan.FromSeconds(1));
-        EvaluateResult result = task.Result;
+        Task<EvaluateResult> task = module.CallFunctionAsync(new CallFunctionCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true), cancellationToken: TestContext.Current.CancellationToken);
+        EvaluateResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.TypeOf<EvaluateResultException>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultException>(result);
         EvaluateResultException? exceptionResult = result as EvaluateResultException;
-        Assert.That(exceptionResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exceptionResult.RealmId, Is.EqualTo("myRealmId"));
-            Assert.That(exceptionResult.ResultType, Is.EqualTo(EvaluateResultType.Exception));
-            Assert.That(exceptionResult.ExceptionDetails.Text, Is.EqualTo("error received from script"));
-            Assert.That(exceptionResult.ExceptionDetails.LineNumber, Is.EqualTo(2));
-            Assert.That(exceptionResult.ExceptionDetails.ColumnNumber, Is.EqualTo(5));
-            Assert.That(exceptionResult.ExceptionDetails.StackTrace, Is.Not.Null);
-            Assert.That(exceptionResult.ExceptionDetails.StackTrace.CallFrames, Is.Empty);
-            Assert.That(exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myStringValue"));
-        }
+        Assert.NotNull(exceptionResult);
+
+        Assert.Equal("myRealmId", exceptionResult.RealmId);
+        Assert.Equal(EvaluateResultType.Exception, exceptionResult.ResultType);
+        Assert.Equal("error received from script", exceptionResult.ExceptionDetails.Text);
+        Assert.Equal(2, exceptionResult.ExceptionDetails.LineNumber);
+        Assert.Equal(5, exceptionResult.ExceptionDetails.ColumnNumber);
+        Assert.NotNull(exceptionResult.ExceptionDetails.StackTrace);
+        Assert.Empty(exceptionResult.ExceptionDetails.StackTrace.CallFrames);
+        Assert.Equal("myStringValue", exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteEvaluateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -132,27 +125,24 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<EvaluateResult> task = module.EvaluateAsync(new EvaluateCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
-        task.Wait(TimeSpan.FromSeconds(1));
-        EvaluateResult result = task.Result;
+        Task<EvaluateResult> task = module.EvaluateAsync(new EvaluateCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true), cancellationToken: TestContext.Current.CancellationToken);
+        EvaluateResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.TypeOf<EvaluateResultSuccess>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultSuccess>(result);
         EvaluateResultSuccess? successResult = result as EvaluateResultSuccess;
-        Assert.That(successResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(successResult.RealmId, Is.EqualTo("myRealmId"));
-            Assert.That(successResult.ResultType, Is.EqualTo(EvaluateResultType.Success));
-            Assert.That(successResult.Result, Is.Not.Null);
-            Assert.That(successResult.Result.Type, Is.EqualTo(RemoteValueType.String));
-            Assert.That(successResult.Result.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myStringValue"));
-        }
+        Assert.NotNull(successResult);
+
+        Assert.Equal("myRealmId", successResult.RealmId);
+        Assert.Equal(EvaluateResultType.Success, successResult.ResultType);
+        Assert.NotNull(successResult.Result);
+        Assert.Equal(RemoteValueType.String, successResult.Result.Type);
+        Assert.Equal("myStringValue", successResult.Result.ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteEvaluateCommandReturningError()
     {
         TestWebSocketConnection connection = new();
@@ -185,30 +175,27 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<EvaluateResult> task = module.EvaluateAsync(new EvaluateCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
-        task.Wait(TimeSpan.FromSeconds(1));
-        EvaluateResult result = task.Result;
+        Task<EvaluateResult> task = module.EvaluateAsync(new EvaluateCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true), cancellationToken: TestContext.Current.CancellationToken);
+        EvaluateResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.TypeOf<EvaluateResultException>());
+        Assert.NotNull(result);
+        Assert.IsType<EvaluateResultException>(result);
         EvaluateResultException? exceptionResult = result as EvaluateResultException;
-        Assert.That(exceptionResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exceptionResult.RealmId, Is.EqualTo("myRealmId"));
-            Assert.That(exceptionResult.ResultType, Is.EqualTo(EvaluateResultType.Exception));
-            Assert.That(exceptionResult.ExceptionDetails.Text, Is.EqualTo("error received from script"));
-            Assert.That(exceptionResult.ExceptionDetails.LineNumber, Is.EqualTo(2));
-            Assert.That(exceptionResult.ExceptionDetails.ColumnNumber, Is.EqualTo(5));
-            Assert.That(exceptionResult.ExceptionDetails.StackTrace, Is.Not.Null);
-            Assert.That(exceptionResult.ExceptionDetails.StackTrace.CallFrames, Is.Empty);
-            Assert.That(exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myStringValue"));
-        }
+        Assert.NotNull(exceptionResult);
+
+        Assert.Equal("myRealmId", exceptionResult.RealmId);
+        Assert.Equal(EvaluateResultType.Exception, exceptionResult.ResultType);
+        Assert.Equal("error received from script", exceptionResult.ExceptionDetails.Text);
+        Assert.Equal(2, exceptionResult.ExceptionDetails.LineNumber);
+        Assert.Equal(5, exceptionResult.ExceptionDetails.ColumnNumber);
+        Assert.NotNull(exceptionResult.ExceptionDetails.StackTrace);
+        Assert.Empty(exceptionResult.ExceptionDetails.StackTrace.CallFrames);
+        Assert.Equal("myStringValue", exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetRealmsCommand()
     {
         TestWebSocketConnection connection = new();
@@ -235,30 +222,26 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<GetRealmsCommandResult> task = module.GetRealmsAsync(new GetRealmsCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetRealmsCommandResult result = task.Result;
+        Task<GetRealmsCommandResult> task = module.GetRealmsAsync(new GetRealmsCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        GetRealmsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Realms, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Realms[0].Type, Is.EqualTo(RealmType.Window));
-            Assert.That(result.Realms[0], Is.TypeOf<WindowRealmInfo>());
-        }
+        Assert.NotNull(result);
+        Assert.Single(result.Realms);
+
+        Assert.Equal(RealmType.Window, result.Realms[0].Type);
+        Assert.IsType<WindowRealmInfo>(result.Realms[0]);
+
         WindowRealmInfo info = result.Realms[0].As<WindowRealmInfo>();
-        Assert.That(info, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(info.RealmId, Is.EqualTo("myRealmId"));
-            Assert.That(info.Origin, Is.EqualTo("myOrigin"));
-            Assert.That(info.BrowsingContext, Is.EqualTo("myContextId"));
-        }
+        Assert.NotNull(info);
+
+        Assert.Equal("myRealmId", info.RealmId);
+        Assert.Equal("myOrigin", info.Origin);
+        Assert.Equal("myContextId", info.BrowsingContext);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteGetRealmsCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -278,17 +261,16 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<GetRealmsCommandResult> task = module.GetRealmsAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetRealmsCommandResult result = task.Result;
+        Task<GetRealmsCommandResult> task = module.GetRealmsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        GetRealmsCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Realms, Has.Count.EqualTo(0));
+        Assert.NotNull(result);
+        Assert.Empty(result.Realms);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteDisownCommand()
     {
         TestWebSocketConnection connection = new();
@@ -306,34 +288,32 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<DisownCommandResult> task = module.DisownAsync(new DisownCommandParameters(new ContextTarget("myContextId"), new string[] { "myValue" }));
-        task.Wait(TimeSpan.FromSeconds(1));
-        DisownCommandResult result = task.Result;
+        Task<DisownCommandResult> task = module.DisownAsync(new DisownCommandParameters(new ContextTarget("myContextId"), new string[] { "myValue" }), cancellationToken: TestContext.Current.CancellationToken);
+        DisownCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.TypeOf<DisownCommandResult>());
+        Assert.NotNull(result);
+        Assert.IsType<DisownCommandResult>(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveRealmCreatedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         ManualResetEvent syncEvent = new(false);
         module.OnRealmCreated.AddObserver((RealmCreatedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.RealmId, Is.EqualTo("myRealm"));
-                Assert.That(e.Origin, Is.EqualTo("myOrigin"));
-                Assert.That(e.Type, Is.EqualTo(RealmType.Window));
-                Assert.That(e.As<WindowRealmInfo>().BrowsingContext, Is.EqualTo("myContext"));
-            }
+
+            Assert.Equal("myRealm", e.RealmId);
+            Assert.Equal("myOrigin", e.Origin);
+            Assert.Equal(RealmType.Window, e.Type);
+            Assert.Equal("myContext", e.As<WindowRealmInfo>().BrowsingContext);
+
             syncEvent.Set();
             return Task.CompletedTask;
         });
@@ -352,26 +332,25 @@ public class ScriptModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveRealmCreatedEventForNonWindowRealm()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         ManualResetEvent syncEvent = new(false);
         module.OnRealmCreated.AddObserver((RealmCreatedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.RealmId, Is.EqualTo("myRealm"));
-                Assert.That(e.Origin, Is.EqualTo("myOrigin"));
-                Assert.That(e.Type, Is.EqualTo(RealmType.Worker));
-            }
+
+            Assert.Equal("myRealm", e.RealmId);
+            Assert.Equal("myOrigin", e.Origin);
+            Assert.Equal(RealmType.Worker, e.Type);
+
             syncEvent.Set();
             return Task.CompletedTask;
         });
@@ -389,21 +368,21 @@ public class ScriptModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveRealmDestroyedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         ManualResetEvent syncEvent = new(false);
         module.OnRealmDestroyed.AddObserver((RealmDestroyedEventArgs e) =>
         {
-            Assert.That(e.RealmId, Is.EqualTo("myRealm"));
+            Assert.Equal("myRealm", e.RealmId);
             syncEvent.Set();
             return Task.CompletedTask;
         });
@@ -419,29 +398,28 @@ public class ScriptModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanReceiveMessageEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         ManualResetEvent syncEvent = new(false);
         module.OnMessage.AddObserver((MessageEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.ChannelId, Is.EqualTo("myChannel"));
-                Assert.That(e.Data, Is.Not.Null);
-                Assert.That(e.Data.Type, Is.EqualTo(RemoteValueType.String));
-                Assert.That(e.Data.ConvertTo<StringRemoteValue>().Value, Is.EqualTo("myChannelValue"));
-                Assert.That(e.Source, Is.Not.Null);
-                Assert.That(e.Source.RealmId, Is.EqualTo("myRealm"));
-            }
+
+            Assert.Equal("myChannel", e.ChannelId);
+            Assert.NotNull(e.Data);
+            Assert.Equal(RemoteValueType.String, e.Data.Type);
+            Assert.Equal("myChannelValue", e.Data.ConvertTo<StringRemoteValue>().Value);
+            Assert.NotNull(e.Source);
+            Assert.Equal("myRealm", e.Source.RealmId);
+
             syncEvent.Set();
             return Task.CompletedTask;
         });
@@ -464,10 +442,10 @@ public class ScriptModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromSeconds(1));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanAddPreloadScript()
     {
         TestWebSocketConnection connection = new();
@@ -487,18 +465,17 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<AddPreloadScriptCommandResult> task = module.AddPreloadScriptAsync(new AddPreloadScriptCommandParameters("window.foo = false;"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        AddPreloadScriptCommandResult result = task.Result;
+        Task<AddPreloadScriptCommandResult> task = module.AddPreloadScriptAsync(new AddPreloadScriptCommandParameters("window.foo = false;"), cancellationToken: TestContext.Current.CancellationToken);
+        AddPreloadScriptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result, Is.TypeOf<AddPreloadScriptCommandResult>());
-        Assert.That(result.PreloadScriptId, Is.EqualTo("loadScriptId"));
+        Assert.NotNull(result);
+        Assert.IsType<AddPreloadScriptCommandResult>(result);
+        Assert.Equal("loadScriptId", result.PreloadScriptId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestCanRemovePreloadScript()
     {
         TestWebSocketConnection connection = new();
@@ -516,12 +493,11 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = driver.Script;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<RemovePreloadScriptCommandResult> task = module.RemovePreloadScriptAsync(new RemovePreloadScriptCommandParameters("loadScriptId"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        RemovePreloadScriptCommandResult result = task.Result;
+        Task<RemovePreloadScriptCommandResult> task = module.RemovePreloadScriptAsync(new RemovePreloadScriptCommandParameters("loadScriptId"), cancellationToken: TestContext.Current.CancellationToken);
+        RemovePreloadScriptCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/SerializationOptionsTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/SerializationOptionsTests.cs
@@ -3,23 +3,20 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SerializationOptionsTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeOptions()
     {
         SerializationOptions options = new();
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Is.Empty);
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeOptionsWithOptionalMaxDomDepth()
     {
         SerializationOptions options = new()
@@ -28,17 +25,17 @@ public class SerializationOptionsTests
         };
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("maxDomDepth"));
-            Assert.That(serialized["maxDomDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxDomDepth"]!.Value<long>, Is.EqualTo(1));
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("maxDomDepth"));
+        JToken? maxDomDepth = serialized["maxDomDepth"];
+        Assert.NotNull(maxDomDepth);
+        Assert.Equal(JTokenType.Integer, maxDomDepth.Type);
+        Assert.Equal(1L, maxDomDepth.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeOptionsWithOptionalInfiniteMaxDomDepth()
     {
         SerializationOptions options = new()
@@ -47,16 +44,16 @@ public class SerializationOptionsTests
         };
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("maxDomDepth"));
-            Assert.That(serialized["maxDomDepth"]!.Type, Is.EqualTo(JTokenType.Null));
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("maxDomDepth"));
+        JToken? maxDomDepth = serialized["maxDomDepth"];
+        Assert.NotNull(maxDomDepth);
+        Assert.Equal(JTokenType.Null, maxDomDepth.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeOptionsWithOptionalMaxObjectDepth()
     {
         SerializationOptions options = new()
@@ -65,17 +62,17 @@ public class SerializationOptionsTests
         };
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("maxObjectDepth"));
-            Assert.That(serialized["maxObjectDepth"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["maxObjectDepth"]!.Value<long>, Is.EqualTo(1));
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("maxObjectDepth"));
+        JToken? maxObjectDepth = serialized["maxObjectDepth"];
+        Assert.NotNull(maxObjectDepth);
+        Assert.Equal(JTokenType.Integer, maxObjectDepth.Type);
+        Assert.Equal(1L, maxObjectDepth.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeOptionsWithOptionalIncludeShadowTree()
     {
         SerializationOptions options = new()
@@ -84,17 +81,17 @@ public class SerializationOptionsTests
         };
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("includeShadowTree"));
-            Assert.That(serialized["includeShadowTree"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["includeShadowTree"]!.Value<string>, Is.EqualTo("none"));
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("includeShadowTree"));
+        JToken? includeShadowTree = serialized["includeShadowTree"];
+        Assert.NotNull(includeShadowTree);
+        Assert.Equal(JTokenType.String, includeShadowTree.Type);
+        Assert.Equal("none", includeShadowTree.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeOptionsWithOptionalIncludeOpenShadowTree()
     {
         SerializationOptions options = new()
@@ -103,17 +100,17 @@ public class SerializationOptionsTests
         };
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("includeShadowTree"));
-            Assert.That(serialized["includeShadowTree"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["includeShadowTree"]!.Value<string>, Is.EqualTo("open"));
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("includeShadowTree"));
+        JToken? includeShadowTree = serialized["includeShadowTree"];
+        Assert.NotNull(includeShadowTree);
+        Assert.Equal(JTokenType.String, includeShadowTree.Type);
+        Assert.Equal("open", includeShadowTree.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeOptionsWithOptionalIncludeAllShadowTree()
     {
         SerializationOptions options = new()
@@ -122,13 +119,13 @@ public class SerializationOptionsTests
         };
         string json = JsonSerializer.Serialize(options);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized.Type, Is.EqualTo(JTokenType.Object));
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("includeShadowTree"));
-            Assert.That(serialized["includeShadowTree"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["includeShadowTree"]!.Value<string>, Is.EqualTo("all"));
-        }
+
+        Assert.Equal(JTokenType.Object, serialized.Type);
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("includeShadowTree"));
+        JToken? includeShadowTree = serialized["includeShadowTree"];
+        Assert.NotNull(includeShadowTree);
+        Assert.Equal(JTokenType.String, includeShadowTree.Type);
+        Assert.Equal("all", includeShadowTree.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/SharedReferenceTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/SharedReferenceTests.cs
@@ -3,24 +3,23 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SharedReferenceTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeSharedReference()
     {
         SharedReference reference = new("mySharedId");
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("sharedId"));
-            Assert.That(referenceObject["sharedId"]!.Value<string>(), Is.EqualTo("mySharedId"));
-        }
+        Assert.Single(referenceObject);
+
+        Assert.True(referenceObject.ContainsKey("sharedId"));
+        JToken? sharedId = referenceObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal("mySharedId", sharedId.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanEditSharedReferenceSharedId()
     {
         SharedReference reference = new("mySharedId")
@@ -29,15 +28,15 @@ public class SharedReferenceTests
         };
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("sharedId"));
-            Assert.That(referenceObject["sharedId"]!.Value<string>(), Is.EqualTo("myNewSharedId"));
-        }
+        Assert.Single(referenceObject);
+
+        Assert.True(referenceObject.ContainsKey("sharedId"));
+        JToken? sharedId = referenceObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal("myNewSharedId", sharedId.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeSharedReferenceWithHandle()
     {
         SharedReference reference = new("mySharedId")
@@ -46,54 +45,57 @@ public class SharedReferenceTests
         };
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("sharedId"));
-            Assert.That(referenceObject["sharedId"]!.Value<string>(), Is.EqualTo("mySharedId"));
-            Assert.That(referenceObject, Contains.Key("handle"));
-            Assert.That(referenceObject["handle"]!.Value<string>(), Is.EqualTo("myHandle"));
-        }
+        Assert.Equal(2, referenceObject.Count);
+
+        Assert.True(referenceObject.ContainsKey("sharedId"));
+        JToken? sharedId = referenceObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal("mySharedId", sharedId.Value<string>());
+
+        Assert.True(referenceObject.ContainsKey("handle"));
+        JToken? handle = referenceObject["handle"];
+        Assert.NotNull(handle);
+        Assert.Equal("myHandle", handle.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestSharedReferenceCopySemantics()
     {
         SharedReference reference = new("mySharedId");
         SharedReference copy = reference with { };
-        Assert.That(copy, Is.EqualTo(reference));
+        Assert.Equal(reference, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestSharedReferenceSharedIdGetterReturnsValue()
     {
         SharedReference reference = new("mySharedId");
-        Assert.That(reference.SharedId, Is.EqualTo("mySharedId"));
+        Assert.Equal("mySharedId", reference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestSharedReferenceSharedIdSetterSetsValue()
     {
         SharedReference reference = new("mySharedId");
         reference.SharedId = "myNewSharedId";
-        Assert.That(reference.SharedId, Is.EqualTo("myNewSharedId"));
+        Assert.Equal("myNewSharedId", reference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingSharedReferenceHandleToNullThrows()
     {
         SharedReference reference = new("mySharedId");
-        Assert.That(() => reference.SharedId = null!, Throws.InstanceOf<ArgumentNullException>());
+        Assert.ThrowsAny<ArgumentNullException>(() => reference.SharedId = null!);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingSharedReferenceThrowsWhenSharedIdIsMissing()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<SharedReference>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SharedReference>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingSharedReferenceThrowsWhenSharedIdIsInvalidType()
     {
         string json = """
@@ -101,24 +103,27 @@ public class SharedReferenceTests
                         "sharedId": 123
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SharedReference>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SharedReference>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeSharedReferenceWithAdditionalProperties()
     {
         SharedReference reference = new("mySharedId");
         reference.AdditionalData["myPropertyName"] = "myValue";
         string json = JsonSerializer.Serialize(reference);
         JObject referenceObject = JObject.Parse(json);
-        Assert.That(referenceObject, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(referenceObject, Contains.Key("sharedId"));
-            Assert.That(referenceObject["sharedId"]!.Value<string>(), Is.EqualTo("mySharedId"));
-            Assert.That(referenceObject, Contains.Key("myPropertyName"));
-            Assert.That(referenceObject["myPropertyName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(referenceObject["myPropertyName"]!.Value<string>(), Is.EqualTo("myValue"));
-        }
+        Assert.Equal(2, referenceObject.Count);
+
+        Assert.True(referenceObject.ContainsKey("sharedId"));
+        JToken? sharedId = referenceObject["sharedId"];
+        Assert.NotNull(sharedId);
+        Assert.Equal("mySharedId", sharedId.Value<string>());
+
+        Assert.True(referenceObject.ContainsKey("myPropertyName"));
+        JToken? myPropertyName = referenceObject["myPropertyName"];
+        Assert.NotNull(myPropertyName);
+        Assert.Equal(JTokenType.String, myPropertyName.Type);
+        Assert.Equal("myValue", myPropertyName.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/SourceTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/SourceTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SourceTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,15 +13,13 @@ public class SourceTests
                       }
                       """;
         Source? source = JsonSerializer.Deserialize<Source>(json);
-        Assert.That(source, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(source.Context, Is.Null);
-        }
+        Assert.NotNull(source);
+
+        Assert.Equal("realmId", source.RealmId);
+        Assert.Null(source.Context);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -31,19 +28,19 @@ public class SourceTests
                       }
                       """;
         Source? source = JsonSerializer.Deserialize<Source>(json);
-        Assert.That(source, Is.Not.Null);
+        Assert.NotNull(source);
         Source copy = source with { };
-        Assert.That(copy, Is.EqualTo(source));
+        Assert.Equal(source, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingRealmThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<Source>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Source>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidRealmTypeThrows()
     {
         string json = """
@@ -51,10 +48,10 @@ public class SourceTests
                         "realm": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Source>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Source>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalContext()
     {
         string json = """
@@ -64,16 +61,14 @@ public class SourceTests
                       }
                       """;
         Source? source = JsonSerializer.Deserialize<Source>(json);
-        Assert.That(source, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(source.Context, Is.Not.Null);
-            Assert.That(source.Context, Is.EqualTo("contextId"));
-        }
+        Assert.NotNull(source);
+
+        Assert.Equal("realmId", source.RealmId);
+        Assert.NotNull(source.Context);
+        Assert.Equal("contextId", source.Context);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithOptionalUserContext()
     {
         string json = """
@@ -83,16 +78,14 @@ public class SourceTests
                       }
                       """;
         Source? source = JsonSerializer.Deserialize<Source>(json);
-        Assert.That(source, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(source.RealmId, Is.EqualTo("realmId"));
-            Assert.That(source.UserContext, Is.Not.Null);
-            Assert.That(source.UserContext, Is.EqualTo("userContextId"));
-        }
+        Assert.NotNull(source);
+
+        Assert.Equal("realmId", source.RealmId);
+        Assert.NotNull(source.UserContext);
+        Assert.Equal("userContextId", source.UserContext);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidFlagsTypeThrows()
     {
         string json = """
@@ -101,6 +94,6 @@ public class SourceTests
                         "context": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<Source>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Source>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/StackFrameTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/StackFrameTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class StackFrameTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -17,17 +16,15 @@ public class StackFrameTests
                       }
                       """;
         StackFrame? stackFrame = JsonSerializer.Deserialize<StackFrame>(json);
-        Assert.That(stackFrame, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(stackFrame.FunctionName, Is.EqualTo("myFunction"));
-            Assert.That(stackFrame.LineNumber, Is.EqualTo(1));
-            Assert.That(stackFrame.ColumnNumber, Is.EqualTo(5));
-            Assert.That(stackFrame.Url, Is.EqualTo("http://some.url/file.js"));
-        }
+        Assert.NotNull(stackFrame);
+
+        Assert.Equal("myFunction", stackFrame.FunctionName);
+        Assert.Equal(1, stackFrame.LineNumber);
+        Assert.Equal(5, stackFrame.ColumnNumber);
+        Assert.Equal("http://some.url/file.js", stackFrame.Url);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -39,12 +36,12 @@ public class StackFrameTests
                       }
                       """;
         StackFrame? stackFrame = JsonSerializer.Deserialize<StackFrame>(json);
-        Assert.That(stackFrame, Is.Not.Null);
+        Assert.NotNull(stackFrame);
         StackFrame copy = stackFrame with { };
-        Assert.That(copy, Is.EqualTo(stackFrame));
+        Assert.Equal(stackFrame, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingFunctionNameThrows()
     {
         string json = """
@@ -54,10 +51,10 @@ public class StackFrameTests
                         "url": "http://some.url/file.js"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidFunctionNameTypeThrows()
     {
         string json = """
@@ -68,10 +65,10 @@ public class StackFrameTests
                         "url": "http://some.url/file.js"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingLineNumberThrows()
     {
         string json = """
@@ -81,10 +78,10 @@ public class StackFrameTests
                         "url": "http://some.url/file.js"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidLineNumberTypeThrows()
     {
         string json = """
@@ -95,10 +92,10 @@ public class StackFrameTests
                         "url": "http://some.url/file.js"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingColumnNumberThrows()
     {
         string json = """
@@ -108,10 +105,10 @@ public class StackFrameTests
                         "url": "http://some.url/file.js"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidColumnNumberTypeThrows()
     {
         string json = """
@@ -122,10 +119,10 @@ public class StackFrameTests
                         "url": "http://some.url/file.js"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingUrlThrows()
     {
         string json = """
@@ -135,10 +132,10 @@ public class StackFrameTests
                         "columnNumber": 5
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidUrlTypeThrows()
     {
         string json = """
@@ -149,6 +146,6 @@ public class StackFrameTests
                         "url": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackFrame>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackFrame>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/StackTraceTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/StackTraceTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class StackTraceTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -21,16 +20,14 @@ public class StackTraceTests
                       }
                       """;
         StackTrace? stacktrace = JsonSerializer.Deserialize<StackTrace>(json);
-        Assert.That(stacktrace, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(stacktrace.CallFrames, Is.Not.Null);
-            Assert.That(stacktrace.CallFrames, Has.Count.EqualTo(1));
-            Assert.That(stacktrace.CallFrames[0], Is.TypeOf<StackFrame>());
-        }
+        Assert.NotNull(stacktrace);
+
+        Assert.NotNull(stacktrace.CallFrames);
+        Assert.Single(stacktrace.CallFrames);
+        Assert.IsType<StackFrame>(stacktrace.CallFrames[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -46,19 +43,19 @@ public class StackTraceTests
                       }
                       """;
         StackTrace? stacktrace = JsonSerializer.Deserialize<StackTrace>(json);
-        Assert.That(stacktrace, Is.Not.Null);
+        Assert.NotNull(stacktrace);
         StackTrace copy = stacktrace with { };
-        Assert.That(copy, Is.EqualTo(stacktrace));
+        Assert.Equal(stacktrace, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingCallFramesThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<StackTrace>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackTrace>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidCallFramesTypeThrows()
     {
         string json = """
@@ -73,6 +70,6 @@ public class StackTraceTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StackTrace>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StackTrace>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/StringRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/StringRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class StringRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeStringRemoteValue()
     {
         string json = """
@@ -17,12 +16,12 @@ public class StringRemoteValueTests
 
         StringRemoteValue? result = JsonSerializer.Deserialize<StringRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.String));
-        Assert.That(result.Value, Is.EqualTo("my string value"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.String, result.Type);
+        Assert.Equal("my string value", result.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -34,15 +33,15 @@ public class StringRemoteValueTests
 
         StringRemoteValue? result = JsonSerializer.Deserialize<StringRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("string"));
-        Assert.That(argumentLocalValue.Value, Is.InstanceOf<string>());
-        Assert.That(argumentLocalValue.Value, Is.EqualTo("my string value"));
+        Assert.Equal("string", argumentLocalValue.Type);
+        Assert.IsType<string>(argumentLocalValue.Value);
+        Assert.Equal("my string value", argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestCanUseImplicitConversionToString()
     {
         string json = """
@@ -54,12 +53,12 @@ public class StringRemoteValueTests
 
         StringRemoteValue? result = JsonSerializer.Deserialize<StringRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         string stringValue = result;
-        Assert.That(stringValue, Is.EqualTo("my string value"));
+        Assert.Equal("my string value", stringValue);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingStringRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -68,10 +67,10 @@ public class StringRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<StringRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StringRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingStringRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -81,10 +80,10 @@ public class StringRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<StringRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StringRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingStringRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -94,10 +93,10 @@ public class StringRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<StringRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StringRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -108,9 +107,9 @@ public class StringRemoteValueTests
                       """;
 
         StringRemoteValue? result = JsonSerializer.Deserialize<StringRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         StringRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/TargetTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/TargetTests.cs
@@ -3,77 +3,71 @@ namespace WebDriverBiDi.Script;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class TargetTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeRealmTarget()
     {
         string json = @"{ ""realm"": ""myRealm"" }";
         Target? target = JsonSerializer.Deserialize<Target>(json);
-        Assert.That(target, Is.Not.Null);
-        Assert.That(target, Is.InstanceOf<RealmTarget>());
-        RealmTarget realmTarget = (RealmTarget)target!;
-        Assert.That(realmTarget.RealmId, Is.EqualTo("myRealm"));
+        Assert.NotNull(target);
+        Assert.IsType<RealmTarget>(target);
+        RealmTarget realmTarget = (RealmTarget)target;
+        Assert.Equal("myRealm", realmTarget.RealmId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeContextTarget()
     {
         string json = @"{ ""context"": ""myContext"" }";
         Target? target = JsonSerializer.Deserialize<Target>(json);
-        Assert.That(target, Is.Not.Null);
-        Assert.That(target, Is.InstanceOf<ContextTarget>());
-        ContextTarget contextTarget = (ContextTarget)target!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(contextTarget.BrowsingContextId, Is.EqualTo("myContext"));
-            Assert.That(contextTarget.Sandbox, Is.Null);
-        }
+        Assert.NotNull(target);
+        Assert.IsType<ContextTarget>(target);
+        ContextTarget contextTarget = (ContextTarget)target;
+
+        Assert.Equal("myContext", contextTarget.BrowsingContextId);
+        Assert.Null(contextTarget.Sandbox);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeContextTargetWithSandbox()
     {
         string json = @"{ ""context"": ""myContext"", ""sandbox"": ""mySandbox"" }";
         Target? target = JsonSerializer.Deserialize<Target>(json);
-        Assert.That(target, Is.Not.Null);
-        Assert.That(target, Is.InstanceOf<ContextTarget>());
-        ContextTarget contextTarget = (ContextTarget)target!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(contextTarget.BrowsingContextId, Is.EqualTo("myContext"));
-            Assert.That(contextTarget.Sandbox, Is.EqualTo("mySandbox"));
-        }
+        Assert.NotNull(target);
+        Assert.IsType<ContextTarget>(target);
+        ContextTarget contextTarget = (ContextTarget)target;
+
+        Assert.Equal("myContext", contextTarget.BrowsingContextId);
+        Assert.Equal("mySandbox", contextTarget.Sandbox);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializationOfInvalidJsonThrows()
     {
         string json = @"{ ""invalid"": ""invalidValue"" }";
-        Assert.That(() => JsonSerializer.Deserialize<ContextTarget>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'context"));
-        Assert.That(() => JsonSerializer.Deserialize<RealmTarget>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("missing required properties including: 'realm"));
-        Assert.That(() => JsonSerializer.Deserialize<Target>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'Target' must contain one of the following properties: context, realm"));
-        Assert.That(() => JsonSerializer.Deserialize<Target>(@"[ ""invalid target"" ]"), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'Target' must be an object"));
+        Assert.Contains("missing required properties including: 'context", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ContextTarget>(json)).Message);
+        Assert.Contains("missing required properties including: 'realm", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<RealmTarget>(json)).Message);
+        Assert.Contains("JSON for 'Target' must contain one of the following properties: context, realm", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Target>(json)).Message);
+        Assert.Contains("JSON for 'Target' must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Target>(@"[ ""invalid target"" ]")).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeRealmTarget()
     {
         Target target = new RealmTarget("myRealm");
         string json = JsonSerializer.Serialize(target);
         JObject deserialized = JObject.Parse(json);
-        Assert.That(deserialized, Has.Count.EqualTo(1));
-        Assert.That(deserialized, Contains.Key("realm"));
-        JToken realmValue = deserialized.GetValue("realm")!;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(realmValue.Type, Is.EqualTo(JTokenType.String));
-            Assert.That((string?)realmValue, Is.EqualTo("myRealm"));
-        }
+        Assert.Single(deserialized);
+        Assert.True(deserialized.ContainsKey("realm"));
+        JToken? realmValue = deserialized.GetValue("realm");
+        Assert.NotNull(realmValue);
+
+        Assert.Equal(JTokenType.String, realmValue.Type);
+        Assert.Equal("myRealm", (string?)realmValue);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeContextTarget()
     {
         Target target = new ContextTarget("myContext")
@@ -82,35 +76,34 @@ public class TargetTests
         };
         string json = JsonSerializer.Serialize(target);
         JObject deserialized = JObject.Parse(json);
-        Assert.That(deserialized, Has.Count.EqualTo(2));
-        Assert.That(deserialized, Contains.Key("context"));
-        JToken contextValue = deserialized.GetValue("context")!;
-        JToken sandboxValue = deserialized.GetValue("sandbox")!;
+        Assert.Equal(2, deserialized.Count);
+        Assert.True(deserialized.ContainsKey("context"));
+        JToken? contextValue = deserialized.GetValue("context");
+        Assert.NotNull(contextValue);
+        JToken? sandboxValue = deserialized.GetValue("sandbox");
+        Assert.NotNull(sandboxValue);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(contextValue.Type, Is.EqualTo(JTokenType.String));
-            Assert.That((string?)contextValue, Is.EqualTo("myContext"));
-            Assert.That(sandboxValue.Type, Is.EqualTo(JTokenType.String));
-            Assert.That((string?)sandboxValue, Is.EqualTo("mySandbox"));
-        }
+        Assert.Equal(JTokenType.String, contextValue.Type);
+        Assert.Equal("myContext", (string?)contextValue);
+        Assert.Equal(JTokenType.String, sandboxValue.Type);
+        Assert.Equal("mySandbox", (string?)sandboxValue);
     }
 
-    [Test]
+    [Fact]
     public void TestContextTargetCopySemantics()
     {
         Target target = new ContextTarget("myContext");
         Target copy = target with { };
-        Assert.That(copy, Is.InstanceOf<ContextTarget>());
-        Assert.That(copy, Is.EqualTo(target));
+        Assert.IsType<ContextTarget>(copy);
+        Assert.Equal(target, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestRealmTargetCopySemantics()
     {
         Target target = new RealmTarget("myContext");
         Target copy = target with { };
-        Assert.That(copy, Is.InstanceOf<RealmTarget>());
-        Assert.That(copy, Is.EqualTo(target));
+        Assert.IsType<RealmTarget>(copy);
+        Assert.Equal(target, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/UndefinedRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/UndefinedRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class UndefinedRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeUndefinedRemoteValue()
     {
         string json = """
@@ -16,11 +15,11 @@ public class UndefinedRemoteValueTests
 
         UndefinedRemoteValue? result = JsonSerializer.Deserialize<UndefinedRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Undefined));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Undefined, result.Type);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -31,14 +30,14 @@ public class UndefinedRemoteValueTests
 
         UndefinedRemoteValue? result = JsonSerializer.Deserialize<UndefinedRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         LocalArgumentValue argumentLocalValue = (LocalArgumentValue)localValue;
-        Assert.That(argumentLocalValue.Type, Is.EqualTo("undefined"));
-        Assert.That(argumentLocalValue.Value, Is.Null);
+        Assert.Equal("undefined", argumentLocalValue.Type);
+        Assert.Null(argumentLocalValue.Value);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingStringRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -47,10 +46,10 @@ public class UndefinedRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<UndefinedRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UndefinedRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -60,9 +59,9 @@ public class UndefinedRemoteValueTests
                       """;
 
         UndefinedRemoteValue? result = JsonSerializer.Deserialize<UndefinedRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UndefinedRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/WindowProxyPropertiesTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/WindowProxyPropertiesTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class WindowProxyPropertiesTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,10 +13,10 @@ public class WindowProxyPropertiesTests
                       }
                       """;
         WindowProxyProperties windowProxyProperties = JsonSerializer.Deserialize<WindowProxyProperties>(json);
-        Assert.That(windowProxyProperties.Context, Is.EqualTo("myContextId"));
+        Assert.Equal("myContextId", windowProxyProperties.Context);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,10 +26,10 @@ public class WindowProxyPropertiesTests
                       """;
         WindowProxyProperties windowProxyProperties = JsonSerializer.Deserialize<WindowProxyProperties>(json);
         WindowProxyProperties copy = windowProxyProperties;
-        Assert.That(copy, Is.EqualTo(windowProxyProperties));
+        Assert.Equal(windowProxyProperties, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidContextTypeThrows()
     {
         string json = """
@@ -38,10 +37,10 @@ public class WindowProxyPropertiesTests
                         "context": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyProperties>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithMissingContextThrows()
     {
         string json = """
@@ -49,6 +48,6 @@ public class WindowProxyPropertiesTests
                         "nodeType": 1
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyProperties>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyProperties>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Script/WindowProxyRemoteValueTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/WindowProxyRemoteValueTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Script;
 
 using System.Text.Json;
 
-[TestFixture]
 public class WindowProxyRemoteValueTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWindowProxyRemoteValue()
     {
         string json = """
@@ -19,14 +18,14 @@ public class WindowProxyRemoteValueTests
 
         WindowProxyRemoteValue? result = JsonSerializer.Deserialize<WindowProxyRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Window));
-        Assert.That(result.Value.Context, Is.EqualTo("myContextid"));
-        Assert.That(result.Handle, Is.Null);
-        Assert.That(result.InternalId, Is.Null);
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Window, result.Type);
+        Assert.Equal("myContextid", result.Value.Context);
+        Assert.Null(result.Handle);
+        Assert.Null(result.InternalId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWindowProxyRemoteValueWithHandle()
     {
         string json = """
@@ -42,15 +41,14 @@ public class WindowProxyRemoteValueTests
 
         WindowProxyRemoteValue? result = JsonSerializer.Deserialize<WindowProxyRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Type, Is.EqualTo(RemoteValueType.Window));
-        Assert.That(result.Value.Context, Is.EqualTo("myContextid"));
-        Assert.That(result.Handle, Is.EqualTo("myHandle"));
-        Assert.That(result.InternalId, Is.EqualTo("myInternalId"));
+        Assert.NotNull(result);
+        Assert.Equal(RemoteValueType.Window, result.Type);
+        Assert.Equal("myContextid", result.Value.Context);
+        Assert.Equal("myHandle", result.Handle);
+        Assert.Equal("myInternalId", result.InternalId);
     }
 
-
-    [Test]
+    [Fact]
     public void TestCanConvertToLocalValue()
     {
         string json = """
@@ -66,14 +64,14 @@ public class WindowProxyRemoteValueTests
 
         WindowProxyRemoteValue? result = JsonSerializer.Deserialize<WindowProxyRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         LocalValue localValue = result.ToLocalValue();
         RemoteObjectReference remoteObjectReference = (RemoteObjectReference)localValue;
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestCanConvertToRemoteObjectReference()
     {
         string json = """
@@ -89,13 +87,13 @@ public class WindowProxyRemoteValueTests
 
         WindowProxyRemoteValue? result = JsonSerializer.Deserialize<WindowProxyRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         RemoteObjectReference remoteObjectReference = result.ToRemoteObjectReference();
-        Assert.That(remoteObjectReference.Handle, Is.EqualTo("myHandle"));
-        Assert.That(remoteObjectReference.SharedId, Is.Null);
+        Assert.Equal("myHandle", remoteObjectReference.Handle);
+        Assert.Null(remoteObjectReference.SharedId);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowProxyRemoteValueWithMissingValueThrows()
     {
         string json = """
@@ -104,10 +102,10 @@ public class WindowProxyRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowProxyRemoteValueWithInvalidValueTypeThrows()
     {
         string json = """
@@ -117,10 +115,10 @@ public class WindowProxyRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowProxyRemoteValueWithInvalidTypeValueThrows()
     {
         string json = """
@@ -132,10 +130,10 @@ public class WindowProxyRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowProxyRemoteValueWithInvalidHandleTypeThrows()
     {
         string json = """
@@ -149,10 +147,10 @@ public class WindowProxyRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWindowProxyRemoteValueWithInvalidInternalIdTypeThrows()
     {
         string json = """
@@ -166,10 +164,10 @@ public class WindowProxyRemoteValueTests
                       }
                       """;
 
-        Assert.That(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<WindowProxyRemoteValue>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestConvertingToRemoteObjectReferenceWithoutHandleThrows()
     {
         string json = """
@@ -183,11 +181,11 @@ public class WindowProxyRemoteValueTests
 
         WindowProxyRemoteValue? result = JsonSerializer.Deserialize<WindowProxyRemoteValue>(json);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(() => result.ToRemoteObjectReference(), Throws.InstanceOf<WebDriverBiDiException>());
+        Assert.NotNull(result);
+        Assert.ThrowsAny<WebDriverBiDiException>(() => result.ToRemoteObjectReference());
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -200,9 +198,9 @@ public class WindowProxyRemoteValueTests
                       """;
 
         WindowProxyRemoteValue? result = JsonSerializer.Deserialize<WindowProxyRemoteValue>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         WindowProxyRemoteValue copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
-        Assert.That(copy, Is.Not.SameAs(result));
+        Assert.Equal(result, copy);
+        Assert.NotSame(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/CapabilitiesResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/CapabilitiesResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class CapabilitiesResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -20,24 +19,22 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.Proxy, Is.Null);
-            Assert.That(result.UnhandledPromptBehavior, Is.Null);
-            Assert.That(result.WebSocketUrl, Is.Null);
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.True(result.SetWindowRect);
+        Assert.Null(result.Proxy);
+        Assert.Null(result.UnhandledPromptBehavior);
+        Assert.Null(result.WebSocketUrl);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithWebSocketUrl()
     {
         string json = """
@@ -53,24 +50,22 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Null);
-            Assert.That(result.UnhandledPromptBehavior, Is.Null);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.WebSocketUrl, Is.EqualTo("ws://socket:1234"));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.Null(result.Proxy);
+        Assert.Null(result.UnhandledPromptBehavior);
+        Assert.True(result.SetWindowRect);
+        Assert.Equal("ws://socket:1234", result.WebSocketUrl);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeManualWithFullProxyProperties()
     {
         string json = """
@@ -93,30 +88,29 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            ManualProxyConfigurationResult proxyResult = result.Proxy!.ProxyConfigurationResultAs<ManualProxyConfigurationResult>();
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.Manual));
-            Assert.That(proxyResult.HttpProxy, Is.EqualTo("http.proxy"));
-            Assert.That(proxyResult.SslProxy, Is.EqualTo("ssl.proxy"));
-            Assert.That(proxyResult.SocksProxy, Is.EqualTo("socks.proxy"));
-            Assert.That(proxyResult.SocksVersion, Is.EqualTo(5));
-            Assert.That(proxyResult.NoProxyAddresses, Has.Count.EqualTo(1));
-            Assert.That(proxyResult.AdditionalData, Is.Empty);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        ManualProxyConfigurationResult proxyResult = result.Proxy.ProxyConfigurationResultAs<ManualProxyConfigurationResult>();
+        Assert.Equal(ProxyType.Manual, proxyResult.ProxyType);
+        Assert.Equal("http.proxy", proxyResult.HttpProxy);
+        Assert.Equal("ssl.proxy", proxyResult.SslProxy);
+        Assert.Equal("socks.proxy", proxyResult.SocksProxy);
+        Assert.Equal(5, proxyResult.SocksVersion);
+        Assert.NotNull(proxyResult.NoProxyAddresses);
+        Assert.Single(proxyResult.NoProxyAddresses);
+        Assert.Empty(proxyResult.AdditionalData);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeProxyAutoConfigWithFullProxyProperties()
     {
         string json = """
@@ -135,26 +129,24 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            PacProxyConfigurationResult proxyResult = result.Proxy!.ProxyConfigurationResultAs<PacProxyConfigurationResult>();
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.ProxyAutoConfig));
-            Assert.That(proxyResult.ProxyAutoConfigUrl, Is.EqualTo("proxy.autoconfig.url"));
-            Assert.That(proxyResult.AdditionalData, Is.Empty);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        PacProxyConfigurationResult proxyResult = result.Proxy.ProxyConfigurationResultAs<PacProxyConfigurationResult>();
+        Assert.Equal(ProxyType.ProxyAutoConfig, proxyResult.ProxyType);
+        Assert.Equal("proxy.autoconfig.url", proxyResult.ProxyAutoConfigUrl);
+        Assert.Empty(proxyResult.AdditionalData);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeAutoDetectWithFullProxyProperties()
     {
         string json = """
@@ -172,25 +164,23 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            AutoDetectProxyConfigurationResult proxyResult = result.Proxy!.ProxyConfigurationResultAs<AutoDetectProxyConfigurationResult>();
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.AutoDetect));
-            Assert.That(proxyResult.AdditionalData, Is.Empty);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        AutoDetectProxyConfigurationResult proxyResult = result.Proxy.ProxyConfigurationResultAs<AutoDetectProxyConfigurationResult>();
+        Assert.Equal(ProxyType.AutoDetect, proxyResult.ProxyType);
+        Assert.Empty(proxyResult.AdditionalData);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeSystemWithFullProxyProperties()
     {
         string json = """
@@ -208,25 +198,23 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            SystemProxyConfigurationResult proxyResult = result.Proxy!.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.System));
-            Assert.That(proxyResult.AdditionalData, Is.Empty);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        SystemProxyConfigurationResult proxyResult = result.Proxy.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
+        Assert.Equal(ProxyType.System, proxyResult.ProxyType);
+        Assert.Empty(proxyResult.AdditionalData);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeDirectWithFullProxyProperties()
     {
         string json = """
@@ -244,25 +232,23 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            DirectProxyConfigurationResult proxyResult = result.Proxy!.ProxyConfigurationResultAs<DirectProxyConfigurationResult>();
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.Direct));
-            Assert.That(proxyResult.AdditionalData, Is.Empty);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        DirectProxyConfigurationResult proxyResult = result.Proxy.ProxyConfigurationResultAs<DirectProxyConfigurationResult>();
+        Assert.Equal(ProxyType.Direct, proxyResult.ProxyType);
+        Assert.Empty(proxyResult.AdditionalData);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyContainingAdditionalData()
     {
         string json = """
@@ -281,28 +267,26 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            SystemProxyConfigurationResult proxyResult = result.Proxy!.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.System));
-            Assert.That(proxyResult.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(proxyResult.AdditionalData, Contains.Key("additionalName"));
-            Assert.That(proxyResult.AdditionalData["additionalName"], Is.InstanceOf<string>());
-            Assert.That(proxyResult.AdditionalData["additionalName"], Is.EqualTo("additionalValue"));
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        SystemProxyConfigurationResult proxyResult = result.Proxy.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
+        Assert.Equal(ProxyType.System, proxyResult.ProxyType);
+        Assert.Single(proxyResult.AdditionalData);
+        Assert.True(proxyResult.AdditionalData.ContainsKey("additionalName"));
+        Assert.IsType<string>(proxyResult.AdditionalData["additionalName"]);
+        Assert.Equal("additionalValue", proxyResult.AdditionalData["additionalName"]);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -317,12 +301,12 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         CapabilitiesResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithInvalidProxyTypeThrows()
     {
         // spell-checker: disable
@@ -342,44 +326,11 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'ProxyConfiguration' proxyType property contains unknown value 'proxyautoconfig'"));
+        Assert.Contains("JSON for 'ProxyConfiguration' proxyType property contains unknown value 'proxyautoconfig'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json)).Message);
         // spell-checker: enable
     }
 
-    // TODO (Issue #19): Remove this test and enable the one below
-    // once https://bugzilla.mozilla.org/show_bug.cgi?id=1916463 is fixed.
-    // [Test]
-    public void TestDeserializeWithEmptyProxyYieldsNull()
-    {
-        string json = """
-                      {
-                        "browserName": "greatBrowser",
-                        "browserVersion": "101.5b",
-                        "platformName": "otherOS",
-                        "userAgent": "WebDriverBidi.NET/1.0",
-                        "acceptInsecureCerts": true,
-                        "proxy": {},
-                        "setWindowRect": true,
-                        "capName": "capValue"
-                      }
-                      """;
-        CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Null);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
-    }
-
-    [Test]
+    [Fact]
     public void TestCannotDeserializeWithEmptyProxy()
     {
         string json = """
@@ -394,10 +345,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must contain a 'proxyType' property"));
+        Assert.Contains("must contain a 'proxyType' property", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithFullUnhandledPromptBehavior()
     {
         string json = """
@@ -419,27 +370,25 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.UnhandledPromptBehavior, Is.Not.Null);
-            UserPromptHandlerResult userPromptHandler = result.UnhandledPromptBehavior!;
-            Assert.That(userPromptHandler.Default, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(userPromptHandler.Alert, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(userPromptHandler.Confirm, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(userPromptHandler.Prompt, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(userPromptHandler.BeforeUnload, Is.EqualTo(UserPromptHandlerType.Ignore));
-            Assert.That(userPromptHandler.File, Is.EqualTo(UserPromptHandlerType.Ignore));
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.UnhandledPromptBehavior);
+        UserPromptHandlerResult userPromptHandler = result.UnhandledPromptBehavior;
+        Assert.Equal(UserPromptHandlerType.Accept, userPromptHandler.Default);
+        Assert.Equal(UserPromptHandlerType.Accept, userPromptHandler.Alert);
+        Assert.Equal(UserPromptHandlerType.Dismiss, userPromptHandler.Confirm);
+        Assert.Equal(UserPromptHandlerType.Dismiss, userPromptHandler.Prompt);
+        Assert.Equal(UserPromptHandlerType.Ignore, userPromptHandler.BeforeUnload);
+        Assert.Equal(UserPromptHandlerType.Ignore, userPromptHandler.File);
+        Assert.True(result.SetWindowRect);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNoUnhandledPromptBehavior()
     {
         string json = """
@@ -454,26 +403,24 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.UnhandledPromptBehavior, Is.Not.Null);
-            UserPromptHandlerResult userPromptHandler = result.UnhandledPromptBehavior!;
-            Assert.That(userPromptHandler.Default, Is.Null);
-            Assert.That(userPromptHandler.Alert, Is.Null);
-            Assert.That(userPromptHandler.Confirm, Is.Null);
-            Assert.That(userPromptHandler.Prompt, Is.Null);
-            Assert.That(userPromptHandler.BeforeUnload, Is.Null);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.UnhandledPromptBehavior);
+        UserPromptHandlerResult userPromptHandler = result.UnhandledPromptBehavior;
+        Assert.Null(userPromptHandler.Default);
+        Assert.Null(userPromptHandler.Alert);
+        Assert.Null(userPromptHandler.Confirm);
+        Assert.Null(userPromptHandler.Prompt);
+        Assert.Null(userPromptHandler.BeforeUnload);
+        Assert.True(result.SetWindowRect);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithPartialUnhandledPromptBehavior()
     {
         string json = """
@@ -490,26 +437,24 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.UnhandledPromptBehavior, Is.Not.Null);
-            UserPromptHandlerResult userPromptHandler = result.UnhandledPromptBehavior!;
-            Assert.That(userPromptHandler.Default, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(userPromptHandler.Alert, Is.Null);
-            Assert.That(userPromptHandler.Confirm, Is.Null);
-            Assert.That(userPromptHandler.Prompt, Is.Null);
-            Assert.That(userPromptHandler.BeforeUnload, Is.Null);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.UnhandledPromptBehavior);
+        UserPromptHandlerResult userPromptHandler = result.UnhandledPromptBehavior;
+        Assert.Equal(UserPromptHandlerType.Accept, userPromptHandler.Default);
+        Assert.Null(userPromptHandler.Alert);
+        Assert.Null(userPromptHandler.Confirm);
+        Assert.Null(userPromptHandler.Prompt);
+        Assert.Null(userPromptHandler.BeforeUnload);
+        Assert.True(result.SetWindowRect);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializingWithInvalidUnhandledPromptBehaviorThrows()
     {
         string json = """
@@ -523,10 +468,10 @@ public class CapabilitiesResultTests
                         "unhandledPromptBehavior": "accept"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNoAdditionalProperties()
     {
         string json = """
@@ -543,21 +488,19 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result!.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Proxy, Is.Not.Null);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.AcceptInsecureCertificates);
+        Assert.Equal("greatBrowser", result.BrowserName);
+        Assert.Equal("101.5b", result.BrowserVersion);
+        Assert.Equal("otherOS", result.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.UserAgent);
+        Assert.NotNull(result.Proxy);
+        Assert.True(result.SetWindowRect);
+        Assert.Empty(result.AdditionalCapabilities);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingBrowserNameThrows()
     {
         string json = """
@@ -573,10 +516,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingBrowserVersionThrows()
     {
         string json = """
@@ -592,10 +535,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingPlatformNameThrows()
     {
         string json = """
@@ -611,10 +554,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingUserAgentThrows()
     {
         string json = """
@@ -630,10 +573,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingAcceptInsecureCertificatesThrows()
     {
         string json = """
@@ -649,10 +592,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingSetWindowRectThrows()
     {
         string json = """
@@ -668,10 +611,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidProxyTypeThrows()
     {
         string json = """
@@ -686,10 +629,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidUnhandledPromptTypeThrows()
     {
         string json = """
@@ -704,10 +647,10 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestProxyReturnsCachedInstanceOnRepeatedAccess()
     {
         string json = """
@@ -724,14 +667,14 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? first = result.Proxy;
         ProxyConfigurationResult? second = result.Proxy;
-        Assert.That(first, Is.Not.Null);
-        Assert.That(second, Is.SameAs(first));
+        Assert.NotNull(first);
+        Assert.Same(first, second);
     }
 
-    [Test]
+    [Fact]
     public void TestAdditionalCapabilitiesReturnsCachedInstanceOnRepeatedAccess()
     {
         string json = """
@@ -746,13 +689,13 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ReceivedDataDictionary first = result.AdditionalCapabilities;
         ReceivedDataDictionary second = result.AdditionalCapabilities;
-        Assert.That(first, Is.SameAs(second));
+        Assert.Same(second, first);
     }
 
-    [Test]
+    [Fact]
     public void TestUnhandledPromptBehaviorReturnsCachedInstanceOnRepeatedAccess()
     {
         string json = """
@@ -769,17 +712,17 @@ public class CapabilitiesResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UserPromptHandlerResult? first = result.UnhandledPromptBehavior;
         UserPromptHandlerResult? second = result.UnhandledPromptBehavior;
-        Assert.That(first, Is.Not.Null);
-        Assert.That(second, Is.SameAs(first));
+        Assert.NotNull(first);
+        Assert.Same(first, second);
     }
 
-    [Test]
+    [Fact]
     public void TestProxyReturnsCachedInstanceForEachProxyType()
     {
-        string[] proxyJsonValues = [ "\"proxyType\": \"direct\"", "\"proxyType\": \"system\"", "\"proxyType\": \"autodetect\"", "\"proxyType\": \"pac\", \"proxyAutoconfigUrl\": \"http://proxy.example\"", "\"proxyType\": \"manual\", \"httpProxy\": \"http.proxy\"" ];
+        string[] proxyJsonValues = ["\"proxyType\": \"direct\"", "\"proxyType\": \"system\"", "\"proxyType\": \"autodetect\"", "\"proxyType\": \"pac\", \"proxyAutoconfigUrl\": \"http://proxy.example\"", "\"proxyType\": \"manual\", \"httpProxy\": \"http.proxy\""];
         foreach (string proxyJson in proxyJsonValues)
         {
             string json = $$"""
@@ -794,15 +737,15 @@ public class CapabilitiesResultTests
                           }
                           """;
             CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-            Assert.That(result, Is.Not.Null);
+            Assert.NotNull(result);
             ProxyConfigurationResult? first = result.Proxy;
             ProxyConfigurationResult? second = result.Proxy;
-            Assert.That(first, Is.Not.Null);
-            Assert.That(second, Is.SameAs(first));
+            Assert.NotNull(first);
+            Assert.Same(first, second);
         }
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidWebSocketUrlTypeThrows()
     {
         string json = """
@@ -820,6 +763,6 @@ public class CapabilitiesResultTests
                         "capName": "capValue"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<CapabilitiesResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<CapabilitiesResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/CapabilityRequestTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/CapabilityRequestTests.cs
@@ -3,19 +3,18 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class CapabilityRequestTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         CapabilityRequest capabilities = new();
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Is.Empty);
+        Assert.Empty(result);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithBrowserName()
     {
         CapabilityRequest capabilities = new()
@@ -24,16 +23,16 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("browserName"));
-            Assert.That(result["browserName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(result["browserName"]!.Value<string>(), Is.EqualTo("greatBrowser"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("browserName"));
+        JToken? browserName = result["browserName"];
+        Assert.NotNull(browserName);
+        Assert.Equal(JTokenType.String, browserName.Type);
+        Assert.Equal("greatBrowser", browserName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithBrowserVersion()
     {
         CapabilityRequest capabilities = new()
@@ -42,16 +41,16 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("browserVersion"));
-            Assert.That(result["browserVersion"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(result["browserVersion"]!.Value<string>(), Is.EqualTo("101.5b"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("browserVersion"));
+        JToken? browserVersion = result["browserVersion"];
+        Assert.NotNull(browserVersion);
+        Assert.Equal(JTokenType.String, browserVersion.Type);
+        Assert.Equal("101.5b", browserVersion.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithPlatformName()
     {
         CapabilityRequest capabilities = new()
@@ -60,16 +59,16 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("platformName"));
-            Assert.That(result["platformName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(result["platformName"]!.Value<string>(), Is.EqualTo("oddOS"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("platformName"));
+        JToken? platformName = result["platformName"];
+        Assert.NotNull(platformName);
+        Assert.Equal(JTokenType.String, platformName.Type);
+        Assert.Equal("oddOS", platformName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAcceptInsecureCertificatesTrue()
     {
         CapabilityRequest capabilities = new()
@@ -78,16 +77,16 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("acceptInsecureCerts"));
-            Assert.That(result["acceptInsecureCerts"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(result["acceptInsecureCerts"]!.Value<bool>(), Is.True);
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("acceptInsecureCerts"));
+        JToken? acceptInsecureCerts = result["acceptInsecureCerts"];
+        Assert.NotNull(acceptInsecureCerts);
+        Assert.Equal(JTokenType.Boolean, acceptInsecureCerts.Type);
+        Assert.True(acceptInsecureCerts.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAcceptInsecureCertificatesFalse()
     {
         CapabilityRequest capabilities = new()
@@ -96,16 +95,16 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("acceptInsecureCerts"));
-            Assert.That(result["acceptInsecureCerts"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(result["acceptInsecureCerts"]!.Value<bool>(), Is.False);
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("acceptInsecureCerts"));
+        JToken? acceptInsecureCerts = result["acceptInsecureCerts"];
+        Assert.NotNull(acceptInsecureCerts);
+        Assert.Equal(JTokenType.Boolean, acceptInsecureCerts.Type);
+        Assert.False(acceptInsecureCerts.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithUnhandledPromptBehavior()
     {
         CapabilityRequest capabilities = new()
@@ -117,23 +116,25 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("unhandledPromptBehavior"));
-            Assert.That(result["unhandledPromptBehavior"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? proxyObject = result["unhandledPromptBehavior"] as JObject;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyObject, Has.Count.EqualTo(1));
-            Assert.That(proxyObject, Contains.Key("alert"));
-            Assert.That(proxyObject!["alert"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(proxyObject["alert"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("unhandledPromptBehavior"));
+        JToken? unhandledPromptBehaviorToken = result["unhandledPromptBehavior"];
+        Assert.NotNull(unhandledPromptBehaviorToken);
+        Assert.Equal(JTokenType.Object, unhandledPromptBehaviorToken.Type);
+
+        JObject? proxyObject = unhandledPromptBehaviorToken as JObject;
+        Assert.NotNull(proxyObject);
+        Assert.Single(proxyObject);
+
+        Assert.True(proxyObject.ContainsKey("alert"));
+        JToken? alert = proxyObject["alert"];
+        Assert.NotNull(alert);
+        Assert.Equal(JTokenType.String, alert.Type);
+        Assert.Equal("accept", alert.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithProxy()
     {
         CapabilityRequest capabilities = new()
@@ -142,61 +143,68 @@ public class CapabilityRequestTests
         };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("proxy"));
-            Assert.That(result["proxy"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? proxyObject = result["proxy"] as JObject;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyObject, Has.Count.EqualTo(2));
-            Assert.That(proxyObject, Contains.Key("proxyType"));
-            Assert.That(proxyObject!["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(proxyObject["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(proxyObject!, Contains.Key("httpProxy"));
-            Assert.That(proxyObject!["httpProxy"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(proxyObject["httpProxy"]!.Value<string>(), Is.EqualTo("http.proxy"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("proxy"));
+        JToken? proxyToken = result["proxy"];
+        Assert.NotNull(proxyToken);
+        Assert.Equal(JTokenType.Object, proxyToken.Type);
+
+        JObject? proxyObject = proxyToken as JObject;
+        Assert.NotNull(proxyObject);
+        Assert.Equal(2, proxyObject.Count);
+
+        Assert.True(proxyObject.ContainsKey("proxyType"));
+        JToken? proxyType = proxyObject["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(proxyObject.ContainsKey("httpProxy"));
+        JToken? httpProxy = proxyObject["httpProxy"];
+        Assert.NotNull(httpProxy);
+        Assert.Equal(JTokenType.String, httpProxy.Type);
+        Assert.Equal("http.proxy", httpProxy.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAdditionalCapabilities()
     {
         CapabilityRequest capabilities = new();
         capabilities.AdditionalCapabilities["capName"] = "capValue";
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("capName"));
-            Assert.That(result["capName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(result["capName"]!.Value<string>(), Is.EqualTo("capValue"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("capName"));
+        JToken? capName = result["capName"];
+        Assert.NotNull(capName);
+        Assert.Equal(JTokenType.String, capName.Type);
+        Assert.Equal("capValue", capName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAdditionalCapabilitiesObject()
     {
         CapabilityRequest capabilities = new();
         capabilities.AdditionalCapabilities["additional"] = new Dictionary<string, object?>() { { "capName", "capValue" } };
         string json = JsonSerializer.Serialize(capabilities);
         JObject result = JObject.Parse(json);
-        Assert.That(result, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result, Contains.Key("additional"));
-            Assert.That(result["additional"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? additionalObject = result["additional"] as JObject;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(additionalObject, Has.Count.EqualTo(1));
-            Assert.That(additionalObject!, Contains.Key("capName"));
-            Assert.That(additionalObject!["capName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(additionalObject!["capName"]!.Value<string>(), Is.EqualTo("capValue"));
-        }
+        Assert.Single(result);
+
+        Assert.True(result.ContainsKey("additional"));
+        JToken? additionalToken = result["additional"];
+        Assert.NotNull(additionalToken);
+        Assert.Equal(JTokenType.Object, additionalToken.Type);
+
+        JObject? additionalObject = additionalToken as JObject;
+        Assert.NotNull(additionalObject);
+        Assert.Single(additionalObject);
+
+        Assert.True(additionalObject.ContainsKey("capName"));
+        JToken? capName = additionalObject["capName"];
+        Assert.NotNull(capName);
+        Assert.Equal(JTokenType.String, capName.Type);
+        Assert.Equal("capValue", capName.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/EndCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/EndCommandParametersTests.cs
@@ -3,22 +3,21 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class EndCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         EndCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("session.end"));
+        Assert.Equal("session.end", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         EndCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/EndCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/EndCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class EndCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         EndCommandResult? result = JsonSerializer.Deserialize<EndCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         EndCommandResult? result = JsonSerializer.Deserialize<EndCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         EndCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/NewCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/NewCommandParametersTests.cs
@@ -3,27 +3,28 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class NewCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         NewCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("session.new"));
+        Assert.Equal("session.new", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         NewCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Contains.Key("capabilities"));
-        Assert.That(serialized["capabilities"], Is.Empty);
+        Assert.True(serialized.ContainsKey("capabilities"));
+        JObject? capabilities = serialized["capabilities"] as JObject;
+        Assert.NotNull(capabilities);
+        Assert.Empty(capabilities);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAlwaysMatch()
     {
         NewCommandParameters properties = new()
@@ -35,24 +36,27 @@ public class NewCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("capabilities"));
+        Assert.Single(serialized);
 
-            Assert.That(serialized["capabilities"], Contains.Key("alwaysMatch"));
-            Assert.That(serialized["capabilities"]!["alwaysMatch"]!.Type, Is.EqualTo(JTokenType.Object));
-        }
-        JObject? alwaysMatch = serialized["capabilities"]["alwaysMatch"] as JObject;
-        Assert.That(alwaysMatch, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(alwaysMatch!, Contains.Key("browserName"));
-            Assert.That(alwaysMatch!["browserName"]!.Value<string>(), Is.EqualTo("greatBrowser"));
-        }
+        Assert.True(serialized.ContainsKey("capabilities"));
+        JObject? capabilities = serialized["capabilities"] as JObject;
+        Assert.NotNull(capabilities);
+        Assert.True(capabilities.ContainsKey("alwaysMatch"));
+        JToken? alwaysMatchToken = capabilities["alwaysMatch"];
+        Assert.NotNull(alwaysMatchToken);
+        Assert.Equal(JTokenType.Object, alwaysMatchToken.Type);
+
+        JObject? alwaysMatch = alwaysMatchToken as JObject;
+        Assert.NotNull(alwaysMatch);
+        Assert.Single(alwaysMatch);
+
+        Assert.True(alwaysMatch.ContainsKey("browserName"));
+        JToken? browserName = alwaysMatch["browserName"];
+        Assert.NotNull(browserName);
+        Assert.Equal("greatBrowser", browserName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithFirstMatch()
     {
         NewCommandParameters properties = new()
@@ -64,24 +68,27 @@ public class NewCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("capabilities"));
-            Assert.That(serialized["capabilities"], Contains.Key("firstMatch"));
-            Assert.That(serialized["capabilities"]!["firstMatch"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
-        JArray? firstMatch = serialized["capabilities"]["firstMatch"] as JArray;
-        Assert.That(firstMatch, Is.Not.Null);
-        Assert.That(firstMatch, Has.Count.EqualTo(1));
-        Assert.That(firstMatch![0].Type, Is.EqualTo(JTokenType.Object));
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("capabilities"));
+        JObject? capabilities = serialized["capabilities"] as JObject;
+        Assert.NotNull(capabilities);
+        Assert.True(capabilities.ContainsKey("firstMatch"));
+        JToken? firstMatchToken = capabilities["firstMatch"];
+        Assert.NotNull(firstMatchToken);
+        Assert.Equal(JTokenType.Array, firstMatchToken.Type);
+
+        JArray? firstMatch = firstMatchToken as JArray;
+        Assert.NotNull(firstMatch);
+        Assert.Single(firstMatch);
+        Assert.Equal(JTokenType.Object, firstMatch[0].Type);
 
         JObject? firstMatchElement = firstMatch[0] as JObject;
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(firstMatchElement, Has.Count.EqualTo(1));
-            Assert.That(firstMatchElement!, Contains.Key("browserName"));
-            Assert.That(firstMatchElement!["browserName"]!.Value<string>(), Is.EqualTo("greatBrowser"));
-        }
+        Assert.NotNull(firstMatchElement);
+        Assert.Single(firstMatchElement);
+        Assert.True(firstMatchElement.ContainsKey("browserName"));
+        JToken? browserName = firstMatchElement["browserName"];
+        Assert.NotNull(browserName);
+        Assert.Equal("greatBrowser", browserName.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/NewCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/NewCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class NewCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -27,28 +26,26 @@ public class NewCommandResultTests
                       }
                       """;
         NewCommandResult? result = JsonSerializer.Deserialize<NewCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.SessionId, Is.EqualTo("mySession"));
-            Assert.That(result.Capabilities.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.Capabilities.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.Capabilities.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.Capabilities.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Capabilities.AcceptInsecureCertificates, Is.EqualTo(true));
-            Assert.That(result.Capabilities.Proxy, Is.Not.Null);
-            ProxyConfigurationResult proxyResult = result.Capabilities.Proxy!;
-            Assert.That(proxyResult.ProxyType, Is.EqualTo(ProxyType.Manual));
-            Assert.That(proxyResult.ProxyConfigurationResultAs<ManualProxyConfigurationResult>().HttpProxy, Is.EqualTo("http.proxy"));
-            Assert.That(result.Capabilities.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.Capabilities.AdditionalCapabilities, Has.Count.EqualTo(1));
-            Assert.That(result.Capabilities.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.Capabilities.AdditionalCapabilities["capName"], Is.Not.Null);
-            Assert.That(result.Capabilities.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("mySession", result.SessionId);
+        Assert.Equal("greatBrowser", result.Capabilities.BrowserName);
+        Assert.Equal("101.5b", result.Capabilities.BrowserVersion);
+        Assert.Equal("otherOS", result.Capabilities.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.Capabilities.UserAgent);
+        Assert.True(result.Capabilities.AcceptInsecureCertificates);
+        Assert.NotNull(result.Capabilities.Proxy);
+        ProxyConfigurationResult proxyResult = result.Capabilities.Proxy;
+        Assert.Equal(ProxyType.Manual, proxyResult.ProxyType);
+        Assert.Equal("http.proxy", proxyResult.ProxyConfigurationResultAs<ManualProxyConfigurationResult>().HttpProxy);
+        Assert.True(result.Capabilities.SetWindowRect);
+        Assert.Single(result.Capabilities.AdditionalCapabilities);
+        Assert.True(result.Capabilities.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.NotNull(result.Capabilities.AdditionalCapabilities["capName"]);
+        Assert.Equal("capValue", result.Capabilities.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -70,12 +67,12 @@ public class NewCommandResultTests
                       }
                       """;
         NewCommandResult? result = JsonSerializer.Deserialize<NewCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         NewCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingSessionIdThrows()
     {
         string json = """
@@ -95,10 +92,10 @@ public class NewCommandResultTests
                         }
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NewCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NewCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingCapabilitiesThrows()
     {
         string json = """
@@ -106,6 +103,6 @@ public class NewCommandResultTests
                         "sessionId": "mySession"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<NewCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<NewCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/ProxyConfigurationResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/ProxyConfigurationResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class ProxyConfigurationResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeManualProxyConfigurationResult()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -31,24 +30,23 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<ManualProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<ManualProxyConfigurationResult>(proxyResult);
         ManualProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<ManualProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.Manual));
-            Assert.That(proxyConfig.HttpProxy, Is.EqualTo("http.proxy"));
-            Assert.That(proxyConfig.SslProxy, Is.EqualTo("ssl.proxy"));
-            Assert.That(proxyConfig.SocksProxy, Is.EqualTo("socks.proxy"));
-            Assert.That(proxyConfig.SocksVersion, Is.EqualTo(5));
-            Assert.That(proxyConfig.NoProxyAddresses, Has.Count.EqualTo(1));
-            Assert.That(proxyConfig.AdditionalData, Is.Empty);
-        }
+
+        Assert.Equal(ProxyType.Manual, proxyConfig.ProxyType);
+        Assert.Equal("http.proxy", proxyConfig.HttpProxy);
+        Assert.Equal("ssl.proxy", proxyConfig.SslProxy);
+        Assert.Equal("socks.proxy", proxyConfig.SocksProxy);
+        Assert.Equal(5, proxyConfig.SocksVersion);
+        Assert.NotNull(proxyConfig.NoProxyAddresses);
+        Assert.Single(proxyConfig.NoProxyAddresses);
+        Assert.Empty(proxyConfig.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeManualProxyConfigurationResultWithNullNoProxyList()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -73,24 +71,22 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<ManualProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<ManualProxyConfigurationResult>(proxyResult);
         ManualProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<ManualProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.Manual));
-            Assert.That(proxyConfig.HttpProxy, Is.EqualTo("http.proxy"));
-            Assert.That(proxyConfig.SslProxy, Is.EqualTo("ssl.proxy"));
-            Assert.That(proxyConfig.SocksProxy, Is.EqualTo("socks.proxy"));
-            Assert.That(proxyConfig.SocksVersion, Is.EqualTo(5));
-            Assert.That(proxyConfig.NoProxyAddresses, Is.Null);
-            Assert.That(proxyConfig.AdditionalData, Is.Empty);
-        }
+
+        Assert.Equal(ProxyType.Manual, proxyConfig.ProxyType);
+        Assert.Equal("http.proxy", proxyConfig.HttpProxy);
+        Assert.Equal("ssl.proxy", proxyConfig.SslProxy);
+        Assert.Equal("socks.proxy", proxyConfig.SocksProxy);
+        Assert.Equal(5, proxyConfig.SocksVersion);
+        Assert.Null(proxyConfig.NoProxyAddresses);
+        Assert.Empty(proxyConfig.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestManualProxyConfigurationResultCopySemantics()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -116,16 +112,16 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<ManualProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<ManualProxyConfigurationResult>(proxyResult);
         ManualProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<ManualProxyConfigurationResult>();
         ManualProxyConfigurationResult copy = proxyConfig with { };
-        Assert.That(copy, Is.EqualTo(proxyConfig));
+        Assert.Equal(proxyConfig, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeProxyAutoConfigProxyConfigurationResult()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -147,20 +143,18 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<PacProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<PacProxyConfigurationResult>(proxyResult);
         PacProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<PacProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.ProxyAutoConfig));
-            Assert.That(proxyConfig.ProxyAutoConfigUrl, Is.EqualTo("proxy.autoconfig.url"));
-            Assert.That(proxyConfig.AdditionalData, Is.Empty);
-        }
+
+        Assert.Equal(ProxyType.ProxyAutoConfig, proxyConfig.ProxyType);
+        Assert.Equal("proxy.autoconfig.url", proxyConfig.ProxyAutoConfigUrl);
+        Assert.Empty(proxyConfig.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeProxyAutoConfigProxyConfigurationResultCopySemantics()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -182,16 +176,16 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<PacProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<PacProxyConfigurationResult>(proxyResult);
         PacProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<PacProxyConfigurationResult>();
         PacProxyConfigurationResult copy = proxyConfig with { };
-        Assert.That(copy, Is.EqualTo(proxyConfig));
+        Assert.Equal(proxyConfig, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeAutoDetectProxyConfigurationResult()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -212,19 +206,17 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<AutoDetectProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<AutoDetectProxyConfigurationResult>(proxyResult);
         AutoDetectProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<AutoDetectProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.AutoDetect));
-            Assert.That(proxyConfig.AdditionalData, Is.Empty);
-        }
+
+        Assert.Equal(ProxyType.AutoDetect, proxyConfig.ProxyType);
+        Assert.Empty(proxyConfig.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestAutoDetectProxyConfigurationResultCopySemantics()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -245,16 +237,16 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<AutoDetectProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<AutoDetectProxyConfigurationResult>(proxyResult);
         AutoDetectProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<AutoDetectProxyConfigurationResult>();
         AutoDetectProxyConfigurationResult copy = proxyConfig with { };
-        Assert.That(copy, Is.EqualTo(proxyConfig));
+        Assert.Equal(proxyConfig, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeSystemProxyConfigurationResult()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -275,22 +267,20 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<SystemProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<SystemProxyConfigurationResult>(proxyResult);
         SystemProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.System));
-            Assert.That(proxyConfig.AdditionalData, Is.Empty);
-            Assert.That(result.SetWindowRect, Is.EqualTo(true));
-            Assert.That(result.AdditionalCapabilities, Contains.Key("capName"));
-            Assert.That(result.AdditionalCapabilities["capName"], Is.EqualTo("capValue"));
-        }
+
+        Assert.Equal(ProxyType.System, proxyConfig.ProxyType);
+        Assert.Empty(proxyConfig.AdditionalData);
+        Assert.True(result.SetWindowRect);
+        Assert.True(result.AdditionalCapabilities.ContainsKey("capName"));
+        Assert.Equal("capValue", result.AdditionalCapabilities["capName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestSystemProxyConfigurationResultCopySemantics()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -311,16 +301,16 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<SystemProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<SystemProxyConfigurationResult>(proxyResult);
         SystemProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
         SystemProxyConfigurationResult copy = proxyConfig with { };
-        Assert.That(copy, Is.EqualTo(proxyConfig));
+        Assert.Equal(proxyConfig, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeDirectProxyConfigurationResult()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -341,19 +331,17 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<DirectProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<DirectProxyConfigurationResult>(proxyResult);
         DirectProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<DirectProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.Direct));
-            Assert.That(proxyConfig.AdditionalData, Is.Empty);
-        }
+
+        Assert.Equal(ProxyType.Direct, proxyConfig.ProxyType);
+        Assert.Empty(proxyConfig.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestDirectProxyConfigurationResultCopySemantics()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -374,16 +362,16 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<DirectProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<DirectProxyConfigurationResult>(proxyResult);
         DirectProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<DirectProxyConfigurationResult>();
         DirectProxyConfigurationResult copy = proxyConfig with { };
-        Assert.That(copy, Is.EqualTo(proxyConfig));
+        Assert.Equal(proxyConfig, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyContainingAdditionalData()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -405,18 +393,16 @@ public class ProxyConfigurationResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         ProxyConfigurationResult? proxyResult = result.Proxy;
-        Assert.That(proxyResult, Is.Not.Null);
-        Assert.That(proxyResult, Is.InstanceOf<SystemProxyConfigurationResult>());
+        Assert.NotNull(proxyResult);
+        Assert.IsType<SystemProxyConfigurationResult>(proxyResult);
         SystemProxyConfigurationResult proxyConfig = proxyResult.ProxyConfigurationResultAs<SystemProxyConfigurationResult>();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(proxyConfig.ProxyType, Is.EqualTo(ProxyType.System));
-            Assert.That(proxyConfig.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(proxyConfig.AdditionalData, Contains.Key("additionalName"));
-            Assert.That(proxyConfig.AdditionalData["additionalName"], Is.InstanceOf<string>());
-            Assert.That(proxyConfig.AdditionalData["additionalName"], Is.EqualTo("additionalValue"));
-        }
+
+        Assert.Equal(ProxyType.System, proxyConfig.ProxyType);
+        Assert.Single(proxyConfig.AdditionalData);
+        Assert.True(proxyConfig.AdditionalData.ContainsKey("additionalName"));
+        Assert.IsType<string>(proxyConfig.AdditionalData["additionalName"]);
+        Assert.Equal("additionalValue", proxyConfig.AdditionalData["additionalName"]);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/ProxyConfigurationTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/ProxyConfigurationTests.cs
@@ -3,10 +3,9 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ProxyConfigurationTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeWithHttpProxy()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration()
@@ -15,19 +14,22 @@ public class ProxyConfigurationTests
         };
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(serialized, Contains.Key("httpProxy"));
-            Assert.That(serialized["httpProxy"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["httpProxy"]!.Value<string>(), Is.EqualTo("http.proxy"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("httpProxy"));
+        JToken? httpProxy = serialized["httpProxy"];
+        Assert.NotNull(httpProxy);
+        Assert.Equal(JTokenType.String, httpProxy.Type);
+        Assert.Equal("http.proxy", httpProxy.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithSslProxy()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration()
@@ -36,19 +38,22 @@ public class ProxyConfigurationTests
         };
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(serialized, Contains.Key("sslProxy"));
-            Assert.That(serialized["sslProxy"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sslProxy"]!.Value<string>(), Is.EqualTo("ssl.proxy"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sslProxy"));
+        JToken? sslProxy = serialized["sslProxy"];
+        Assert.NotNull(sslProxy);
+        Assert.Equal(JTokenType.String, sslProxy.Type);
+        Assert.Equal("ssl.proxy", sslProxy.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithSocksProxy()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration()
@@ -57,19 +62,22 @@ public class ProxyConfigurationTests
         };
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(serialized, Contains.Key("socksProxy"));
-            Assert.That(serialized["socksProxy"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["socksProxy"]!.Value<string>(), Is.EqualTo("socks.proxy"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("socksProxy"));
+        JToken? socksProxy = serialized["socksProxy"];
+        Assert.NotNull(socksProxy);
+        Assert.Equal(JTokenType.String, socksProxy.Type);
+        Assert.Equal("socks.proxy", socksProxy.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithSocksVersion()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration()
@@ -78,19 +86,22 @@ public class ProxyConfigurationTests
         };
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(serialized, Contains.Key("socksVersion"));
-            Assert.That(serialized["socksVersion"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["socksVersion"]!.Value<long>(), Is.EqualTo(4));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("socksVersion"));
+        JToken? socksVersion = serialized["socksVersion"];
+        Assert.NotNull(socksVersion);
+        Assert.Equal(JTokenType.Integer, socksVersion.Type);
+        Assert.Equal(4L, socksVersion.Value<long>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithNoProxyAddresses()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration()
@@ -99,25 +110,28 @@ public class ProxyConfigurationTests
         };
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(serialized, Contains.Key("noProxy"));
-            Assert.That(serialized["noProxy"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
-        JArray? noProxyArray = serialized["noProxy"] as JArray;
-        Assert.That(noProxyArray, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(noProxyArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(noProxyArray![0].Value<string>(), Is.EqualTo("no.proxy.address"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("noProxy"));
+        JToken? noProxyToken = serialized["noProxy"];
+        Assert.NotNull(noProxyToken);
+        Assert.Equal(JTokenType.Array, noProxyToken.Type);
+
+        JArray? noProxyArray = noProxyToken as JArray;
+        Assert.NotNull(noProxyArray);
+        Assert.Single(noProxyArray);
+
+        Assert.Equal(JTokenType.String, noProxyArray[0].Type);
+        Assert.Equal("no.proxy.address", noProxyArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithEmptyNoProxyAddresses()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration()
@@ -126,117 +140,128 @@ public class ProxyConfigurationTests
         };
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-            Assert.That(serialized, Contains.Key("noProxy"));
-            Assert.That(serialized["noProxy"]!.Type, Is.EqualTo(JTokenType.Array));
-        }
-        JArray? noProxyArray = serialized["noProxy"] as JArray;
-        Assert.That(noProxyArray, Is.Empty);
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("noProxy"));
+        JToken? noProxyToken = serialized["noProxy"];
+        Assert.NotNull(noProxyToken);
+        Assert.Equal(JTokenType.Array, noProxyToken.Type);
+
+        JArray? noProxyArray = noProxyToken as JArray;
+        Assert.NotNull(noProxyArray);
+        Assert.Empty(noProxyArray);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithProxyTypeDirect()
     {
         ProxyConfiguration proxy = new DirectProxyConfiguration();
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("direct"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("direct", proxyType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithProxyTypeManual()
     {
         ProxyConfiguration proxy = new ManualProxyConfiguration();
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("manual"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("manual", proxyType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithProxyTypeSystem()
     {
         ProxyConfiguration proxy = new SystemProxyConfiguration();
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("system"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("system", proxyType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithProxyTypeAutoDetect()
     {
         ProxyConfiguration proxy = new AutoDetectProxyConfiguration();
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("autodetect"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("autodetect", proxyType.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithProxyTypeProxyAutoconfig()
     {
         ProxyConfiguration proxy = new PacProxyConfiguration("proxy.autoconfig.url");
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("pac"));
-            Assert.That(serialized, Contains.Key("proxyAutoconfigUrl"));
-            Assert.That(serialized["proxyAutoconfigUrl"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyAutoconfigUrl"]!.Value<string>(), Is.EqualTo("proxy.autoconfig.url"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("pac", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("proxyAutoconfigUrl"));
+        JToken? proxyAutoconfigUrl = serialized["proxyAutoconfigUrl"];
+        Assert.NotNull(proxyAutoconfigUrl);
+        Assert.Equal(JTokenType.String, proxyAutoconfigUrl.Type);
+        Assert.Equal("proxy.autoconfig.url", proxyAutoconfigUrl.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAdditionalData()
     {
         ProxyConfiguration proxy = new DirectProxyConfiguration();
         proxy.AdditionalData["additionalName"] = "additionalValue";
         string json = JsonSerializer.Serialize(proxy);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("proxyType"));
-            Assert.That(serialized["proxyType"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["proxyType"]!.Value<string>(), Is.EqualTo("direct"));
-            Assert.That(serialized, Contains.Key("additionalName"));
-            Assert.That(serialized["additionalName"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["additionalName"]!.Value<string>(), Is.EqualTo("additionalValue"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("proxyType"));
+        JToken? proxyType = serialized["proxyType"];
+        Assert.NotNull(proxyType);
+        Assert.Equal(JTokenType.String, proxyType.Type);
+        Assert.Equal("direct", proxyType.Value<string>());
+
+        Assert.True(serialized.ContainsKey("additionalName"));
+        JToken? additionalName = serialized["additionalName"];
+        Assert.NotNull(additionalName);
+        Assert.Equal(JTokenType.String, additionalName.Type);
+        Assert.Equal("additionalValue", additionalName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyTypeManual()
     {
         string json = """
@@ -245,20 +270,18 @@ public class ProxyConfigurationTests
                       }
                       """;
         ProxyConfiguration? deserialized = JsonSerializer.Deserialize<ProxyConfiguration>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized!.ProxyType, Is.EqualTo(ProxyType.Manual));
-            Assert.That(deserialized, Is.InstanceOf<ManualProxyConfiguration>());
-            ManualProxyConfiguration deserializedResult = (ManualProxyConfiguration)deserialized;
-            Assert.That(deserializedResult.HttpProxy, Is.Null);
-            Assert.That(deserializedResult.SslProxy, Is.Null);
-            Assert.That(deserializedResult.SocksProxy, Is.Null);
-            Assert.That(deserializedResult.SocksVersion, Is.Null);
-        }
+        Assert.NotNull(deserialized);
+
+        Assert.Equal(ProxyType.Manual, deserialized.ProxyType);
+        Assert.IsType<ManualProxyConfiguration>(deserialized);
+        ManualProxyConfiguration deserializedResult = (ManualProxyConfiguration)deserialized;
+        Assert.Null(deserializedResult.HttpProxy);
+        Assert.Null(deserializedResult.SslProxy);
+        Assert.Null(deserializedResult.SocksProxy);
+        Assert.Null(deserializedResult.SocksVersion);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyTypeSystem()
     {
         string json = """
@@ -267,15 +290,13 @@ public class ProxyConfigurationTests
                       }
                       """;
         ProxyConfiguration? deserialized = JsonSerializer.Deserialize<ProxyConfiguration>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized!.ProxyType, Is.EqualTo(ProxyType.System));
-            Assert.That(deserialized, Is.InstanceOf<SystemProxyConfiguration>());
-        }
+        Assert.NotNull(deserialized);
+
+        Assert.Equal(ProxyType.System, deserialized.ProxyType);
+        Assert.IsType<SystemProxyConfiguration>(deserialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyTypeAutoDetect()
     {
         string json = """
@@ -284,15 +305,13 @@ public class ProxyConfigurationTests
                       }
                       """;
         ProxyConfiguration? deserialized = JsonSerializer.Deserialize<ProxyConfiguration>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized!.ProxyType, Is.EqualTo(ProxyType.AutoDetect));
-            Assert.That(deserialized, Is.InstanceOf<AutoDetectProxyConfiguration>());
-        }
+        Assert.NotNull(deserialized);
+
+        Assert.Equal(ProxyType.AutoDetect, deserialized.ProxyType);
+        Assert.IsType<AutoDetectProxyConfiguration>(deserialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyTypeProxyAutoconfig()
     {
         string json = """
@@ -302,17 +321,15 @@ public class ProxyConfigurationTests
                       }
                       """;
         ProxyConfiguration? deserialized = JsonSerializer.Deserialize<ProxyConfiguration>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized!.ProxyType, Is.EqualTo(ProxyType.ProxyAutoConfig));
-            Assert.That(deserialized, Is.InstanceOf<PacProxyConfiguration>());
-            PacProxyConfiguration deserializedResult = (PacProxyConfiguration)deserialized;
-            Assert.That(deserializedResult.ProxyAutoConfigUrl, Is.EqualTo("proxy.autoconfig.url"));
-        }
+        Assert.NotNull(deserialized);
+
+        Assert.Equal(ProxyType.ProxyAutoConfig, deserialized.ProxyType);
+        Assert.IsType<PacProxyConfiguration>(deserialized);
+        PacProxyConfiguration deserializedResult = (PacProxyConfiguration)deserialized;
+        Assert.Equal("proxy.autoconfig.url", deserializedResult.ProxyAutoConfigUrl);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithProxyTypeDirect()
     {
         string json = """
@@ -321,15 +338,13 @@ public class ProxyConfigurationTests
                       }
                       """;
         ProxyConfiguration? deserialized = JsonSerializer.Deserialize<ProxyConfiguration>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized!.ProxyType, Is.EqualTo(ProxyType.Direct));
-            Assert.That(deserialized, Is.InstanceOf<DirectProxyConfiguration>());
-        }
+        Assert.NotNull(deserialized);
+
+        Assert.Equal(ProxyType.Direct, deserialized.ProxyType);
+        Assert.IsType<DirectProxyConfiguration>(deserialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithAdditionalData()
     {
         string json = """
@@ -339,23 +354,21 @@ public class ProxyConfigurationTests
                       }
                       """;
         ProxyConfiguration? deserialized = JsonSerializer.Deserialize<ProxyConfiguration>(json);
-        Assert.That(deserialized, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized!.ProxyType, Is.EqualTo(ProxyType.Direct));
-            Assert.That(deserialized, Is.InstanceOf<DirectProxyConfiguration>());
-            Assert.That(deserialized.AdditionalData, Has.Count.EqualTo(1));
-        }
+        Assert.NotNull(deserialized);
+
+        Assert.Equal(ProxyType.Direct, deserialized.ProxyType);
+        Assert.IsType<DirectProxyConfiguration>(deserialized);
+        Assert.Single(deserialized.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithNonObjectJsonThrows()
     {
         string json = @"""proxyType""";
-        Assert.That(() => JsonSerializer.Deserialize<ProxyConfiguration>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must be an object"));
+        Assert.Contains("must be an object", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ProxyConfiguration>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithProxyTypeProxyAutoconfigWithMissingUrlThrows()
     {
         string json = """
@@ -363,10 +376,10 @@ public class ProxyConfigurationTests
                         "proxyType": "pac"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ProxyConfiguration>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("proxyAutoconfigUrl"));
+        Assert.Contains("proxyAutoconfigUrl", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ProxyConfiguration>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithInvalidProxyTypeThrows()
     {
         string json = """
@@ -374,10 +387,10 @@ public class ProxyConfigurationTests
                         "proxyType": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ProxyConfiguration>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("JSON for 'ProxyConfiguration' proxyType property contains unknown value 'invalid'"));
+        Assert.Contains("JSON for 'ProxyConfiguration' proxyType property contains unknown value 'invalid'", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ProxyConfiguration>(json)).Message);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializeWithNonStringProxyTypeThrows()
     {
         string json = """
@@ -385,6 +398,6 @@ public class ProxyConfigurationTests
                         "proxyType": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<ProxyConfiguration>(json), Throws.InstanceOf<JsonException>().With.Message.Contains("must be a string"));
+        Assert.Contains("must be a string", Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<ProxyConfiguration>(json)).Message);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
@@ -23,7 +23,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -55,7 +55,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -86,7 +86,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -114,7 +114,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -142,7 +142,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -184,7 +184,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -226,7 +226,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -252,7 +252,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using TestUtilities;
 
-[TestFixture]
 public class SessionModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestExecuteStatusCommand()
     {
         TestWebSocketConnection connection = new();
@@ -26,21 +25,18 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<StatusCommandResult> task = module.StatusAsync(new StatusCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        StatusCommandResult result = task.Result;
+        Task<StatusCommandResult> task = module.StatusAsync(new StatusCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        StatusCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsReady, Is.True);
-            Assert.That(result.Message, Is.EqualTo("ready for connection"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.IsReady);
+        Assert.Equal("ready for connection", result.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteStatusCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -61,21 +57,18 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<StatusCommandResult> task = module.StatusAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        StatusCommandResult result = task.Result;
+        Task<StatusCommandResult> task = module.StatusAsync(cancellationToken: TestContext.Current.CancellationToken);
+        StatusCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsReady, Is.True);
-            Assert.That(result.Message, Is.EqualTo("ready for connection"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.IsReady);
+        Assert.Equal("ready for connection", result.Message);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteSubscribeCommand()
     {
         TestWebSocketConnection connection = new();
@@ -95,18 +88,17 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         SubscribeCommandParameters subscribeParameters = new(["log.entryAdded"]);
-        Task<SubscribeCommandResult> task = module.SubscribeAsync(subscribeParameters);
-        task.Wait(TimeSpan.FromSeconds(1));
-        SubscribeCommandResult result = task.Result;
+        Task<SubscribeCommandResult> task = module.SubscribeAsync(subscribeParameters, cancellationToken: TestContext.Current.CancellationToken);
+        SubscribeCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.SubscriptionId, Is.EqualTo("mySubscriptionId"));
+        Assert.NotNull(result);
+        Assert.Equal("mySubscriptionId", result.SubscriptionId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteUnsubscribeByAttributesCommand()
     {
         TestWebSocketConnection connection = new();
@@ -124,18 +116,17 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         UnsubscribeByAttributesCommandParameters unsubscribeParameters = new();
         unsubscribeParameters.Events.Add("log.entryAdded");
-        Task<UnsubscribeCommandResult> task = module.UnsubscribeAsync(unsubscribeParameters);
-        task.Wait(TimeSpan.FromSeconds(1));
-        UnsubscribeCommandResult result = task.Result;
+        Task<UnsubscribeCommandResult> task = module.UnsubscribeAsync(unsubscribeParameters, cancellationToken: TestContext.Current.CancellationToken);
+        UnsubscribeCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteUnsubscribeBySubscriptionIdsCommand()
     {
         TestWebSocketConnection connection = new();
@@ -153,18 +144,17 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         UnsubscribeByIdsCommandParameters unsubscribeParameters = new();
         unsubscribeParameters.SubscriptionIds.Add("mySubscriptionId");
-        Task<UnsubscribeCommandResult> task = module.UnsubscribeAsync(unsubscribeParameters);
-        task.Wait(TimeSpan.FromSeconds(1));
-        UnsubscribeCommandResult result = task.Result;
+        Task<UnsubscribeCommandResult> task = module.UnsubscribeAsync(unsubscribeParameters, cancellationToken: TestContext.Current.CancellationToken);
+        UnsubscribeCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteNewCommand()
     {
         TestWebSocketConnection connection = new();
@@ -196,33 +186,31 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         NewCommandParameters newCommandParameters = new();
-        Task<NewCommandResult> task = module.NewSessionAsync(newCommandParameters);
-        task.Wait(TimeSpan.FromSeconds(1));
-        NewCommandResult result = task.Result;
+        Task<NewCommandResult> task = module.NewSessionAsync(newCommandParameters, cancellationToken: TestContext.Current.CancellationToken);
+        NewCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.SessionId, Is.EqualTo("mySession"));
-            Assert.That(result.Capabilities.BrowserName, Is.EqualTo("greatBrowser"));
-            Assert.That(result.Capabilities.BrowserVersion, Is.EqualTo("101.5b"));
-            Assert.That(result.Capabilities.PlatformName, Is.EqualTo("otherOS"));
-            Assert.That(result.Capabilities.UserAgent, Is.EqualTo("WebDriverBidi.NET/1.0"));
-            Assert.That(result.Capabilities.AcceptInsecureCertificates, Is.True);
-            Assert.That(result.Capabilities.SetWindowRect, Is.True);
-            Assert.That(result.Capabilities.Proxy, Is.Not.Null);
-            Assert.That(result.Capabilities.AdditionalCapabilities, Has.Count.EqualTo(1));
-            Assert.That(result.Capabilities.AdditionalCapabilities, Contains.Key("additionalCapName"));
-            Assert.That(result.Capabilities.AdditionalCapabilities["additionalCapName"], Is.Not.Null);
-            Assert.That(result.Capabilities.AdditionalCapabilities["additionalCapName"], Is.TypeOf<string>());
-            Assert.That(result.Capabilities.AdditionalCapabilities["additionalCapName"]!.ToString(), Is.EqualTo("additionalCapValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("mySession", result.SessionId);
+        Assert.Equal("greatBrowser", result.Capabilities.BrowserName);
+        Assert.Equal("101.5b", result.Capabilities.BrowserVersion);
+        Assert.Equal("otherOS", result.Capabilities.PlatformName);
+        Assert.Equal("WebDriverBidi.NET/1.0", result.Capabilities.UserAgent);
+        Assert.True(result.Capabilities.AcceptInsecureCertificates);
+        Assert.True(result.Capabilities.SetWindowRect);
+        Assert.NotNull(result.Capabilities.Proxy);
+        Assert.Single(result.Capabilities.AdditionalCapabilities);
+        Assert.True(result.Capabilities.AdditionalCapabilities.ContainsKey("additionalCapName"));
+        object? additionalCapValue = result.Capabilities.AdditionalCapabilities["additionalCapName"];
+        Assert.NotNull(additionalCapValue);
+        Assert.IsType<string>(additionalCapValue);
+        Assert.Equal("additionalCapValue", additionalCapValue.ToString());
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteEndCommand()
     {
         TestWebSocketConnection connection = new();
@@ -240,16 +228,15 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
         EndCommandParameters endParameters = new();
-        Task<EndCommandResult> task = module.EndAsync(endParameters);
-        task.Wait(TimeSpan.FromSeconds(1));
-        EndCommandResult result = task.Result;
-        Assert.That(result, Is.Not.Null);
+        Task<EndCommandResult> task = module.EndAsync(endParameters, cancellationToken: TestContext.Current.CancellationToken);
+        EndCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestExecuteEndCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -267,12 +254,11 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<EndCommandResult> task = module.EndAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        EndCommandResult result = task.Result;
+        Task<EndCommandResult> task = module.EndAsync(cancellationToken: TestContext.Current.CancellationToken);
+        EndCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
@@ -25,7 +25,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<StatusCommandResult> task = module.StatusAsync(new StatusCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
         StatusCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
@@ -57,7 +57,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<StatusCommandResult> task = module.StatusAsync(cancellationToken: TestContext.Current.CancellationToken);
         StatusCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
@@ -88,7 +88,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         SubscribeCommandParameters subscribeParameters = new(["log.entryAdded"]);
         Task<SubscribeCommandResult> task = module.SubscribeAsync(subscribeParameters, cancellationToken: TestContext.Current.CancellationToken);
@@ -116,7 +116,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         UnsubscribeByAttributesCommandParameters unsubscribeParameters = new();
         unsubscribeParameters.Events.Add("log.entryAdded");
@@ -144,7 +144,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         UnsubscribeByIdsCommandParameters unsubscribeParameters = new();
         unsubscribeParameters.SubscriptionIds.Add("mySubscriptionId");
@@ -186,7 +186,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         NewCommandParameters newCommandParameters = new();
         Task<NewCommandResult> task = module.NewSessionAsync(newCommandParameters, cancellationToken: TestContext.Current.CancellationToken);
@@ -228,7 +228,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         EndCommandParameters endParameters = new();
         Task<EndCommandResult> task = module.EndAsync(endParameters, cancellationToken: TestContext.Current.CancellationToken);
@@ -254,7 +254,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = driver.Session;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<EndCommandResult> task = module.EndAsync(cancellationToken: TestContext.Current.CancellationToken);
         EndCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/Session/StatusCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/StatusCommandParametersTests.cs
@@ -3,22 +3,21 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class StatusCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         StatusCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("session.status"));
+        Assert.Equal("session.status", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         StatusCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/StatusCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/StatusCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class StatusCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -15,15 +14,13 @@ public class StatusCommandResultTests
                       }
                       """;
         StatusCommandResult? result = JsonSerializer.Deserialize<StatusCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsReady, Is.EqualTo(true));
-            Assert.That(result.Message, Is.EqualTo("myMessage"));
-        }
+        Assert.NotNull(result);
+
+        Assert.True(result.IsReady);
+        Assert.Equal("myMessage", result.Message);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -33,12 +30,12 @@ public class StatusCommandResultTests
                       }
                       """;
         StatusCommandResult? result = JsonSerializer.Deserialize<StatusCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         StatusCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingReadyThrows()
     {
         string json = """
@@ -46,10 +43,10 @@ public class StatusCommandResultTests
                         "message": "myMessage"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StatusCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StatusCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidReadyTypeThrows()
     {
         string json = """
@@ -58,10 +55,10 @@ public class StatusCommandResultTests
                         "message": "myMessage"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StatusCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StatusCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingMessageThrows()
     {
         string json = """
@@ -69,10 +66,10 @@ public class StatusCommandResultTests
                         "ready": true
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StatusCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StatusCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidMessageTypeThrows()
     {
         string json = """
@@ -81,6 +78,6 @@ public class StatusCommandResultTests
                         "message": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<StatusCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<StatusCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/SubscribeCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SubscribeCommandParametersTests.cs
@@ -3,164 +3,159 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SubscribeCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SubscribeCommandParameters properties = new(["my.event"]);
-        Assert.That(properties.MethodName, Is.EqualTo("session.subscribe"));
+        Assert.Equal("session.subscribe", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCannotInitializeWithEmptyEventList()
     {
         Assert.Throws<ArgumentException>(() => new SubscribeCommandParameters(Array.Empty<string>()));
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithASingleEvent()
     {
         SubscribeCommandParameters properties = new("some.event");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("events"));
-            Assert.That(serialized["events"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["events"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["events"]![0]!.Value<string>(), Is.EqualTo("some.event"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("events"));
+        JToken? eventsToken = serialized["events"];
+        Assert.NotNull(eventsToken);
+        Assert.Equal(JTokenType.Array, eventsToken.Type);
+        Assert.Single(eventsToken);
+        Assert.Equal("some.event", eventsToken[0]!.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithEvents()
     {
         SubscribeCommandParameters properties = new(["some.event"]);
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("events"));
-            Assert.That(serialized["events"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["events"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["events"]![0]!.Value<string>(), Is.EqualTo("some.event"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("events"));
+        JToken? eventsToken = serialized["events"];
+        Assert.NotNull(eventsToken);
+        Assert.Equal(JTokenType.Array, eventsToken.Type);
+        Assert.Single(eventsToken);
+        Assert.Equal("some.event", eventsToken[0]!.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBrowsingContextData()
     {
         SubscribeCommandParameters properties = new(["some.event"]);
         properties.Contexts.Add("myContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("events"));
-            Assert.That(serialized["events"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["events"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["events"]![0]!.Value<string>(), Is.EqualTo("some.event"));
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["contexts"]![0]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("events"));
+        JToken? eventsToken = serialized["events"];
+        Assert.NotNull(eventsToken);
+        Assert.Equal(JTokenType.Array, eventsToken.Type);
+        Assert.Single(eventsToken);
+        Assert.Equal("some.event", eventsToken[0]!.Value<string>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        Assert.Single(contextsToken);
+        Assert.Equal("myContext", contextsToken[0]!.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithUserContextData()
     {
         SubscribeCommandParameters properties = new(["some.event"]);
         properties.UserContexts.Add("myUserContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("events"));
-            Assert.That(serialized["events"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["events"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["events"]![0]!.Value<string>(), Is.EqualTo("some.event"));
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["userContexts"]![0]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("events"));
+        JToken? eventsToken = serialized["events"];
+        Assert.NotNull(eventsToken);
+        Assert.Equal(JTokenType.Array, eventsToken.Type);
+        Assert.Single(eventsToken);
+        Assert.Equal("some.event", eventsToken[0]!.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        Assert.Single(userContextsToken);
+        Assert.Equal("myUserContext", userContextsToken[0]!.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestInitializeUsingConstructor()
     {
         SubscribeCommandParameters properties = new(["someEvent"], ["someContext"], ["someUserContext"]);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Events, Has.Count.EqualTo(1));
-            Assert.That(properties.Events, Contains.Item("someEvent"));
-            Assert.That(properties.Contexts, Has.Count.EqualTo(1));
-            Assert.That(properties.Contexts, Contains.Item("someContext"));
-            Assert.That(properties.UserContexts, Has.Count.EqualTo(1));
-            Assert.That(properties.UserContexts, Contains.Item("someUserContext"));
-        }
+
+        Assert.Single(properties.Events);
+        Assert.Contains("someEvent", properties.Events);
+        Assert.Single(properties.Contexts);
+        Assert.Contains("someContext", properties.Contexts);
+        Assert.Single(properties.UserContexts);
+        Assert.Contains("someUserContext", properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestInitializeUsingConstructorForBrowsingContexts()
     {
         SubscribeCommandParameters properties = new(["someEvent"], ["someContext"]);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Events, Has.Count.EqualTo(1));
-            Assert.That(properties.Events, Contains.Item("someEvent"));
-            Assert.That(properties.Contexts, Has.Count.EqualTo(1));
-            Assert.That(properties.Contexts, Contains.Item("someContext"));
-            Assert.That(properties.UserContexts, Is.Empty);
-        }
+
+        Assert.Single(properties.Events);
+        Assert.Contains("someEvent", properties.Events);
+        Assert.Single(properties.Contexts);
+        Assert.Contains("someContext", properties.Contexts);
+        Assert.Empty(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestInitializeUsingConstructorForBrowsingContextsWithEmptyUserContextList()
     {
         SubscribeCommandParameters properties = new(["someEvent"], ["someContext"], []);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Events, Has.Count.EqualTo(1));
-            Assert.That(properties.Events, Contains.Item("someEvent"));
-            Assert.That(properties.Contexts, Has.Count.EqualTo(1));
-            Assert.That(properties.Contexts, Contains.Item("someContext"));
-            Assert.That(properties.UserContexts, Is.Empty);
-        }
+
+        Assert.Single(properties.Events);
+        Assert.Contains("someEvent", properties.Events);
+        Assert.Single(properties.Contexts);
+        Assert.Contains("someContext", properties.Contexts);
+        Assert.Empty(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestInitializeUsingConstructorForUserContexts()
     {
         SubscribeCommandParameters properties = new(["someEvent"], null, ["someUserContext"]);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Events, Has.Count.EqualTo(1));
-            Assert.That(properties.Events, Contains.Item("someEvent"));
-            Assert.That(properties.Contexts, Is.Empty);
-            Assert.That(properties.UserContexts, Has.Count.EqualTo(1));
-            Assert.That(properties.UserContexts, Contains.Item("someUserContext"));
-        }
+
+        Assert.Single(properties.Events);
+        Assert.Contains("someEvent", properties.Events);
+        Assert.Empty(properties.Contexts);
+        Assert.Single(properties.UserContexts);
+        Assert.Contains("someUserContext", properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestInitializeUsingConstructorForUserContextsWithEmptyBrowsingContextList()
     {
         SubscribeCommandParameters properties = new(["someEvent"], [], ["someUserContext"]);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.Events, Has.Count.EqualTo(1));
-            Assert.That(properties.Events, Contains.Item("someEvent"));
-            Assert.That(properties.Contexts, Is.Empty);
-            Assert.That(properties.UserContexts, Has.Count.EqualTo(1));
-            Assert.That(properties.UserContexts, Contains.Item("someUserContext"));
-        }
+
+        Assert.Single(properties.Events);
+        Assert.Contains("someEvent", properties.Events);
+        Assert.Empty(properties.Contexts);
+        Assert.Single(properties.UserContexts);
+        Assert.Contains("someUserContext", properties.UserContexts);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/SubscribeCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SubscribeCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SubscribeCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class SubscribeCommandResultTests
                       }
                       """;
         SubscribeCommandResult? result = JsonSerializer.Deserialize<SubscribeCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.SubscriptionId, Is.EqualTo("mySubscription"));
+        Assert.NotNull(result);
+        Assert.Equal("mySubscription", result.SubscriptionId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,22 +26,22 @@ public class SubscribeCommandResultTests
                       }
                       """;
         SubscribeCommandResult? result = JsonSerializer.Deserialize<SubscribeCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SubscribeCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializationWithMissingSubscriptionThrows()
     {
         string json = """
                       {
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SubscribeCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SubscribeCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializationWithIncorrectSubscriptionTypeThrows()
     {
         string json = """
@@ -50,6 +49,6 @@ public class SubscribeCommandResultTests
                         "subscription": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SubscribeCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SubscribeCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/UnsubscribeCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/UnsubscribeCommandParametersTests.cs
@@ -3,77 +3,76 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class UnsubscribeCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         UnsubscribeByAttributesCommandParameters byAttributesProperties = new();
-        Assert.That(byAttributesProperties.MethodName, Is.EqualTo("session.unsubscribe"));
+        Assert.Equal("session.unsubscribe", byAttributesProperties.MethodName);
         UnsubscribeByIdsCommandParameters byIdProperties = new();
-        Assert.That(byIdProperties.MethodName, Is.EqualTo("session.unsubscribe"));
+        Assert.Equal("session.unsubscribe", byIdProperties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeByAttributesParameters()
     {
         UnsubscribeByAttributesCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("events"));
-            Assert.That(serialized["events"]!.Count, Is.EqualTo(0));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("events"));
+        JToken? events = serialized["events"];
+        Assert.NotNull(events);
+        Assert.Empty(events);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeByAttributesParametersWithEvents()
     {
         UnsubscribeByAttributesCommandParameters properties = new();
         properties.Events.Add("some.event");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("events"));
-            Assert.That(serialized["events"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["events"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["events"]![0]!.Value<string>(), Is.EqualTo("some.event"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("events"));
+        JToken? eventsToken = serialized["events"];
+        Assert.NotNull(eventsToken);
+        Assert.Single(eventsToken);
+        Assert.Equal(JTokenType.Array, eventsToken.Type);
+        Assert.Equal("some.event", eventsToken[0]!.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeByIdsParameters()
     {
         UnsubscribeByIdsCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("subscriptions"));
-            Assert.That(serialized["subscriptions"]!.Count, Is.EqualTo(0));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("subscriptions"));
+        JToken? subscriptions = serialized["subscriptions"];
+        Assert.NotNull(subscriptions);
+        Assert.Empty(subscriptions);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeByIdsParametersWithEvents()
     {
         UnsubscribeByIdsCommandParameters properties = new();
         properties.SubscriptionIds.Add("mySubscriptionId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("subscriptions"));
-            Assert.That(serialized["subscriptions"]!.Count, Is.EqualTo(1));
-            Assert.That(serialized["subscriptions"]!.Type, Is.EqualTo(JTokenType.Array));
-            Assert.That(serialized["subscriptions"]![0]!.Value<string>(), Is.EqualTo("mySubscriptionId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("subscriptions"));
+        JToken? subscriptionsToken = serialized["subscriptions"];
+        Assert.NotNull(subscriptionsToken);
+        Assert.Single(subscriptionsToken);
+        Assert.Equal(JTokenType.Array, subscriptionsToken.Type);
+        Assert.Equal("mySubscriptionId", subscriptionsToken[0]!.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/UnsubscribeCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/UnsubscribeCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class UnsubscribeCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         UnsubscribeCommandResult? result = JsonSerializer.Deserialize<UnsubscribeCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         UnsubscribeCommandResult? result = JsonSerializer.Deserialize<UnsubscribeCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UnsubscribeCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/UserPromptHandlerResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/UserPromptHandlerResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Session;
 
 using System.Text.Json;
 
-[TestFixture]
 public class UserPromptHandlerResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerResult()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -30,21 +29,19 @@ public class UserPromptHandlerResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UserPromptHandlerResult? handlerResult = result.UnhandledPromptBehavior;
-        Assert.That(handlerResult, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handlerResult.Default, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handlerResult.Alert, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handlerResult.Confirm, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(handlerResult.Prompt, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(handlerResult.BeforeUnload, Is.EqualTo(UserPromptHandlerType.Ignore));
-            Assert.That(handlerResult.File, Is.EqualTo(UserPromptHandlerType.Ignore));
-        }
+        Assert.NotNull(handlerResult);
+
+        Assert.Equal(UserPromptHandlerType.Accept, handlerResult.Default);
+        Assert.Equal(UserPromptHandlerType.Accept, handlerResult.Alert);
+        Assert.Equal(UserPromptHandlerType.Dismiss, handlerResult.Confirm);
+        Assert.Equal(UserPromptHandlerType.Dismiss, handlerResult.Prompt);
+        Assert.Equal(UserPromptHandlerType.Ignore, handlerResult.BeforeUnload);
+        Assert.Equal(UserPromptHandlerType.Ignore, handlerResult.File);
     }
 
-    [Test]
+    [Fact]
     public void TestUserPromptHandlerResultCopySemantics()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -69,10 +66,10 @@ public class UserPromptHandlerResultTests
                       }
                       """;
         CapabilitiesResult? result = JsonSerializer.Deserialize<CapabilitiesResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UserPromptHandlerResult? handlerResult = result.UnhandledPromptBehavior;
-        Assert.That(handlerResult, Is.Not.Null);
+        Assert.NotNull(handlerResult);
         UserPromptHandlerResult copy = handlerResult with { };
-        Assert.That(copy, Is.EqualTo(handlerResult));
+        Assert.Equal(handlerResult, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Session/UserPromptHandlerTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/UserPromptHandlerTests.cs
@@ -3,20 +3,18 @@ namespace WebDriverBiDi.Session;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-
-[TestFixture]
 public class UserPromptHandlerTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         UserPromptHandler handler = new();
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Empty);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithAllOptions()
     {
         UserPromptHandler handler = new()
@@ -30,31 +28,47 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(6));
-            Assert.That(serialized, Contains.Key("default"));
-            Assert.That(serialized["default"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["default"]!.Value<string>(), Is.EqualTo("accept"));
-            Assert.That(serialized, Contains.Key("alert"));
-            Assert.That(serialized["alert"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["alert"]!.Value<string>(), Is.EqualTo("accept"));
-            Assert.That(serialized, Contains.Key("confirm"));
-            Assert.That(serialized["confirm"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["confirm"]!.Value<string>(), Is.EqualTo("dismiss"));
-            Assert.That(serialized, Contains.Key("prompt"));
-            Assert.That(serialized["prompt"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["prompt"]!.Value<string>(), Is.EqualTo("dismiss"));
-            Assert.That(serialized, Contains.Key("beforeunload"));
-            Assert.That(serialized["beforeunload"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["beforeunload"]!.Value<string>(), Is.EqualTo("ignore"));
-            Assert.That(serialized, Contains.Key("file"));
-            Assert.That(serialized["file"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["file"]!.Value<string>(), Is.EqualTo("ignore"));
-        }
+
+        Assert.Equal(6, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("default"));
+        JToken? defaultToken = serialized["default"];
+        Assert.NotNull(defaultToken);
+        Assert.Equal(JTokenType.String, defaultToken.Type);
+        Assert.Equal("accept", defaultToken.Value<string>());
+
+        Assert.True(serialized.ContainsKey("alert"));
+        JToken? alert = serialized["alert"];
+        Assert.NotNull(alert);
+        Assert.Equal(JTokenType.String, alert.Type);
+        Assert.Equal("accept", alert.Value<string>());
+
+        Assert.True(serialized.ContainsKey("confirm"));
+        JToken? confirm = serialized["confirm"];
+        Assert.NotNull(confirm);
+        Assert.Equal(JTokenType.String, confirm.Type);
+        Assert.Equal("dismiss", confirm.Value<string>());
+
+        Assert.True(serialized.ContainsKey("prompt"));
+        JToken? prompt = serialized["prompt"];
+        Assert.NotNull(prompt);
+        Assert.Equal(JTokenType.String, prompt.Type);
+        Assert.Equal("dismiss", prompt.Value<string>());
+
+        Assert.True(serialized.ContainsKey("beforeunload"));
+        JToken? beforeunload = serialized["beforeunload"];
+        Assert.NotNull(beforeunload);
+        Assert.Equal(JTokenType.String, beforeunload.Type);
+        Assert.Equal("ignore", beforeunload.Value<string>());
+
+        Assert.True(serialized.ContainsKey("file"));
+        JToken? file = serialized["file"];
+        Assert.NotNull(file);
+        Assert.Equal(JTokenType.String, file.Type);
+        Assert.Equal("ignore", file.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOnlyDefault()
     {
         UserPromptHandler handler = new()
@@ -63,16 +77,17 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("default"));
-            Assert.That(serialized["default"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["default"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("default"));
+        JToken? defaultToken = serialized["default"];
+        Assert.NotNull(defaultToken);
+        Assert.Equal(JTokenType.String, defaultToken.Type);
+        Assert.Equal("accept", defaultToken.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOnlyAlert()
     {
         UserPromptHandler handler = new()
@@ -81,16 +96,17 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("alert"));
-            Assert.That(serialized["alert"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["alert"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("alert"));
+        JToken? alert = serialized["alert"];
+        Assert.NotNull(alert);
+        Assert.Equal(JTokenType.String, alert.Type);
+        Assert.Equal("accept", alert.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOnlyConfirm()
     {
         UserPromptHandler handler = new()
@@ -99,16 +115,17 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("confirm"));
-            Assert.That(serialized["confirm"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["confirm"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("confirm"));
+        JToken? confirm = serialized["confirm"];
+        Assert.NotNull(confirm);
+        Assert.Equal(JTokenType.String, confirm.Type);
+        Assert.Equal("accept", confirm.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOnlyPrompt()
     {
         UserPromptHandler handler = new()
@@ -117,16 +134,17 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("prompt"));
-            Assert.That(serialized["prompt"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["prompt"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("prompt"));
+        JToken? prompt = serialized["prompt"];
+        Assert.NotNull(prompt);
+        Assert.Equal(JTokenType.String, prompt.Type);
+        Assert.Equal("accept", prompt.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOnlyBeforeUnload()
     {
         UserPromptHandler handler = new()
@@ -135,16 +153,17 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("beforeunload"));
-            Assert.That(serialized["beforeunload"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["beforeunload"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("beforeunload"));
+        JToken? beforeunload = serialized["beforeunload"];
+        Assert.NotNull(beforeunload);
+        Assert.Equal(JTokenType.String, beforeunload.Type);
+        Assert.Equal("accept", beforeunload.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOnlyFile()
     {
         UserPromptHandler handler = new()
@@ -153,16 +172,17 @@ public class UserPromptHandlerTests
         };
         string json = JsonSerializer.Serialize(handler);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("file"));
-            Assert.That(serialized["file"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["file"]!.Value<string>(), Is.EqualTo("accept"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("file"));
+        JToken? file = serialized["file"];
+        Assert.NotNull(file);
+        Assert.Equal(JTokenType.String, file.Type);
+        Assert.Equal("accept", file.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -173,19 +193,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.Null);
-            Assert.That(handler.Alert, Is.Null);
-            Assert.That(handler.Confirm, Is.Null);
-            Assert.That(handler.Prompt, Is.Null);
-            Assert.That(handler.BeforeUnload, Is.Null);
-            Assert.That(handler.File, Is.Null);
-        }
+        Assert.NotNull(handler);
+
+        Assert.Null(handler.Default);
+        Assert.Null(handler.Alert);
+        Assert.Null(handler.Confirm);
+        Assert.Null(handler.Prompt);
+        Assert.Null(handler.BeforeUnload);
+        Assert.Null(handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithAllOptions()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -202,19 +220,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.Alert, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.Confirm, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(handler.Prompt, Is.EqualTo(UserPromptHandlerType.Dismiss));
-            Assert.That(handler.BeforeUnload, Is.EqualTo(UserPromptHandlerType.Ignore));
-            Assert.That(handler.File, Is.EqualTo(UserPromptHandlerType.Ignore));
-        }
+        Assert.NotNull(handler);
+
+        Assert.Equal(UserPromptHandlerType.Accept, handler.Default);
+        Assert.Equal(UserPromptHandlerType.Accept, handler.Alert);
+        Assert.Equal(UserPromptHandlerType.Dismiss, handler.Confirm);
+        Assert.Equal(UserPromptHandlerType.Dismiss, handler.Prompt);
+        Assert.Equal(UserPromptHandlerType.Ignore, handler.BeforeUnload);
+        Assert.Equal(UserPromptHandlerType.Ignore, handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerWithOnlyDefault()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -226,19 +242,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.Alert, Is.Null);
-            Assert.That(handler.Confirm, Is.Null);
-            Assert.That(handler.Prompt, Is.Null);
-            Assert.That(handler.BeforeUnload, Is.Null);
-            Assert.That(handler.File, Is.Null);
-        }
+        Assert.NotNull(handler);
+
+        Assert.Equal(UserPromptHandlerType.Accept, handler.Default);
+        Assert.Null(handler.Alert);
+        Assert.Null(handler.Confirm);
+        Assert.Null(handler.Prompt);
+        Assert.Null(handler.BeforeUnload);
+        Assert.Null(handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerWithOnlyAlert()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -250,19 +264,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.Null);
-            Assert.That(handler.Alert, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.Confirm, Is.Null);
-            Assert.That(handler.Prompt, Is.Null);
-            Assert.That(handler.BeforeUnload, Is.Null);
-            Assert.That(handler.File, Is.Null);
-        }
+        Assert.NotNull(handler);
+
+        Assert.Null(handler.Default);
+        Assert.Equal(UserPromptHandlerType.Accept, handler.Alert);
+        Assert.Null(handler.Confirm);
+        Assert.Null(handler.Prompt);
+        Assert.Null(handler.BeforeUnload);
+        Assert.Null(handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerWithOnlyConfirm()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -274,19 +286,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.Null);
-            Assert.That(handler.Alert, Is.Null);
-            Assert.That(handler.Confirm, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.Prompt, Is.Null);
-            Assert.That(handler.BeforeUnload, Is.Null);
-            Assert.That(handler.File, Is.Null);
-        }
+        Assert.NotNull(handler);
+
+        Assert.Null(handler.Default);
+        Assert.Null(handler.Alert);
+        Assert.Equal(UserPromptHandlerType.Accept, handler.Confirm);
+        Assert.Null(handler.Prompt);
+        Assert.Null(handler.BeforeUnload);
+        Assert.Null(handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerWithOnlyPrompt()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -298,19 +308,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.Null);
-            Assert.That(handler.Alert, Is.Null);
-            Assert.That(handler.Confirm, Is.Null);
-            Assert.That(handler.Prompt, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.BeforeUnload, Is.Null);
-            Assert.That(handler.File, Is.Null);
-        }
+        Assert.NotNull(handler);
+
+        Assert.Null(handler.Default);
+        Assert.Null(handler.Alert);
+        Assert.Null(handler.Confirm);
+        Assert.Equal(UserPromptHandlerType.Accept, handler.Prompt);
+        Assert.Null(handler.BeforeUnload);
+        Assert.Null(handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerWithOnlyBeforeUnload()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -322,19 +330,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.Null);
-            Assert.That(handler.Alert, Is.Null);
-            Assert.That(handler.Confirm, Is.Null);
-            Assert.That(handler.Prompt, Is.Null);
-            Assert.That(handler.BeforeUnload, Is.EqualTo(UserPromptHandlerType.Accept));
-            Assert.That(handler.File, Is.Null);
-        }
+        Assert.NotNull(handler);
+
+        Assert.Null(handler.Default);
+        Assert.Null(handler.Alert);
+        Assert.Null(handler.Confirm);
+        Assert.Null(handler.Prompt);
+        Assert.Equal(UserPromptHandlerType.Accept, handler.BeforeUnload);
+        Assert.Null(handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeUserPromptHandlerWithOnlyFile()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -346,19 +352,17 @@ public class UserPromptHandlerTests
                       }
                       """;
         UserPromptHandler? handler = JsonSerializer.Deserialize<UserPromptHandler>(json);
-        Assert.That(handler, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(handler.Default, Is.Null);
-            Assert.That(handler.Alert, Is.Null);
-            Assert.That(handler.Confirm, Is.Null);
-            Assert.That(handler.Prompt, Is.Null);
-            Assert.That(handler.BeforeUnload, Is.Null);
-            Assert.That(handler.File, Is.EqualTo(UserPromptHandlerType.Accept));
-        }
+        Assert.NotNull(handler);
+
+        Assert.Null(handler.Default);
+        Assert.Null(handler.Alert);
+        Assert.Null(handler.Confirm);
+        Assert.Null(handler.Prompt);
+        Assert.Null(handler.BeforeUnload);
+        Assert.Equal(UserPromptHandlerType.Accept, handler.File);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializingWithInvalidTypeValueThrows()
     {
         // ProxyConfigurationResult constructor is internal, and the only
@@ -369,6 +373,6 @@ public class UserPromptHandlerTests
                         "default": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<UserPromptHandler>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<UserPromptHandler>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Speculation/PrefetchStatusUpdatedEventArgsTests.cs
+++ b/test/WebDriverBiDi.Tests/Speculation/PrefetchStatusUpdatedEventArgsTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Speculation;
 
 using System.Text.Json;
 
-[TestFixture]
 public class PrefetchStatusUpdatedEventArgsTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithPendingStatus()
     {
         string json = """
@@ -16,16 +15,14 @@ public class PrefetchStatusUpdatedEventArgsTests
                       }
                       """;
         PrefetchStatusUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("https://example.com/index.html"));
-            Assert.That(eventArgs.Status, Is.EqualTo(PreloadingStatus.Pending));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("https://example.com/index.html", eventArgs.Url);
+        Assert.Equal(PreloadingStatus.Pending, eventArgs.Status);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithReadyStatus()
     {
         string json = """
@@ -36,16 +33,14 @@ public class PrefetchStatusUpdatedEventArgsTests
                       }
                       """;
         PrefetchStatusUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("https://example.com/index.html"));
-            Assert.That(eventArgs.Status, Is.EqualTo(PreloadingStatus.Ready));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("https://example.com/index.html", eventArgs.Url);
+        Assert.Equal(PreloadingStatus.Ready, eventArgs.Status);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithSuccessStatus()
     {
         string json = """
@@ -56,16 +51,14 @@ public class PrefetchStatusUpdatedEventArgsTests
                       }
                       """;
         PrefetchStatusUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("https://example.com/index.html"));
-            Assert.That(eventArgs.Status, Is.EqualTo(PreloadingStatus.Success));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("https://example.com/index.html", eventArgs.Url);
+        Assert.Equal(PreloadingStatus.Success, eventArgs.Status);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithFailureStatus()
     {
         string json = """
@@ -76,16 +69,14 @@ public class PrefetchStatusUpdatedEventArgsTests
                       }
                       """;
         PrefetchStatusUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(eventArgs.BrowsingContextId, Is.EqualTo("myContextId"));
-            Assert.That(eventArgs.Url, Is.EqualTo("https://example.com/index.html"));
-            Assert.That(eventArgs.Status, Is.EqualTo(PreloadingStatus.Failure));
-        }
+        Assert.NotNull(eventArgs);
+
+        Assert.Equal("myContextId", eventArgs.BrowsingContextId);
+        Assert.Equal("https://example.com/index.html", eventArgs.Url);
+        Assert.Equal(PreloadingStatus.Failure, eventArgs.Status);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -96,12 +87,12 @@ public class PrefetchStatusUpdatedEventArgsTests
                       }
                       """;
         PrefetchStatusUpdatedEventArgs? eventArgs = JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json);
-        Assert.That(eventArgs, Is.Not.Null);
+        Assert.NotNull(eventArgs);
         PrefetchStatusUpdatedEventArgs copy = eventArgs with { };
-        Assert.That(copy, Is.EqualTo(eventArgs));
+        Assert.Equal(eventArgs, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingContextThrows()
     {
         string json = """
@@ -110,10 +101,10 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "status": "pending"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidContextTypeThrows()
     {
         string json = """
@@ -123,10 +114,10 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "status": "pending"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingUrlThrows()
     {
         string json = """
@@ -135,10 +126,10 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "status": "pending"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidUrlTypeThrows()
     {
         string json = """
@@ -148,10 +139,10 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "status": "pending"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingStatusThrows()
     {
         string json = """
@@ -160,10 +151,10 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "url": "https://example.com/index.html"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidStatusTypeThrows()
     {
         string json = """
@@ -173,10 +164,10 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "status": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidStatusValueThrows()
     {
         string json = """
@@ -186,6 +177,6 @@ public class PrefetchStatusUpdatedEventArgsTests
                         "status": "invalid"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<PrefetchStatusUpdatedEventArgs>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
@@ -8,7 +8,7 @@ public class SpeculationModuleTests
     public async Task TestCanReceivePrefetchStatusUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         SpeculationModule module = driver.Speculation;
 

--- a/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
@@ -9,18 +9,16 @@ public class SpeculationModuleTests
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         SpeculationModule module = driver.Speculation;
 
-        ManualResetEvent syncEvent = new(false);
-        module.OnPrefetchStatusUpdated.AddObserver((PrefetchStatusUpdatedEventArgs e) =>
+        TaskCompletionSource taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        module.OnPrefetchStatusUpdated.AddObserver(e =>
         {
-
             Assert.Equal("myContext", e.BrowsingContextId);
             Assert.Equal("https://example.com/index.html", e.Url);
             Assert.Equal(PreloadingStatus.Pending, e.Status);
-
-            syncEvent.Set();
+            taskCompletionSource.TrySetResult();
         });
 
         string eventJson = """
@@ -35,7 +33,6 @@ public class SpeculationModuleTests
                            }
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
-        bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.True(eventRaised);
+        await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 }

--- a/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
@@ -2,26 +2,24 @@ namespace WebDriverBiDi.Speculation;
 
 using TestUtilities;
 
-[TestFixture]
 public class SpeculationModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestCanReceivePrefetchStatusUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         SpeculationModule module = driver.Speculation;
 
         ManualResetEvent syncEvent = new(false);
         module.OnPrefetchStatusUpdated.AddObserver((PrefetchStatusUpdatedEventArgs e) =>
         {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(e.BrowsingContextId, Is.EqualTo("myContext"));
-                Assert.That(e.Url, Is.EqualTo("https://example.com/index.html"));
-                Assert.That(e.Status, Is.EqualTo(PreloadingStatus.Pending));
-            }
+
+            Assert.Equal("myContext", e.BrowsingContextId);
+            Assert.Equal("https://example.com/index.html", e.Url);
+            Assert.Equal(PreloadingStatus.Pending, e.Status);
+
             syncEvent.Set();
         });
 
@@ -38,6 +36,6 @@ public class SpeculationModuleTests
                            """;
         await connection.RaiseDataReceivedEventAsync(eventJson);
         bool eventRaised = syncEvent.WaitOne(TimeSpan.FromMilliseconds(250));
-        Assert.That(eventRaised, Is.True);
+        Assert.True(eventRaised);
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/CookieFilterTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/CookieFilterTests.cs
@@ -4,10 +4,9 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Network;
 
-[TestFixture]
 public class CookieFilterTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithName()
     {
         CookieFilter properties = new()
@@ -16,16 +15,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithValue()
     {
         CookieFilter properties = new()
@@ -34,23 +34,31 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject bytesValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(bytesValueObject, Has.Count.EqualTo(2));
-            Assert.That(bytesValueObject, Contains.Key("type"));
-            Assert.That(bytesValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bytesValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(bytesValueObject, Contains.Key("value"));
-            Assert.That(bytesValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(bytesValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? bytesValueObject = value.Value<JObject>();
+        Assert.NotNull(bytesValueObject);
+        Assert.Equal(2, bytesValueObject.Count);
+
+        Assert.True(bytesValueObject.ContainsKey("type"));
+        JToken? valueType = bytesValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(bytesValueObject.ContainsKey("value"));
+        JToken? valueValue = bytesValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithDomain()
     {
         CookieFilter properties = new()
@@ -59,16 +67,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithPath()
     {
         CookieFilter properties = new()
@@ -77,16 +86,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("path"));
-            Assert.That(serialized["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["path"]!.Value<string>(), Is.EqualTo("myCookiePath"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("path"));
+        JToken? path = serialized["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myCookiePath", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithSize()
     {
         CookieFilter properties = new()
@@ -95,16 +105,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("size"));
-            Assert.That(serialized["size"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["size"]!.Value<ulong>(), Is.EqualTo(3));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("size"));
+        JToken? size = serialized["size"];
+        Assert.NotNull(size);
+        Assert.Equal(JTokenType.Integer, size.Type);
+        Assert.Equal(3UL, size.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithHttpOnlyTrue()
     {
         CookieFilter properties = new()
@@ -113,16 +124,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("httpOnly"));
-            Assert.That(serialized["httpOnly"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["httpOnly"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("httpOnly"));
+        JToken? httpOnly = serialized["httpOnly"];
+        Assert.NotNull(httpOnly);
+        Assert.Equal(JTokenType.Boolean, httpOnly.Type);
+        Assert.True(httpOnly.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithHttpOnlyFalse()
     {
         CookieFilter properties = new()
@@ -131,16 +143,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("httpOnly"));
-            Assert.That(serialized["httpOnly"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["httpOnly"]!.Value<bool>(), Is.False);
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("httpOnly"));
+        JToken? httpOnly = serialized["httpOnly"];
+        Assert.NotNull(httpOnly);
+        Assert.Equal(JTokenType.Boolean, httpOnly.Type);
+        Assert.False(httpOnly.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithSecureTrue()
     {
         CookieFilter properties = new()
@@ -149,16 +162,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("secure"));
-            Assert.That(serialized["secure"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["secure"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("secure"));
+        JToken? secure = serialized["secure"];
+        Assert.NotNull(secure);
+        Assert.Equal(JTokenType.Boolean, secure.Type);
+        Assert.True(secure.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithSecureFalse()
     {
         CookieFilter properties = new()
@@ -167,16 +181,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("secure"));
-            Assert.That(serialized["secure"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["secure"]!.Value<bool>(), Is.False);
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("secure"));
+        JToken? secure = serialized["secure"];
+        Assert.NotNull(secure);
+        Assert.Equal(JTokenType.Boolean, secure.Type);
+        Assert.False(secure.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithSameSiteValue()
     {
         CookieFilter properties = new()
@@ -185,16 +200,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("sameSite"));
-            Assert.That(serialized["sameSite"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sameSite"]!.Value<string>(), Is.EqualTo("strict"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("sameSite"));
+        JToken? sameSite = serialized["sameSite"];
+        Assert.NotNull(sameSite);
+        Assert.Equal(JTokenType.String, sameSite.Type);
+        Assert.Equal("strict", sameSite.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeCookieFilterWithExpirationDate()
     {
         DateTime now = DateTime.UtcNow;
@@ -206,16 +222,17 @@ public class CookieFilterTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("expiry"));
-            Assert.That(serialized["expiry"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["expiry"]!.Value<ulong>(), Is.EqualTo(seconds));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("expiry"));
+        JToken? expiry = serialized["expiry"];
+        Assert.NotNull(expiry);
+        Assert.Equal(JTokenType.Integer, expiry.Type);
+        Assert.Equal(seconds, expiry.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingCookieFilterExpirationDate()
     {
         DateTime now = DateTime.UtcNow.AddDays(1);
@@ -224,10 +241,10 @@ public class CookieFilterTests
         {
             Expires = expirationDate
         };
-        Assert.That(properties.Expires, Is.EqualTo(expirationDate));
+        Assert.Equal(expirationDate, properties.Expires);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingCookieFilterExpirationDateNull()
     {
         DateTime now = DateTime.UtcNow;
@@ -235,6 +252,6 @@ public class CookieFilterTests
         {
             Expires = null
         };
-        Assert.That(properties.Expires, Is.Null);
+        Assert.Null(properties.Expires);
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/DeleteCookiesCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/DeleteCookiesCommandParametersTests.cs
@@ -3,26 +3,25 @@ namespace WebDriverBiDi.Storage;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class DeleteCookiesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         DeleteCookiesCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("storage.deleteCookies"));
+        Assert.Equal("storage.deleteCookies", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         DeleteCookiesCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(0));
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCookieFilter()
     {
         DeleteCookiesCommandParameters properties = new()
@@ -34,20 +33,23 @@ public class DeleteCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("filter"));
-            Assert.That(serialized["filter"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject filterObject = serialized["filter"]!.Value<JObject>()!;
-            Assert.That(filterObject, Has.Count.EqualTo(1));
-            Assert.That(filterObject, Contains.Key("name"));
-            Assert.That(filterObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(filterObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("filter"));
+        JToken? filterToken = serialized["filter"];
+        Assert.NotNull(filterToken);
+        Assert.Equal(JTokenType.Object, filterToken.Type);
+        JObject? filterObject = filterToken as JObject;
+        Assert.NotNull(filterObject);
+        Assert.Single(filterObject);
+        Assert.True(filterObject.ContainsKey("name"));
+        JToken? filterName = filterObject["name"];
+        Assert.NotNull(filterName);
+        Assert.Equal(JTokenType.String, filterName.Type);
+        Assert.Equal("cookieName", filterName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBrowsingContextPartitionDescriptor()
     {
         DeleteCookiesCommandParameters properties = new()
@@ -56,23 +58,28 @@ public class DeleteCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(partitionObject, Contains.Key("context"));
-            Assert.That(partitionObject["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("context", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("context"));
+        JToken? partitionContext = partitionObject["context"];
+        Assert.NotNull(partitionContext);
+        Assert.Equal(JTokenType.String, partitionContext.Type);
+        Assert.Equal("myContext", partitionContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithStorageKeyPartitionDescriptor()
     {
         DeleteCookiesCommandParameters properties = new()
@@ -84,23 +91,28 @@ public class DeleteCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-            Assert.That(partitionObject, Contains.Key("userContext"));
-            Assert.That(partitionObject["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("storageKey", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("userContext"));
+        JToken? userContext = partitionObject["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAllValues()
     {
         DeleteCookiesCommandParameters properties = new()
@@ -113,26 +125,37 @@ public class DeleteCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("filter"));
-            Assert.That(serialized["filter"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject filterObject = serialized["filter"]!.Value<JObject>()!;
-            Assert.That(filterObject, Has.Count.EqualTo(1));
-            Assert.That(filterObject, Contains.Key("name"));
-            Assert.That(filterObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(filterObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(partitionObject, Contains.Key("context"));
-            Assert.That(partitionObject["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("filter"));
+        JToken? filterToken = serialized["filter"];
+        Assert.NotNull(filterToken);
+        Assert.Equal(JTokenType.Object, filterToken.Type);
+        JObject? filterObject = filterToken as JObject;
+        Assert.NotNull(filterObject);
+        Assert.Single(filterObject);
+        Assert.True(filterObject.ContainsKey("name"));
+        JToken? filterName = filterObject["name"];
+        Assert.NotNull(filterName);
+        Assert.Equal(JTokenType.String, filterName.Type);
+        Assert.Equal("cookieName", filterName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("context", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("context"));
+        JToken? partitionContext = partitionObject["context"];
+        Assert.NotNull(partitionContext);
+        Assert.Equal(JTokenType.String, partitionContext.Type);
+        Assert.Equal("myContext", partitionContext.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/DeleteCookiesCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/DeleteCookiesCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Storage;
 
 using System.Text.Json;
 
-[TestFixture]
 public class DeleteCookiesCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -18,19 +17,17 @@ public class DeleteCookiesCommandResultTests
                       }
                       """;
         DeleteCookiesCommandResult? result = JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.PartitionKey, Is.Not.Null);
-            Assert.That(result.PartitionKey.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.PartitionKey.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-            Assert.That(result.PartitionKey.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(result.PartitionKey.AdditionalData, Contains.Key("extraPropertyName"));
-            Assert.That(result.PartitionKey.AdditionalData["extraPropertyName"], Is.EqualTo("extraPropertyValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.PartitionKey);
+        Assert.Equal("myUserContext", result.PartitionKey.UserContextId);
+        Assert.Equal("mySourceOrigin", result.PartitionKey.SourceOrigin);
+        Assert.Single(result.PartitionKey.AdditionalData);
+        Assert.True(result.PartitionKey.AdditionalData.ContainsKey("extraPropertyName"));
+        Assert.Equal("extraPropertyValue", result.PartitionKey.AdditionalData["extraPropertyName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -43,12 +40,12 @@ public class DeleteCookiesCommandResultTests
                       }
                       """;
         DeleteCookiesCommandResult? result = JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         DeleteCookiesCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMissingData()
     {
         string json = """
@@ -57,24 +54,22 @@ public class DeleteCookiesCommandResultTests
                       }
                       """;
         DeleteCookiesCommandResult? result = JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.PartitionKey, Is.Not.Null);
-            Assert.That(result.PartitionKey.UserContextId, Is.Null);
-            Assert.That(result.PartitionKey.SourceOrigin, Is.Null);
-            Assert.That(result.PartitionKey.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.PartitionKey);
+        Assert.Null(result.PartitionKey.UserContextId);
+        Assert.Null(result.PartitionKey.SourceOrigin);
+        Assert.Empty(result.PartitionKey.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializingWithMissingPartition()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidPartitionDataTypeThrows()
     {
         string json = """
@@ -82,6 +77,6 @@ public class DeleteCookiesCommandResultTests
                         "partitionKey": "invalidPartitionType"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<DeleteCookiesCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/GetCookiesCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/GetCookiesCommandParametersTests.cs
@@ -3,26 +3,25 @@ namespace WebDriverBiDi.Storage;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class GetCookiesCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         GetCookiesCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("storage.getCookies"));
+        Assert.Equal("storage.getCookies", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         GetCookiesCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(0));
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithCookieFilter()
     {
         GetCookiesCommandParameters properties = new()
@@ -34,20 +33,23 @@ public class GetCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("filter"));
-            Assert.That(serialized["filter"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject filterObject = serialized["filter"]!.Value<JObject>()!;
-            Assert.That(filterObject, Has.Count.EqualTo(1));
-            Assert.That(filterObject, Contains.Key("name"));
-            Assert.That(filterObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(filterObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("filter"));
+        JToken? filterToken = serialized["filter"];
+        Assert.NotNull(filterToken);
+        Assert.Equal(JTokenType.Object, filterToken.Type);
+        JObject? filterObject = filterToken as JObject;
+        Assert.NotNull(filterObject);
+        Assert.Single(filterObject);
+        Assert.True(filterObject.ContainsKey("name"));
+        JToken? filterName = filterObject["name"];
+        Assert.NotNull(filterName);
+        Assert.Equal(JTokenType.String, filterName.Type);
+        Assert.Equal("cookieName", filterName.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBrowsingContextPartitionDescriptor()
     {
         GetCookiesCommandParameters properties = new()
@@ -56,23 +58,28 @@ public class GetCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(partitionObject, Contains.Key("context"));
-            Assert.That(partitionObject["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("context", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("context"));
+        JToken? partitionContext = partitionObject["context"];
+        Assert.NotNull(partitionContext);
+        Assert.Equal(JTokenType.String, partitionContext.Type);
+        Assert.Equal("myContext", partitionContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithStorageKeyPartitionDescriptor()
     {
         GetCookiesCommandParameters properties = new()
@@ -84,23 +91,28 @@ public class GetCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-            Assert.That(partitionObject, Contains.Key("userContext"));
-            Assert.That(partitionObject["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("storageKey", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("userContext"));
+        JToken? userContext = partitionObject["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithAllValues()
     {
         GetCookiesCommandParameters properties = new()
@@ -113,26 +125,37 @@ public class GetCookiesCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("filter"));
-            Assert.That(serialized["filter"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject filterObject = serialized["filter"]!.Value<JObject>()!;
-            Assert.That(filterObject, Has.Count.EqualTo(1));
-            Assert.That(filterObject, Contains.Key("name"));
-            Assert.That(filterObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(filterObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(partitionObject, Contains.Key("context"));
-            Assert.That(partitionObject["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("filter"));
+        JToken? filterToken = serialized["filter"];
+        Assert.NotNull(filterToken);
+        Assert.Equal(JTokenType.Object, filterToken.Type);
+        JObject? filterObject = filterToken as JObject;
+        Assert.NotNull(filterObject);
+        Assert.Single(filterObject);
+        Assert.True(filterObject.ContainsKey("name"));
+        JToken? filterName = filterObject["name"];
+        Assert.NotNull(filterName);
+        Assert.Equal(JTokenType.String, filterName.Type);
+        Assert.Equal("cookieName", filterName.Value<string>());
+
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("context", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("context"));
+        JToken? partitionContext = partitionObject["context"];
+        Assert.NotNull(partitionContext);
+        Assert.Equal(JTokenType.String, partitionContext.Type);
+        Assert.Equal("myContext", partitionContext.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/GetCookiesCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/GetCookiesCommandResultTests.cs
@@ -4,10 +4,9 @@ using System.Text.Json;
 
 using WebDriverBiDi.Network;
 
-[TestFixture]
 public class GetCookiesCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -39,31 +38,29 @@ public class GetCookiesCommandResultTests
                       }
                       """;
         GetCookiesCommandResult? result = JsonSerializer.Deserialize<GetCookiesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Cookies, Is.Not.Null);
-            Assert.That(result.Cookies, Has.Count.EqualTo(1));
-            Assert.That(result.Cookies[0].Name, Is.EqualTo("cookieName"));
-            Assert.That(result.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(result.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(result.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(result.Cookies[0].Path, Is.EqualTo("cookiePath"));
-            Assert.That(result.Cookies[0].Size, Is.EqualTo(123));
-            Assert.That(result.Cookies[0].HttpOnly, Is.False);
-            Assert.That(result.Cookies[0].Secure, Is.True);
-            Assert.That(result.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(result.Cookies[0].Expires, Is.EqualTo(expireTime));
-            Assert.That(result.PartitionKey, Is.Not.Null);
-            Assert.That(result.PartitionKey.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.PartitionKey.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-            Assert.That(result.PartitionKey.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(result.PartitionKey.AdditionalData, Contains.Key("extraPropertyName"));
-            Assert.That(result.PartitionKey.AdditionalData["extraPropertyName"], Is.EqualTo("extraPropertyValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.Cookies);
+        Assert.Single(result.Cookies);
+        Assert.Equal("cookieName", result.Cookies[0].Name);
+        Assert.Equal(BytesValueType.String, result.Cookies[0].Value.Type);
+        Assert.Equal("cookieValue", result.Cookies[0].Value.Value);
+        Assert.Equal("cookieDomain", result.Cookies[0].Domain);
+        Assert.Equal("cookiePath", result.Cookies[0].Path);
+        Assert.Equal(123, result.Cookies[0].Size);
+        Assert.False(result.Cookies[0].HttpOnly);
+        Assert.True(result.Cookies[0].Secure);
+        Assert.Equal(CookieSameSiteValue.Lax, result.Cookies[0].SameSite);
+        Assert.Equal(expireTime, result.Cookies[0].Expires);
+        Assert.NotNull(result.PartitionKey);
+        Assert.Equal("myUserContext", result.PartitionKey.UserContextId);
+        Assert.Equal("mySourceOrigin", result.PartitionKey.SourceOrigin);
+        Assert.Single(result.PartitionKey.AdditionalData);
+        Assert.True(result.PartitionKey.AdditionalData.ContainsKey("extraPropertyName"));
+        Assert.Equal("extraPropertyValue", result.PartitionKey.AdditionalData["extraPropertyName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithNoCookieData()
     {
         string json = """
@@ -73,19 +70,17 @@ public class GetCookiesCommandResultTests
                       }
                       """;
         GetCookiesCommandResult? result = JsonSerializer.Deserialize<GetCookiesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Cookies, Is.Not.Null);
-            Assert.That(result.Cookies, Is.Empty);
-            Assert.That(result.PartitionKey, Is.Not.Null);
-            Assert.That(result.PartitionKey.UserContextId, Is.Null);
-            Assert.That(result.PartitionKey.SourceOrigin, Is.Null);
-            Assert.That(result.PartitionKey.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.Cookies);
+        Assert.Empty(result.Cookies);
+        Assert.NotNull(result.PartitionKey);
+        Assert.Null(result.PartitionKey.UserContextId);
+        Assert.Null(result.PartitionKey.SourceOrigin);
+        Assert.Empty(result.PartitionKey.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -117,12 +112,12 @@ public class GetCookiesCommandResultTests
                       }
                       """;
         GetCookiesCommandResult? result = JsonSerializer.Deserialize<GetCookiesCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         GetCookiesCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingCookiesThrows()
     {
         string json = """
@@ -130,10 +125,10 @@ public class GetCookiesCommandResultTests
                         "partitionKey": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidCookiesDataTypeThrows()
     {
         string json = """
@@ -141,10 +136,10 @@ public class GetCookiesCommandResultTests
                         "cookies": "invalidCookieArrayType", "partitionKey": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingPartitionThrows()
     {
         string json = """
@@ -152,10 +147,10 @@ public class GetCookiesCommandResultTests
                         "cookies": []
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidPartitionDataTypeThrows()
     {
         string json = """
@@ -163,6 +158,6 @@ public class GetCookiesCommandResultTests
                         "cookies": [], "partitionKey": "invalidPartitionType"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<GetCookiesCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/PartialCookieTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/PartialCookieTests.cs
@@ -4,38 +4,51 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Network;
 
-[TestFixture]
 public class PartialCookieTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookie()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithPath()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -44,32 +57,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("path"));
-            Assert.That(serialized["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["path"]!.Value<string>(), Is.EqualTo("myCookiePath"));
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("path"));
+        JToken? path = serialized["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myCookiePath", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithSize()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -78,32 +108,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("size"));
-            Assert.That(serialized["size"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["size"]!.Value<ulong>(), Is.EqualTo(123));
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("size"));
+        JToken? size = serialized["size"];
+        Assert.NotNull(size);
+        Assert.Equal(JTokenType.Integer, size.Type);
+        Assert.Equal(123UL, size.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithHttpOnlyTrue()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -112,32 +159,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("httpOnly"));
-            Assert.That(serialized["httpOnly"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["httpOnly"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("httpOnly"));
+        JToken? httpOnly = serialized["httpOnly"];
+        Assert.NotNull(httpOnly);
+        Assert.Equal(JTokenType.Boolean, httpOnly.Type);
+        Assert.True(httpOnly.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithHttpOnlyFalse()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -146,32 +210,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("httpOnly"));
-            Assert.That(serialized["httpOnly"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["httpOnly"]!.Value<bool>(), Is.False);
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("httpOnly"));
+        JToken? httpOnly = serialized["httpOnly"];
+        Assert.NotNull(httpOnly);
+        Assert.Equal(JTokenType.Boolean, httpOnly.Type);
+        Assert.False(httpOnly.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithSecureTrue()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -180,32 +261,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("secure"));
-            Assert.That(serialized["secure"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["secure"]!.Value<bool>(), Is.True);
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("secure"));
+        JToken? secure = serialized["secure"];
+        Assert.NotNull(secure);
+        Assert.Equal(JTokenType.Boolean, secure.Type);
+        Assert.True(secure.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithSecureFalse()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -214,32 +312,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("secure"));
-            Assert.That(serialized["secure"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["secure"]!.Value<bool>(), Is.False);
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("secure"));
+        JToken? secure = serialized["secure"];
+        Assert.NotNull(secure);
+        Assert.Equal(JTokenType.Boolean, secure.Type);
+        Assert.False(secure.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithSameSiteNone()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -248,32 +363,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("sameSite"));
-            Assert.That(serialized["sameSite"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sameSite"]!.Value<string>(), Is.EqualTo("none"));
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sameSite"));
+        JToken? sameSite = serialized["sameSite"];
+        Assert.NotNull(sameSite);
+        Assert.Equal(JTokenType.String, sameSite.Type);
+        Assert.Equal("none", sameSite.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithSameSiteLax()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -282,32 +414,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("sameSite"));
-            Assert.That(serialized["sameSite"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sameSite"]!.Value<string>(), Is.EqualTo("lax"));
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sameSite"));
+        JToken? sameSite = serialized["sameSite"];
+        Assert.NotNull(sameSite);
+        Assert.Equal(JTokenType.String, sameSite.Type);
+        Assert.Equal("lax", sameSite.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithSameSiteStrict()
     {
         PartialCookie properties = new("myCookieName", BytesValue.FromString("myCookieValue"), "myCookieDomain")
@@ -316,32 +465,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("sameSite"));
-            Assert.That(serialized["sameSite"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sameSite"]!.Value<string>(), Is.EqualTo("strict"));
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sameSite"));
+        JToken? sameSite = serialized["sameSite"];
+        Assert.NotNull(sameSite);
+        Assert.Equal(JTokenType.String, sameSite.Type);
+        Assert.Equal("strict", sameSite.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithExpirationDate()
     {
         DateTime now = DateTime.UtcNow;
@@ -353,32 +519,49 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(4));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-            Assert.That(serialized, Contains.Key("expiry"));
-            Assert.That(serialized["expiry"]!.Type, Is.EqualTo(JTokenType.Integer));
-            Assert.That(serialized["expiry"]!.Value<ulong>(), Is.EqualTo(seconds));
-        }
+
+        Assert.Equal(4, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("expiry"));
+        JToken? expiry = serialized["expiry"];
+        Assert.NotNull(expiry);
+        Assert.Equal(JTokenType.Integer, expiry.Type);
+        Assert.Equal(seconds, expiry.Value<ulong>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePartialCookieWithNullExpirationDate()
     {
         DateTime now = DateTime.UtcNow;
@@ -389,29 +572,43 @@ public class PartialCookieTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("name"));
-            Assert.That(serialized["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["name"]!.Value<string>(), Is.EqualTo("myCookieName"));
-            Assert.That(serialized, Contains.Key("value"));
-            Assert.That(serialized["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partialCookieValueObject = serialized["value"]!.Value<JObject>()!;
-            Assert.That(partialCookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(partialCookieValueObject, Contains.Key("type"));
-            Assert.That(partialCookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(partialCookieValueObject, Contains.Key("value"));
-            Assert.That(partialCookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partialCookieValueObject["value"]!.Value<string>(), Is.EqualTo("myCookieValue"));
-            Assert.That(serialized, Contains.Key("domain"));
-            Assert.That(serialized["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["domain"]!.Value<string>(), Is.EqualTo("myCookieDomain"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("name"));
+        JToken? name = serialized["name"];
+        Assert.NotNull(name);
+        Assert.Equal(JTokenType.String, name.Type);
+        Assert.Equal("myCookieName", name.Value<string>());
+
+        Assert.True(serialized.ContainsKey("value"));
+        JToken? value = serialized["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.Object, value.Type);
+        JObject? partialCookieValueObject = value.Value<JObject>();
+        Assert.NotNull(partialCookieValueObject);
+        Assert.Equal(2, partialCookieValueObject.Count);
+
+        Assert.True(partialCookieValueObject.ContainsKey("type"));
+        JToken? valueType = partialCookieValueObject["type"];
+        Assert.NotNull(valueType);
+        Assert.Equal(JTokenType.String, valueType.Type);
+        Assert.Equal("string", valueType.Value<string>());
+
+        Assert.True(partialCookieValueObject.ContainsKey("value"));
+        JToken? valueValue = partialCookieValueObject["value"];
+        Assert.NotNull(valueValue);
+        Assert.Equal(JTokenType.String, valueValue.Type);
+        Assert.Equal("myCookieValue", valueValue.Value<string>());
+
+        Assert.True(serialized.ContainsKey("domain"));
+        JToken? domain = serialized["domain"];
+        Assert.NotNull(domain);
+        Assert.Equal(JTokenType.String, domain.Type);
+        Assert.Equal("myCookieDomain", domain.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestSettingPartialCookieExpirationDate()
     {
         DateTime now = DateTime.UtcNow.AddDays(1);
@@ -420,10 +617,10 @@ public class PartialCookieTests
         {
             Expires = expirationDate
         };
-        Assert.That(properties.Expires, Is.EqualTo(expirationDate));
+        Assert.Equal(expirationDate, properties.Expires);
     }
 
-    [Test]
+    [Fact]
     public void TestSettingPartialCookieExpirationDateNull()
     {
         DateTime now = DateTime.UtcNow;
@@ -431,6 +628,6 @@ public class PartialCookieTests
         {
             Expires = null
         };
-        Assert.That(properties.Expires, Is.Null);
+        Assert.Null(properties.Expires);
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/PartitionDescriptorTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/PartitionDescriptorTests.cs
@@ -3,43 +3,47 @@ namespace WebDriverBiDi.Storage;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class PartitionDescriptorTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeBrowsingContextPartitionDescriptor()
     {
         BrowsingContextPartitionDescriptor properties = new("myBrowsingContext");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(serialized, Contains.Key("context"));
-            Assert.That(serialized["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["context"]!.Value<string>(), Is.EqualTo("myBrowsingContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("context", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("context"));
+        JToken? context = serialized["context"];
+        Assert.NotNull(context);
+        Assert.Equal(JTokenType.String, context.Type);
+        Assert.Equal("myBrowsingContext", context.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeStorageKeyPartitionDescriptor()
     {
         StorageKeyPartitionDescriptor properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-        }
+
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("storageKey", type.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeStorageKeyPartitionDescriptorWithUserContext()
     {
         StorageKeyPartitionDescriptor properties = new()
@@ -48,19 +52,23 @@ public class PartitionDescriptorTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-            Assert.That(serialized, Contains.Key("userContext"));
-            Assert.That(serialized["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("storageKey", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContext"));
+        JToken? userContext = serialized["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeStorageKeyPartitionDescriptorWithSourceOrigin()
     {
         StorageKeyPartitionDescriptor properties = new()
@@ -69,19 +77,23 @@ public class PartitionDescriptorTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-            Assert.That(serialized, Contains.Key("sourceOrigin"));
-            Assert.That(serialized["sourceOrigin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sourceOrigin"]!.Value<string>(), Is.EqualTo("mySourceOrigin"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("storageKey", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sourceOrigin"));
+        JToken? sourceOrigin = serialized["sourceOrigin"];
+        Assert.NotNull(sourceOrigin);
+        Assert.Equal(JTokenType.String, sourceOrigin.Type);
+        Assert.Equal("mySourceOrigin", sourceOrigin.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeStorageKeyPartitionDescriptorWithAllProperties()
     {
         StorageKeyPartitionDescriptor properties = new()
@@ -91,18 +103,25 @@ public class PartitionDescriptorTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(3));
-            Assert.That(serialized, Contains.Key("type"));
-            Assert.That(serialized["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-            Assert.That(serialized, Contains.Key("userContext"));
-            Assert.That(serialized["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-            Assert.That(serialized, Contains.Key("sourceOrigin"));
-            Assert.That(serialized["sourceOrigin"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["sourceOrigin"]!.Value<string>(), Is.EqualTo("mySourceOrigin"));
-        }
+
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("type"));
+        JToken? type = serialized["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("storageKey", type.Value<string>());
+
+        Assert.True(serialized.ContainsKey("userContext"));
+        JToken? userContext = serialized["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
+
+        Assert.True(serialized.ContainsKey("sourceOrigin"));
+        JToken? sourceOrigin = serialized["sourceOrigin"];
+        Assert.NotNull(sourceOrigin);
+        Assert.Equal(JTokenType.String, sourceOrigin.Type);
+        Assert.Equal("mySourceOrigin", sourceOrigin.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/PartitionKeyTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/PartitionKeyTests.cs
@@ -2,24 +2,21 @@ namespace WebDriverBiDi.Storage;
 
 using System.Text.Json;
 
-[TestFixture]
 public class PartitionKeyTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserializePartitionKey()
     {
         string json = "{}";
         PartitionKey? result = JsonSerializer.Deserialize<PartitionKey>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContextId, Is.Null);
-            Assert.That(result.SourceOrigin, Is.Null);
-            Assert.That(result.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.Null(result.UserContextId);
+        Assert.Null(result.SourceOrigin);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializePartitionKeyWithUserContext()
     {
         string json = """
@@ -28,16 +25,14 @@ public class PartitionKeyTests
                       }
                       """;
         PartitionKey? result = JsonSerializer.Deserialize<PartitionKey>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.SourceOrigin, Is.Null);
-            Assert.That(result.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myUserContext", result.UserContextId);
+        Assert.Null(result.SourceOrigin);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializePartitionKeyWithSourceOrigin()
     {
         string json = """
@@ -46,16 +41,14 @@ public class PartitionKeyTests
                       }
                       """;
         PartitionKey? result = JsonSerializer.Deserialize<PartitionKey>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContextId, Is.Null);
-            Assert.That(result.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-            Assert.That(result.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.Null(result.UserContextId);
+        Assert.Equal("mySourceOrigin", result.SourceOrigin);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializePartitionKeyWithAdditionalData()
     {
         string json = """
@@ -64,25 +57,26 @@ public class PartitionKeyTests
                       }
                       """;
         PartitionKey? result = JsonSerializer.Deserialize<PartitionKey>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.UserContextId, Is.Null);
-            Assert.That(result.SourceOrigin, Is.Null);
-            Assert.That(result.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(result.AdditionalData, Contains.Key("extraData"));
-            Assert.That(result.AdditionalData["extraData"]!.GetType, Is.EqualTo(typeof(string)));
-            Assert.That(result.AdditionalData["extraData"]!, Is.EqualTo("myExtraData"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Null(result.UserContextId);
+        Assert.Null(result.SourceOrigin);
+        Assert.Single(result.AdditionalData);
+        Assert.True(result.AdditionalData.ContainsKey("extraData"));
+        Assert.NotNull(result.AdditionalData["extraData"]);
+        object? extraData = result.AdditionalData["extraData"];
+        Assert.NotNull(extraData);
+        Assert.Equal(typeof(string), extraData.GetType());
+        Assert.Equal("myExtraData", extraData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = "{}";
         PartitionKey? result = JsonSerializer.Deserialize<PartitionKey>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         PartitionKey copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/SetCookieCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/SetCookieCommandParametersTests.cs
@@ -4,49 +4,62 @@ using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using WebDriverBiDi.Network;
 
-[TestFixture]
 public class SetCookieCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetCookieCommandParameters properties = new(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain"));
-        Assert.That(properties.MethodName, Is.EqualTo("storage.setCookie"));
+        Assert.Equal("storage.setCookie", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetCookieCommandParameters properties = new(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("cookie"));
-            Assert.That(serialized["cookie"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieObject = serialized["cookie"]!.Value<JObject>()!;
-            Assert.That(cookieObject, Has.Count.EqualTo(3));
-            Assert.That(cookieObject, Contains.Key("name"));
-            Assert.That(cookieObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(cookieObject, Contains.Key("value"));
-            Assert.That(cookieObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieValueObject = cookieObject["value"]!.Value<JObject>()!;
-            Assert.That(cookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(cookieValueObject, Contains.Key("type"));
-            Assert.That(cookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(cookieValueObject, Contains.Key("value"));
-            Assert.That(cookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(cookieObject, Contains.Key("domain"));
-            Assert.That(cookieObject["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieObject["domain"]!.Value<string>(), Is.EqualTo("cookieDomain"));
-        }
+
+        Assert.Single(serialized);
+        Assert.True(serialized.ContainsKey("cookie"));
+        JToken? cookieToken = serialized["cookie"];
+        Assert.NotNull(cookieToken);
+        Assert.Equal(JTokenType.Object, cookieToken.Type);
+        JObject? cookieObject = cookieToken as JObject;
+        Assert.NotNull(cookieObject);
+        Assert.Equal(3, cookieObject.Count);
+        Assert.True(cookieObject.ContainsKey("name"));
+        JToken? cookieName = cookieObject["name"];
+        Assert.NotNull(cookieName);
+        Assert.Equal(JTokenType.String, cookieName.Type);
+        Assert.Equal("cookieName", cookieName.Value<string>());
+
+        Assert.True(cookieObject.ContainsKey("value"));
+        JToken? cookieValueToken = cookieObject["value"];
+        Assert.NotNull(cookieValueToken);
+        Assert.Equal(JTokenType.Object, cookieValueToken.Type);
+        JObject? cookieValueObject = cookieValueToken as JObject;
+        Assert.NotNull(cookieValueObject);
+        Assert.Equal(2, cookieValueObject.Count);
+        Assert.True(cookieValueObject.ContainsKey("type"));
+        JToken? cookieValueType = cookieValueObject["type"];
+        Assert.NotNull(cookieValueType);
+        Assert.Equal(JTokenType.String, cookieValueType.Type);
+        Assert.Equal("string", cookieValueType.Value<string>());
+        Assert.True(cookieValueObject.ContainsKey("value"));
+        JToken? cookieValueValue = cookieValueObject["value"];
+        Assert.NotNull(cookieValueValue);
+        Assert.Equal(JTokenType.String, cookieValueValue.Type);
+        Assert.Equal("cookieValue", cookieValueValue.Value<string>());
+
+        Assert.True(cookieObject.ContainsKey("domain"));
+        JToken? cookieDomain = cookieObject["domain"];
+        Assert.NotNull(cookieDomain);
+        Assert.Equal(JTokenType.String, cookieDomain.Type);
+        Assert.Equal("cookieDomain", cookieDomain.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBrowsingContextPartitionDescriptor()
     {
         SetCookieCommandParameters properties = new(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain"))
@@ -55,43 +68,65 @@ public class SetCookieCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("cookie"));
-            Assert.That(serialized["cookie"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieObject = serialized["cookie"]!.Value<JObject>()!;
-            Assert.That(cookieObject, Has.Count.EqualTo(3));
-            Assert.That(cookieObject, Contains.Key("name"));
-            Assert.That(cookieObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(cookieObject, Contains.Key("value"));
-            Assert.That(cookieObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieValueObject = cookieObject["value"]!.Value<JObject>()!;
-            Assert.That(cookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(cookieValueObject, Contains.Key("type"));
-            Assert.That(cookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(cookieValueObject, Contains.Key("value"));
-            Assert.That(cookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(cookieObject, Contains.Key("domain"));
-            Assert.That(cookieObject["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieObject["domain"]!.Value<string>(), Is.EqualTo("cookieDomain"));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("context"));
-            Assert.That(partitionObject, Contains.Key("context"));
-            Assert.That(partitionObject["context"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["context"]!.Value<string>(), Is.EqualTo("myContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("cookie"));
+        JToken? cookieToken = serialized["cookie"];
+        Assert.NotNull(cookieToken);
+        Assert.Equal(JTokenType.Object, cookieToken.Type);
+        JObject? cookieObject = cookieToken as JObject;
+        Assert.NotNull(cookieObject);
+        Assert.Equal(3, cookieObject.Count);
+        Assert.True(cookieObject.ContainsKey("name"));
+        JToken? cookieName = cookieObject["name"];
+        Assert.NotNull(cookieName);
+        Assert.Equal(JTokenType.String, cookieName.Type);
+        Assert.Equal("cookieName", cookieName.Value<string>());
+
+        Assert.True(cookieObject.ContainsKey("value"));
+        JToken? cookieValueToken = cookieObject["value"];
+        Assert.NotNull(cookieValueToken);
+        Assert.Equal(JTokenType.Object, cookieValueToken.Type);
+        JObject? cookieValueObject = cookieValueToken as JObject;
+        Assert.NotNull(cookieValueObject);
+        Assert.Equal(2, cookieValueObject.Count);
+        Assert.True(cookieValueObject.ContainsKey("type"));
+        JToken? cookieValueType = cookieValueObject["type"];
+        Assert.NotNull(cookieValueType);
+        Assert.Equal(JTokenType.String, cookieValueType.Type);
+        Assert.Equal("string", cookieValueType.Value<string>());
+        Assert.True(cookieValueObject.ContainsKey("value"));
+        JToken? cookieValueValue = cookieValueObject["value"];
+        Assert.NotNull(cookieValueValue);
+        Assert.Equal(JTokenType.String, cookieValueValue.Type);
+        Assert.Equal("cookieValue", cookieValueValue.Value<string>());
+
+        Assert.True(cookieObject.ContainsKey("domain"));
+        JToken? cookieDomain = cookieObject["domain"];
+        Assert.NotNull(cookieDomain);
+        Assert.Equal(JTokenType.String, cookieDomain.Type);
+        Assert.Equal("cookieDomain", cookieDomain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("context", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("context"));
+        JToken? partitionContext = partitionObject["context"];
+        Assert.NotNull(partitionContext);
+        Assert.Equal(JTokenType.String, partitionContext.Type);
+        Assert.Equal("myContext", partitionContext.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithStorageKeyPartitionDescriptor()
     {
         SetCookieCommandParameters properties = new(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain"))
@@ -103,39 +138,61 @@ public class SetCookieCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Has.Count.EqualTo(2));
-            Assert.That(serialized, Contains.Key("cookie"));
-            Assert.That(serialized["cookie"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieObject = serialized["cookie"]!.Value<JObject>()!;
-            Assert.That(cookieObject, Has.Count.EqualTo(3));
-            Assert.That(cookieObject, Contains.Key("name"));
-            Assert.That(cookieObject["name"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieObject["name"]!.Value<string>(), Is.EqualTo("cookieName"));
-            Assert.That(cookieObject, Contains.Key("value"));
-            Assert.That(cookieObject["value"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject cookieValueObject = cookieObject["value"]!.Value<JObject>()!;
-            Assert.That(cookieValueObject, Has.Count.EqualTo(2));
-            Assert.That(cookieValueObject, Contains.Key("type"));
-            Assert.That(cookieValueObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["type"]!.Value<string>(), Is.EqualTo("string"));
-            Assert.That(cookieValueObject, Contains.Key("value"));
-            Assert.That(cookieValueObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieValueObject["value"]!.Value<string>(), Is.EqualTo("cookieValue"));
-            Assert.That(cookieObject, Contains.Key("domain"));
-            Assert.That(cookieObject["domain"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(cookieObject["domain"]!.Value<string>(), Is.EqualTo("cookieDomain"));
-            Assert.That(serialized, Contains.Key("partition"));
-            Assert.That(serialized["partition"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject partitionObject = serialized["partition"]!.Value<JObject>()!;
-            Assert.That(partitionObject, Has.Count.EqualTo(2));
-            Assert.That(partitionObject, Contains.Key("type"));
-            Assert.That(partitionObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["type"]!.Value<string>(), Is.EqualTo("storageKey"));
-            Assert.That(partitionObject, Contains.Key("userContext"));
-            Assert.That(partitionObject["userContext"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(partitionObject["userContext"]!.Value<string>(), Is.EqualTo("myUserContext"));
-        }
+
+        Assert.Equal(2, serialized.Count);
+        Assert.True(serialized.ContainsKey("cookie"));
+        JToken? cookieToken = serialized["cookie"];
+        Assert.NotNull(cookieToken);
+        Assert.Equal(JTokenType.Object, cookieToken.Type);
+        JObject? cookieObject = cookieToken as JObject;
+        Assert.NotNull(cookieObject);
+        Assert.Equal(3, cookieObject.Count);
+        Assert.True(cookieObject.ContainsKey("name"));
+        JToken? cookieName = cookieObject["name"];
+        Assert.NotNull(cookieName);
+        Assert.Equal(JTokenType.String, cookieName.Type);
+        Assert.Equal("cookieName", cookieName.Value<string>());
+
+        Assert.True(cookieObject.ContainsKey("value"));
+        JToken? cookieValueToken = cookieObject["value"];
+        Assert.NotNull(cookieValueToken);
+        Assert.Equal(JTokenType.Object, cookieValueToken.Type);
+        JObject? cookieValueObject = cookieValueToken as JObject;
+        Assert.NotNull(cookieValueObject);
+        Assert.Equal(2, cookieValueObject.Count);
+        Assert.True(cookieValueObject.ContainsKey("type"));
+        JToken? cookieValueType = cookieValueObject["type"];
+        Assert.NotNull(cookieValueType);
+        Assert.Equal(JTokenType.String, cookieValueType.Type);
+        Assert.Equal("string", cookieValueType.Value<string>());
+        Assert.True(cookieValueObject.ContainsKey("value"));
+        JToken? cookieValueValue = cookieValueObject["value"];
+        Assert.NotNull(cookieValueValue);
+        Assert.Equal(JTokenType.String, cookieValueValue.Type);
+        Assert.Equal("cookieValue", cookieValueValue.Value<string>());
+
+        Assert.True(cookieObject.ContainsKey("domain"));
+        JToken? cookieDomain = cookieObject["domain"];
+        Assert.NotNull(cookieDomain);
+        Assert.Equal(JTokenType.String, cookieDomain.Type);
+        Assert.Equal("cookieDomain", cookieDomain.Value<string>());
+
+        Assert.True(serialized.ContainsKey("partition"));
+        JToken? partitionToken = serialized["partition"];
+        Assert.NotNull(partitionToken);
+        Assert.Equal(JTokenType.Object, partitionToken.Type);
+        JObject? partitionObject = partitionToken as JObject;
+        Assert.NotNull(partitionObject);
+        Assert.Equal(2, partitionObject.Count);
+        Assert.True(partitionObject.ContainsKey("type"));
+        JToken? partitionType = partitionObject["type"];
+        Assert.NotNull(partitionType);
+        Assert.Equal(JTokenType.String, partitionType.Type);
+        Assert.Equal("storageKey", partitionType.Value<string>());
+        Assert.True(partitionObject.ContainsKey("userContext"));
+        JToken? userContext = partitionObject["userContext"];
+        Assert.NotNull(userContext);
+        Assert.Equal(JTokenType.String, userContext.Type);
+        Assert.Equal("myUserContext", userContext.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/SetCookieCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/SetCookieCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.Storage;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetCookieCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -18,19 +17,17 @@ public class SetCookieCommandResultTests
                       }
                       """;
         SetCookieCommandResult? result = JsonSerializer.Deserialize<SetCookieCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.PartitionKey, Is.Not.Null);
-            Assert.That(result.PartitionKey.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.PartitionKey.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-            Assert.That(result.PartitionKey.AdditionalData, Has.Count.EqualTo(1));
-            Assert.That(result.PartitionKey.AdditionalData, Contains.Key("extraPropertyName"));
-            Assert.That(result.PartitionKey.AdditionalData["extraPropertyName"], Is.EqualTo("extraPropertyValue"));
-        }
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.PartitionKey);
+        Assert.Equal("myUserContext", result.PartitionKey.UserContextId);
+        Assert.Equal("mySourceOrigin", result.PartitionKey.SourceOrigin);
+        Assert.Single(result.PartitionKey.AdditionalData);
+        Assert.True(result.PartitionKey.AdditionalData.ContainsKey("extraPropertyName"));
+        Assert.Equal("extraPropertyValue", result.PartitionKey.AdditionalData["extraPropertyName"]);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializeWithMissingData()
     {
         string json = """
@@ -39,24 +36,22 @@ public class SetCookieCommandResultTests
                       }
                       """;
         SetCookieCommandResult? result = JsonSerializer.Deserialize<SetCookieCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.PartitionKey, Is.Not.Null);
-            Assert.That(result.PartitionKey.UserContextId, Is.Null);
-            Assert.That(result.PartitionKey.SourceOrigin, Is.Null);
-            Assert.That(result.PartitionKey.AdditionalData, Is.Empty);
-        }
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.PartitionKey);
+        Assert.Null(result.PartitionKey.UserContextId);
+        Assert.Null(result.PartitionKey.SourceOrigin);
+        Assert.Empty(result.PartitionKey.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCanDeserializingWithMissingPartition()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<SetCookieCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetCookieCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -69,12 +64,12 @@ public class SetCookieCommandResultTests
                       }
                       """;
         SetCookieCommandResult? result = JsonSerializer.Deserialize<SetCookieCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetCookieCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidPartitionDataTypeThrows()
     {
         string json = """
@@ -82,6 +77,6 @@ public class SetCookieCommandResultTests
                         "partitionKey": "invalidPartitionType"
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<SetCookieCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<SetCookieCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
@@ -48,7 +48,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<GetCookiesCommandResult> task = module.GetCookiesAsync(new GetCookiesCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
         GetCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
@@ -91,7 +91,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<GetCookiesCommandResult> task = module.GetCookiesAsync(cancellationToken: TestContext.Current.CancellationToken);
         GetCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
@@ -120,7 +120,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<DeleteCookiesCommandResult> task = module.DeleteCookiesAsync(cancellationToken: TestContext.Current.CancellationToken);
         DeleteCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
@@ -151,7 +151,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<SetCookieCommandResult> task = module.SetCookieAsync(new SetCookieCommandParameters(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain")), cancellationToken: TestContext.Current.CancellationToken);
         SetCookieCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
@@ -185,7 +185,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
         Task<DeleteCookiesCommandResult> task = module.DeleteCookiesAsync(new DeleteCookiesCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
         DeleteCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
@@ -46,7 +46,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -89,7 +89,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -118,7 +118,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -149,7 +149,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -183,7 +183,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
@@ -4,10 +4,9 @@ using WebDriverBiDi.Network;
 using WebDriverBiDi.Protocol;
 using WebDriverBiDi.TestUtilities;
 
-[TestFixture]
 public class StorageModuleTests()
 {
-    [Test]
+    [Fact]
     public async Task TestGetCookiesCommand()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
@@ -49,32 +48,29 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<GetCookiesCommandResult> task = module.GetCookiesAsync(new GetCookiesCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetCookiesCommandResult result = task.Result;
+        Task<GetCookiesCommandResult> task = module.GetCookiesAsync(new GetCookiesCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        GetCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Cookies, Has.Count.EqualTo(1));
-            Assert.That(result.Cookies[0].Name, Is.EqualTo("cookieName"));
-            Assert.That(result.Cookies[0].Value.Type, Is.EqualTo(BytesValueType.String));
-            Assert.That(result.Cookies[0].Value.Value, Is.EqualTo("cookieValue"));
-            Assert.That(result.Cookies[0].Domain, Is.EqualTo("cookieDomain"));
-            Assert.That(result.Cookies[0].Path, Is.EqualTo("cookiePath"));
-            Assert.That(result.Cookies[0].Size, Is.EqualTo(123));
-            Assert.That(result.Cookies[0].Secure, Is.True);
-            Assert.That(result.Cookies[0].HttpOnly, Is.False);
-            Assert.That(result.Cookies[0].SameSite, Is.EqualTo(CookieSameSiteValue.Lax));
-            Assert.That(result.Cookies[0].Expires, Is.EqualTo(expireTime));
-            Assert.That(result.PartitionKey.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.PartitionKey.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Single(result.Cookies);
+        Assert.Equal("cookieName", result.Cookies[0].Name);
+        Assert.Equal(BytesValueType.String, result.Cookies[0].Value.Type);
+        Assert.Equal("cookieValue", result.Cookies[0].Value.Value);
+        Assert.Equal("cookieDomain", result.Cookies[0].Domain);
+        Assert.Equal("cookiePath", result.Cookies[0].Path);
+        Assert.Equal(123, result.Cookies[0].Size);
+        Assert.True(result.Cookies[0].Secure);
+        Assert.False(result.Cookies[0].HttpOnly);
+        Assert.Equal(CookieSameSiteValue.Lax, result.Cookies[0].SameSite);
+        Assert.Equal(expireTime, result.Cookies[0].Expires);
+        Assert.Equal("myUserContext", result.PartitionKey.UserContextId);
+        Assert.Equal("mySourceOrigin", result.PartitionKey.SourceOrigin);
     }
 
-    [Test]
+    [Fact]
     public async Task TestGetCookiesCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -95,17 +91,16 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<GetCookiesCommandResult> task = module.GetCookiesAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        GetCookiesCommandResult result = task.Result;
+        Task<GetCookiesCommandResult> task = module.GetCookiesAsync(cancellationToken: TestContext.Current.CancellationToken);
+        GetCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Cookies, Has.Count.EqualTo(0));
+        Assert.NotNull(result);
+        Assert.Empty(result.Cookies);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDeleteCookiesCommandWithNoArgument()
     {
         TestWebSocketConnection connection = new();
@@ -125,16 +120,15 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<DeleteCookiesCommandResult> task = module.DeleteCookiesAsync();
-        task.Wait(TimeSpan.FromSeconds(1));
-        DeleteCookiesCommandResult result = task.Result;
+        Task<DeleteCookiesCommandResult> task = module.DeleteCookiesAsync(cancellationToken: TestContext.Current.CancellationToken);
+        DeleteCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 
-    [Test]
+    [Fact]
     public async Task TestSetCookieCommand()
     {
         TestWebSocketConnection connection = new();
@@ -157,21 +151,18 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<SetCookieCommandResult> task = module.SetCookieAsync(new SetCookieCommandParameters(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain")));
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetCookieCommandResult result = task.Result;
+        Task<SetCookieCommandResult> task = module.SetCookieAsync(new SetCookieCommandParameters(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain")), cancellationToken: TestContext.Current.CancellationToken);
+        SetCookieCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.PartitionKey.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.PartitionKey.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myUserContext", result.PartitionKey.UserContextId);
+        Assert.Equal("mySourceOrigin", result.PartitionKey.SourceOrigin);
     }
 
-    [Test]
+    [Fact]
     public async Task TestDeleteCookiesCommand()
     {
         TestWebSocketConnection connection = new();
@@ -194,17 +185,14 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = driver.Storage;
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
-        Task<DeleteCookiesCommandResult> task = module.DeleteCookiesAsync(new DeleteCookiesCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        DeleteCookiesCommandResult result = task.Result;
+        Task<DeleteCookiesCommandResult> task = module.DeleteCookiesAsync(new DeleteCookiesCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        DeleteCookiesCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.PartitionKey.UserContextId, Is.EqualTo("myUserContext"));
-            Assert.That(result.PartitionKey.SourceOrigin, Is.EqualTo("mySourceOrigin"));
-        }
+        Assert.NotNull(result);
+
+        Assert.Equal("myUserContext", result.PartitionKey.UserContextId);
+        Assert.Equal("mySourceOrigin", result.PartitionKey.SourceOrigin);
     }
 }

--- a/test/WebDriverBiDi.Tests/StringEnumConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/StringEnumConverterTests.cs
@@ -1,70 +1,69 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class StringEnumValueConverterTests
 {
-    [Test]
+    [Fact]
     public void ShouldConvertEnumValue()
     {
         StringEnumValueConverter<BasicEnum> converter = new();
-        Assert.That(converter.GetString(BasicEnum.FirstValue), Is.EqualTo("firstvalue"));
+        Assert.Equal("firstvalue", converter.GetString(BasicEnum.FirstValue));
     }
 
-    [Test]
+    [Fact]
     public void ShouldConvertEnumValueWithCustomSerializedValue()
     {
         StringEnumValueConverter<BasicEnum> converter = new();
-        Assert.That(converter.GetString(BasicEnum.SecondValue), Is.EqualTo("second-value"));
+        Assert.Equal("second-value", converter.GetString(BasicEnum.SecondValue));
     }
 
-    [Test]
+    [Fact]
     public void ShouldConvertStringToBasicValue()
     {
         StringEnumValueConverter<BasicEnum> converter = new();
-        Assert.That(converter.GetValue("firstvalue"), Is.EqualTo(BasicEnum.FirstValue));
+        Assert.Equal(BasicEnum.FirstValue, converter.GetValue("firstvalue"));
     }
 
-    [Test]
+    [Fact]
     public void ShouldConvertStringToCustomValue()
     {
         StringEnumValueConverter<BasicEnum> converter = new();
-        Assert.That(converter.GetValue("second-value"), Is.EqualTo(BasicEnum.SecondValue));
+        Assert.Equal(BasicEnum.SecondValue, converter.GetValue("second-value"));
     }
 
-    [Test]
+    [Fact]
     public void ShouldConvertInvalidStringValueWhenDefaultAttributeSet()
     {
         StringEnumValueConverter<EnumWithDefault> converter = new();
         EnumWithDefault value = converter.GetValue("invalid");
-        Assert.That(value, Is.EqualTo(EnumWithDefault.DefaultValue));
+        Assert.Equal(EnumWithDefault.DefaultValue, value);
     }
 
-    [Test]
+    [Fact]
     public void ConvertInvalidStringValueThrows()
     {
         StringEnumValueConverter<BasicEnum> converter = new();
-        Assert.That(() => converter.GetValue("invalid"), Throws.InstanceOf<ArgumentException>());
+        Assert.ThrowsAny<ArgumentException>(() => converter.GetValue("invalid"));
     }
 
-    [Test]
+    [Fact]
     public void TryConvertInvalidStringValueReturnsFalseWithNoDefaultSpecified()
     {
         StringEnumValueConverter<BasicEnum> converter = new();
-        Assert.That(converter.TryGetValue("invalid", out _), Is.False);
+        Assert.False(converter.TryGetValue("invalid", out _));
     }
 
-    [Test]
+    [Fact]
     public void TryConvertInvalidStringValueReturnsFalseWithDefaultSpecified()
     {
         StringEnumValueConverter<EnumWithDefault> converter = new();
-        Assert.That(converter.TryGetValue("invalid", out _), Is.False);
+        Assert.False(converter.TryGetValue("invalid", out _));
     }
 
-    [Test]
+    [Fact]
     public void ConvertInvalidEnumValueThrows()
     {
         StringEnumValueConverter<FlagEnum> converter = new();
-        Assert.That(() => converter.GetString(FlagEnum.FirstValue | FlagEnum.SecondValue), Throws.InstanceOf<ArgumentException>());
+        Assert.ThrowsAny<ArgumentException>(() => converter.GetString(FlagEnum.FirstValue | FlagEnum.SecondValue));
     }
 
     private enum BasicEnum

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestEventListener.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestEventListener.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Tracing;
 /// </summary>
 public class TestEventListener : EventListener
 {
+    private readonly object eventListObject = new();
     private readonly List<EventWrittenEventArgs> events = new();
 
     protected override void OnEventSourceCreated(EventSource eventSource)
@@ -21,7 +22,7 @@ public class TestEventListener : EventListener
     {
         if (eventData.EventSource.Name == "WebDriverBiDi")
         {
-            lock (this.events)
+            lock (this.eventListObject)
             {
                 this.events.Add(eventData);
             }
@@ -37,14 +38,14 @@ public class TestEventListener : EventListener
     {
         DateTime timeoutTime = DateTime.Now.Add(timeout);
         List<EventWrittenEventArgs> foundEvents;
-        lock (this.events)
+        lock (this.eventListObject)
         {
             foundEvents = this.events.Where(e => eventNames.Contains(e.EventName)).ToList();
         }
 
         while (timeout > TimeSpan.Zero && foundEvents.Count == 0 && DateTime.Now <= timeoutTime)
         {
-            lock (this.events)
+            lock (this.eventListObject)
             {
                 foundEvents = this.events.Where(e => eventNames.Contains(e.EventName)).ToList();
             }
@@ -55,7 +56,7 @@ public class TestEventListener : EventListener
 
     public void ClearEvents()
     {
-        lock (this.events)
+        lock (this.eventListObject)
         {
             this.events.Clear();
         }

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestPipeServer.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestPipeServer.cs
@@ -71,16 +71,17 @@ public class TestPipeServer : IPipeServerProcessProvider
     public bool WaitForDataSent(TimeSpan timeout)
     {
         Task timeoutTask = Task.Delay(timeout);
-        Task peekTask = Task.Run(async () =>
-        {
-            if (this.ServerProcess is not null)
+        Task peekTask = Task.Run(
+            async () =>
             {
-                while (this.ServerProcess.StandardOutput.Peek() < 0)
+                if (this.ServerProcess is not null)
                 {
-                    await Task.Delay(TimeSpan.FromMilliseconds(50));
+                    while (this.ServerProcess.StandardOutput.Peek() < 0)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(50));
+                    }
                 }
-            }
-        });
+            });
         int completedTaskIndex = Task.WaitAny(peekTask, timeoutTask);
         return completedTaskIndex == 0;
     }

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestTransport.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestTransport.cs
@@ -138,8 +138,8 @@ public class TestTransport : Transport
     /// </summary>
     public void EnableConnectLockConcurrencyTesting()
     {
-        ManualResetEventSlim connectionMethodHasLock = new(false);
-        ManualResetEventSlim otherMethodBlocked = new(false);
+        TaskCompletionSource firstCallerReadyTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource secondCallerReadyTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         this.BeforeAcquireLockCallback = async () =>
         {
             int currentCallCount = Interlocked.Increment(ref this.concurrentConnectLockAcquisitions);
@@ -148,8 +148,8 @@ public class TestTransport : Transport
                 // ConnectAsync or DisconnectAsync is first into the AcquireConnectionLockAsync,
                 // and is about to acquire the lock. Signal it, then wait for the other method
                 // to also enter the callback.
-                connectionMethodHasLock.Set();
-                await Task.Run(() => otherMethodBlocked.Wait());
+                firstCallerReadyTaskCompletionSource.TrySetResult();
+                await secondCallerReadyTaskCompletionSource.Task;
             }
             else if (currentCallCount == 2)
             {
@@ -157,8 +157,8 @@ public class TestTransport : Transport
                 // Signal that it's here, then wait for ConnectAsync or DisconnectAsync
                 // to signal it is acquiring the lock, and add a small delay so the
                 // semaphore is held by ConnectAsync or DisconnectAsync.
-                otherMethodBlocked.Set();
-                await Task.Run(() => connectionMethodHasLock.Wait());
+                secondCallerReadyTaskCompletionSource.TrySetResult();
+                await firstCallerReadyTaskCompletionSource.Task;
                 await Task.Delay(TimeSpan.FromMilliseconds(50));
             }
         };
@@ -240,9 +240,9 @@ public class TestTransport : Transport
             // TaskCompletionSource.SetException(IEnumerable<Exception>) produces a
             // faulted task whose Exception.InnerExceptions contains every supplied
             // exception, which is what we need to drive the Count != 1 branch.
-            TaskCompletionSource tcs = new();
-            tcs.SetException(this.ReadLoopOuterFault);
-            return tcs.Task;
+            TaskCompletionSource taskCompletionSource = new();
+            taskCompletionSource.SetException(this.ReadLoopOuterFault);
+            return taskCompletionSource.Task;
         }
 
         return base.ReadIncomingMessagesAsync();

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestTransport.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestTransport.cs
@@ -75,8 +75,16 @@ public class TestTransport : Transport
 
         if (this.ReturnCustomValue)
         {
-            Command returnedCommand = new Command(this.LastCommandId, commandParameters);
-            returnedCommand.SetResult(this.CustomReturnValue!);
+            Command returnedCommand = new(this.LastCommandId, commandParameters);
+            if (this.CustomReturnValue is null)
+            {
+                returnedCommand.SetResult(null!);
+            }
+            else
+            {
+                returnedCommand.SetResult(this.CustomReturnValue);
+            }
+
             return returnedCommand;
         }
 

--- a/test/WebDriverBiDi.Tests/TestUtilities/TestWebSocketConnectionDataSetEventArgs.cs
+++ b/test/WebDriverBiDi.Tests/TestUtilities/TestWebSocketConnectionDataSetEventArgs.cs
@@ -12,12 +12,14 @@ public class TestWebSocketConnectionDataSentEventArgs : EventArgs
         if (dataSent is not null)
         {
             JObject jsonObject = JObject.Parse(dataSent);
-            this.sentCommandId = jsonObject["id"]!.Value<long>();
-            this.sentCommandName = jsonObject["method"]!.Value<string>();
+            JToken? id = jsonObject["id"];
+            JToken? method = jsonObject["method"];
+            this.sentCommandId = id?.Value<long>();
+            this.sentCommandName = method?.Value<string>();
         }
     }
 
-    public long SentCommandId => this.sentCommandId!.Value;
+    public long SentCommandId => this.sentCommandId ?? -1;
 
     public string? SentCommandName => this.sentCommandName;
 }

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/BrandVersionTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/BrandVersionTests.cs
@@ -3,24 +3,26 @@ namespace WebDriverBiDi.UserAgentClientHints;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class BrandVersionTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         BrandVersion brandVersion = new("myBrand", "myVersion");
         string json = JsonSerializer.Serialize(brandVersion);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("brand"));
-            Assert.That(serialized["brand"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["brand"]!.Value<string>, Is.EqualTo("myBrand"));
-            Assert.That(serialized, Contains.Key("version"));
-            Assert.That(serialized["version"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["version"]!.Value<string>, Is.EqualTo("myVersion"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("brand"));
+        JToken? brand = serialized["brand"];
+        Assert.NotNull(brand);
+        Assert.Equal(JTokenType.String, brand.Type);
+        Assert.Equal("myBrand", brand.Value<string>());
+
+        Assert.True(serialized.ContainsKey("version"));
+        JToken? version = serialized["version"];
+        Assert.NotNull(version);
+        Assert.Equal(JTokenType.String, version.Type);
+        Assert.Equal("myVersion", version.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/ClientHintsMetadataTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/ClientHintsMetadataTests.cs
@@ -3,20 +3,19 @@ namespace WebDriverBiDi.UserAgentClientHints;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ClientHintsMetadataTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerialize()
     {
         ClientHintsMetadata metadata = new();
         string json = JsonSerializer.Serialize(metadata);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Is.Not.Null);
-        Assert.That(serialized, Is.Empty);
+        Assert.NotNull(serialized);
+        Assert.Empty(serialized);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOptionalProperties()
     {
         ClientHintsMetadata metadata = new()
@@ -34,51 +33,78 @@ public class ClientHintsMetadataTests
         };
         string json = JsonSerializer.Serialize(metadata);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(10));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("brands"));
-            Assert.That(serialized["brands"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? brandArray = serialized["brands"]!.Value<JArray>();
-            Assert.That(brandArray, Is.Not.Null);
-            Assert.That(brandArray, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("fullVersionList"));
-            Assert.That(serialized["fullVersionList"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? fullVersionListArray = serialized["fullVersionList"]!.Value<JArray>();
-            Assert.That(fullVersionListArray, Is.Not.Null);
-            Assert.That(fullVersionListArray, Has.Count.EqualTo(1));
-            Assert.That(serialized, Contains.Key("platform"));
-            Assert.That(serialized["platform"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["platform"]!.Value<string>(), Is.EqualTo("myPlatform"));
-            Assert.That(serialized, Contains.Key("platformVersion"));
-            Assert.That(serialized["platformVersion"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["platformVersion"]!.Value<string>(), Is.EqualTo("myPlatformVersion"));
-            Assert.That(serialized, Contains.Key("architecture"));
-            Assert.That(serialized["architecture"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["architecture"]!.Value<string>(), Is.EqualTo("myArchitecture"));
-            Assert.That(serialized, Contains.Key("model"));
-            Assert.That(serialized["model"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["model"]!.Value<string>(), Is.EqualTo("myModel"));
-            Assert.That(serialized, Contains.Key("mobile"));
-            Assert.That(serialized["mobile"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["mobile"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("bitness"));
-            Assert.That(serialized["bitness"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["bitness"]!.Value<string>(), Is.EqualTo("myBitness"));
-            Assert.That(serialized, Contains.Key("wow64"));
-            Assert.That(serialized["wow64"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["wow64"]!.Value<bool>(), Is.False);
-            Assert.That(serialized, Contains.Key("formFactors"));
-            Assert.That(serialized["formFactors"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? formFactorsArray = serialized["formFactors"]!.Value<JArray>();
-            Assert.That(formFactorsArray, Is.Not.Null);
-            Assert.That(formFactorsArray, Has.Count.EqualTo(1));
-            Assert.That(formFactorsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(formFactorsArray![0].Value<string>(), Is.EqualTo("myFormFactor"));
-        }
+        Assert.Equal(10, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("brands"));
+        JToken? brandsToken = serialized["brands"];
+        Assert.NotNull(brandsToken);
+        Assert.Equal(JTokenType.Array, brandsToken.Type);
+        JArray? brandArray = brandsToken.Value<JArray>();
+        Assert.NotNull(brandArray);
+        Assert.Single(brandArray);
+
+        Assert.True(serialized.ContainsKey("fullVersionList"));
+        JToken? fullVersionListToken = serialized["fullVersionList"];
+        Assert.NotNull(fullVersionListToken);
+        Assert.Equal(JTokenType.Array, fullVersionListToken.Type);
+        JArray? fullVersionListArray = fullVersionListToken.Value<JArray>();
+        Assert.NotNull(fullVersionListArray);
+        Assert.Single(fullVersionListArray);
+
+        Assert.True(serialized.ContainsKey("platform"));
+        JToken? platform = serialized["platform"];
+        Assert.NotNull(platform);
+        Assert.Equal(JTokenType.String, platform.Type);
+        Assert.Equal("myPlatform", platform.Value<string>());
+
+        Assert.True(serialized.ContainsKey("platformVersion"));
+        JToken? platformVersion = serialized["platformVersion"];
+        Assert.NotNull(platformVersion);
+        Assert.Equal(JTokenType.String, platformVersion.Type);
+        Assert.Equal("myPlatformVersion", platformVersion.Value<string>());
+
+        Assert.True(serialized.ContainsKey("architecture"));
+        JToken? architecture = serialized["architecture"];
+        Assert.NotNull(architecture);
+        Assert.Equal(JTokenType.String, architecture.Type);
+        Assert.Equal("myArchitecture", architecture.Value<string>());
+
+        Assert.True(serialized.ContainsKey("model"));
+        JToken? model = serialized["model"];
+        Assert.NotNull(model);
+        Assert.Equal(JTokenType.String, model.Type);
+        Assert.Equal("myModel", model.Value<string>());
+
+        Assert.True(serialized.ContainsKey("mobile"));
+        JToken? mobile = serialized["mobile"];
+        Assert.NotNull(mobile);
+        Assert.Equal(JTokenType.Boolean, mobile.Type);
+        Assert.False(mobile.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("bitness"));
+        JToken? bitness = serialized["bitness"];
+        Assert.NotNull(bitness);
+        Assert.Equal(JTokenType.String, bitness.Type);
+        Assert.Equal("myBitness", bitness.Value<string>());
+
+        Assert.True(serialized.ContainsKey("wow64"));
+        JToken? wow64 = serialized["wow64"];
+        Assert.NotNull(wow64);
+        Assert.Equal(JTokenType.Boolean, wow64.Type);
+        Assert.False(wow64.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("formFactors"));
+        JToken? formFactorsToken = serialized["formFactors"];
+        Assert.NotNull(formFactorsToken);
+        Assert.Equal(JTokenType.Array, formFactorsToken.Type);
+        JArray? formFactorsArray = formFactorsToken.Value<JArray>();
+        Assert.NotNull(formFactorsArray);
+        Assert.Single(formFactorsArray);
+        Assert.Equal(JTokenType.String, formFactorsArray[0].Type);
+        Assert.Equal("myFormFactor", formFactorsArray[0].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithOptionalBooleanTrueProperties()
     {
         ClientHintsMetadata metadata = new()
@@ -88,18 +114,21 @@ public class ClientHintsMetadataTests
         };
         string json = JsonSerializer.Serialize(metadata);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized["mobile"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["mobile"]!.Value<bool>(), Is.True);
-            Assert.That(serialized, Contains.Key("wow64"));
-            Assert.That(serialized["wow64"]!.Type, Is.EqualTo(JTokenType.Boolean));
-            Assert.That(serialized["wow64"]!.Value<bool>(), Is.True);
-        }
+        Assert.Equal(2, serialized.Count);
+
+        JToken? mobile = serialized["mobile"];
+        Assert.NotNull(mobile);
+        Assert.Equal(JTokenType.Boolean, mobile.Type);
+        Assert.True(mobile.Value<bool>());
+
+        Assert.True(serialized.ContainsKey("wow64"));
+        JToken? wow64 = serialized["wow64"];
+        Assert.NotNull(wow64);
+        Assert.Equal(JTokenType.Boolean, wow64.Type);
+        Assert.True(wow64.Value<bool>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeWithEmptyListProperties()
     {
         ClientHintsMetadata metadata = new()
@@ -110,24 +139,30 @@ public class ClientHintsMetadataTests
         };
         string json = JsonSerializer.Serialize(metadata);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(3));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("brands"));
-            Assert.That(serialized["brands"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? brandArray = serialized["brands"]!.Value<JArray>();
-            Assert.That(brandArray, Is.Not.Null);
-            Assert.That(brandArray, Is.Empty);
-            Assert.That(serialized, Contains.Key("fullVersionList"));
-            Assert.That(serialized["fullVersionList"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? fullVersionListArray = serialized["fullVersionList"]!.Value<JArray>();
-            Assert.That(fullVersionListArray, Is.Not.Null);
-            Assert.That(fullVersionListArray, Is.Empty);
-            Assert.That(serialized, Contains.Key("formFactors"));
-            Assert.That(serialized["formFactors"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? formFactorsArray = serialized["formFactors"]!.Value<JArray>();
-            Assert.That(formFactorsArray, Is.Not.Null);
-            Assert.That(formFactorsArray, Is.Empty);
-        }
+        Assert.Equal(3, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("brands"));
+        JToken? brandsToken = serialized["brands"];
+        Assert.NotNull(brandsToken);
+        Assert.Equal(JTokenType.Array, brandsToken.Type);
+        JArray? brandArray = brandsToken.Value<JArray>();
+        Assert.NotNull(brandArray);
+        Assert.Empty(brandArray);
+
+        Assert.True(serialized.ContainsKey("fullVersionList"));
+        JToken? fullVersionListToken = serialized["fullVersionList"];
+        Assert.NotNull(fullVersionListToken);
+        Assert.Equal(JTokenType.Array, fullVersionListToken.Type);
+        JArray? fullVersionListArray = fullVersionListToken.Value<JArray>();
+        Assert.NotNull(fullVersionListArray);
+        Assert.Empty(fullVersionListArray);
+
+        Assert.True(serialized.ContainsKey("formFactors"));
+        JToken? formFactorsToken = serialized["formFactors"];
+        Assert.NotNull(formFactorsToken);
+        Assert.Equal(JTokenType.Array, formFactorsToken.Type);
+        JArray? formFactorsArray = formFactorsToken.Value<JArray>();
+        Assert.NotNull(formFactorsArray);
+        Assert.Empty(formFactorsArray);
     }
 }

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/SetClientHintsOverrideCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/SetClientHintsOverrideCommandParametersTests.cs
@@ -3,32 +3,31 @@ namespace WebDriverBiDi.UserAgentClientHints;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class SetClientHintsOverrideCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         SetClientHintsOverrideCommandParameters properties = new();
-        Assert.That(properties.MethodName, Is.EqualTo("userAgentClientHints.setClientHintsOverride"));
+        Assert.Equal("userAgentClientHints.setClientHintsOverride", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         SetClientHintsOverrideCommandParameters properties = new();
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientHints"));
-            Assert.That(serialized["clientHints"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["clientHints"]!.Value<JObject?>, Is.Null);
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("clientHints"));
+        JToken? clientHints = serialized["clientHints"];
+        Assert.NotNull(clientHints);
+        Assert.Equal(JTokenType.Null, clientHints.Type);
+        Assert.Null(clientHints.Value<JObject?>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithClientHints()
     {
         SetClientHintsOverrideCommandParameters properties = new()
@@ -40,20 +39,22 @@ public class SetClientHintsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientHints"));
-            Assert.That(serialized["clientHints"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject? clientHintsObject = serialized["clientHints"]!.Value<JObject>();
-            Assert.That(clientHintsObject, Is.Not.Null);
-            Assert.That(clientHintsObject, Has.Count.EqualTo(1));
-            Assert.That(clientHintsObject, Contains.Key("platform"));
-            Assert.That(clientHintsObject!["platform"]!.Value<string>(), Is.EqualTo("myPlatform"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("clientHints"));
+        JToken? clientHintsToken = serialized["clientHints"];
+        Assert.NotNull(clientHintsToken);
+        Assert.Equal(JTokenType.Object, clientHintsToken.Type);
+        JObject? clientHintsObject = clientHintsToken as JObject;
+        Assert.NotNull(clientHintsObject);
+        Assert.Single(clientHintsObject);
+        Assert.True(clientHintsObject.ContainsKey("platform"));
+        JToken? platform = clientHintsObject["platform"];
+        Assert.NotNull(platform);
+        Assert.Equal("myPlatform", platform.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithContexts()
     {
         SetClientHintsOverrideCommandParameters properties = new()
@@ -66,24 +67,28 @@ public class SetClientHintsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientHints"));
-            Assert.That(serialized["clientHints"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["clientHints"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("contexts"));
-            Assert.That(serialized["contexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? contextsArray = serialized["contexts"]!.Value<JArray>();
-            Assert.That(contextsArray, Has.Count.EqualTo(2));
-            Assert.That(contextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[0].Value<string>(), Is.EqualTo("context1"));
-            Assert.That(contextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(contextsArray[1].Value<string>(), Is.EqualTo("context2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientHints"));
+        JToken? clientHints = serialized["clientHints"];
+        Assert.NotNull(clientHints);
+        Assert.Equal(JTokenType.Null, clientHints.Type);
+        Assert.Null(clientHints.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("contexts"));
+        JToken? contextsToken = serialized["contexts"];
+        Assert.NotNull(contextsToken);
+        Assert.Equal(JTokenType.Array, contextsToken.Type);
+        JArray? contextsArray = contextsToken as JArray;
+        Assert.NotNull(contextsArray);
+        Assert.Equal(2, contextsArray.Count);
+        Assert.Equal(JTokenType.String, contextsArray[0].Type);
+        Assert.Equal("context1", contextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, contextsArray[1].Type);
+        Assert.Equal("context2", contextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializePropertiesWithUserContexts()
     {
         SetClientHintsOverrideCommandParameters properties = new()
@@ -96,41 +101,43 @@ public class SetClientHintsOverrideCommandParametersTests
         };
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("clientHints"));
-            Assert.That(serialized["clientHints"]!.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(serialized["clientHints"]!.Value<JObject?>(), Is.Null);
-            Assert.That(serialized, Contains.Key("userContexts"));
-            Assert.That(serialized["userContexts"]!.Type, Is.EqualTo(JTokenType.Array));
-            JArray? userContextsArray = serialized["userContexts"]!.Value<JArray>();
-            Assert.That(userContextsArray, Has.Count.EqualTo(2));
-            Assert.That(userContextsArray![0].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[0].Value<string>(), Is.EqualTo("userContext1"));
-            Assert.That(userContextsArray[1].Type, Is.EqualTo(JTokenType.String));
-            Assert.That(userContextsArray[1].Value<string>(), Is.EqualTo("userContext2"));
-        }
+        Assert.Equal(2, serialized.Count);
+
+        Assert.True(serialized.ContainsKey("clientHints"));
+        JToken? clientHints = serialized["clientHints"];
+        Assert.NotNull(clientHints);
+        Assert.Equal(JTokenType.Null, clientHints.Type);
+        Assert.Null(clientHints.Value<JObject?>());
+
+        Assert.True(serialized.ContainsKey("userContexts"));
+        JToken? userContextsToken = serialized["userContexts"];
+        Assert.NotNull(userContextsToken);
+        Assert.Equal(JTokenType.Array, userContextsToken.Type);
+        JArray? userContextsArray = userContextsToken as JArray;
+        Assert.NotNull(userContextsArray);
+        Assert.Equal(2, userContextsArray.Count);
+        Assert.Equal(JTokenType.String, userContextsArray[0].Type);
+        Assert.Equal("userContext1", userContextsArray[0].Value<string>());
+        Assert.Equal(JTokenType.String, userContextsArray[1].Type);
+        Assert.Equal("userContext2", userContextsArray[1].Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanGetResetParameters()
     {
         SetClientHintsOverrideCommandParameters properties = SetClientHintsOverrideCommandParameters.ResetClientHintsOverride;
-        Assert.That(properties, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(properties.ClientHints, Is.Null);
-            Assert.That(properties.Contexts, Is.Null);
-            Assert.That(properties.UserContexts, Is.Null);
-        }
+        Assert.NotNull(properties);
+
+        Assert.Null(properties.ClientHints);
+        Assert.Null(properties.Contexts);
+        Assert.Null(properties.UserContexts);
     }
 
-    [Test]
+    [Fact]
     public void TestResetParametersPropertyReturnsNewInstance()
     {
         SetClientHintsOverrideCommandParameters firstInstance = SetClientHintsOverrideCommandParameters.ResetClientHintsOverride;
         SetClientHintsOverrideCommandParameters secondInstance = SetClientHintsOverrideCommandParameters.ResetClientHintsOverride;
-        Assert.That(firstInstance, Is.Not.SameAs(secondInstance));
+        Assert.NotSame(secondInstance, firstInstance);
     }
 }

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/SetClientHintsOverrideCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/SetClientHintsOverrideCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.UserAgentClientHints;
 
 using System.Text.Json;
 
-[TestFixture]
 public class SetClientHintsOverrideCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         SetClientHintsOverrideCommandResult? result = JsonSerializer.Deserialize<SetClientHintsOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         SetClientHintsOverrideCommandResult? result = JsonSerializer.Deserialize<SetClientHintsOverrideCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         SetClientHintsOverrideCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
@@ -21,7 +21,7 @@ public class UserAgentClientHintsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         UserAgentClientHintsModule module = driver.UserAgentClientHints;
 
         Task<SetClientHintsOverrideCommandResult> task = module.SetClientHintsOverrideAsync(new SetClientHintsOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
@@ -20,7 +20,7 @@ public class UserAgentClientHintsModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         UserAgentClientHintsModule module = driver.UserAgentClientHints;
 

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.UserAgentClientHints;
 
 using TestUtilities;
 
-[TestFixture]
 public class UserAgentClientHintsModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestSetClientHintsOverrideCommand()
     {
         TestWebSocketConnection connection = new();
@@ -22,13 +21,12 @@ public class UserAgentClientHintsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         UserAgentClientHintsModule module = driver.UserAgentClientHints;
 
-        Task<SetClientHintsOverrideCommandResult> task = module.SetClientHintsOverrideAsync(new SetClientHintsOverrideCommandParameters());
-        task.Wait(TimeSpan.FromSeconds(1));
-        SetClientHintsOverrideCommandResult result = task.Result;
+        Task<SetClientHintsOverrideCommandResult> task = module.SetClientHintsOverrideAsync(new SetClientHintsOverrideCommandParameters(), cancellationToken: TestContext.Current.CancellationToken);
+        SetClientHintsOverrideCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/Usings.cs
+++ b/test/WebDriverBiDi.Tests/Usings.cs
@@ -1,3 +1,3 @@
 global using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(MaxParallelThreads = -1)]

--- a/test/WebDriverBiDi.Tests/Usings.cs
+++ b/test/WebDriverBiDi.Tests/Usings.cs
@@ -1,1 +1,3 @@
-global using NUnit.Framework;
+global using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/WebDriverBiDi.Tests/WebDriverBiDi.Tests.csproj
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDi.Tests.csproj
@@ -9,21 +9,17 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <EnableNUnitRunner>true</EnableNUnitRunner>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0">
+      <PrivateAssets>none</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="coverlet.MTP" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PinchHitter" Version="0.0.19" />
   </ItemGroup>
 

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiCommandExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiCommandExceptionTests.cs
@@ -1,69 +1,62 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class WebDriverBiDiCommandExceptionTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithNoArguments()
     {
         WebDriverBiDiCommandException exception = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.Not.Null);
-            Assert.That(exception.ErrorDetails, Is.Not.Null);
-            Assert.That(exception.ErrorCode, Is.EqualTo(ErrorCode.UnsetErrorCode));
-            Assert.That(exception.ProtocolErrorMessage, Is.EqualTo(string.Empty));
-            Assert.That(exception.RemoteStackTrace, Is.Null);
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.NotNull(exception.Message);
+        Assert.NotNull(exception.ErrorDetails);
+        Assert.Equal(ErrorCode.UnsetErrorCode, exception.ErrorCode);
+        Assert.Equal(string.Empty, exception.ProtocolErrorMessage);
+        Assert.Null(exception.RemoteStackTrace);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithErrorResult()
     {
         ErrorResult errorResult = ErrorResult.FromErrorInformation("invalid argument", "This is a test error message", "remote stack trace");
         WebDriverBiDiCommandException exception = new("Test exception message", errorResult);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.ErrorDetails, Is.SameAs(errorResult));
-            Assert.That(exception.ErrorCode, Is.EqualTo(ErrorCode.InvalidArgument));
-            Assert.That(exception.ProtocolErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(exception.RemoteStackTrace, Is.EqualTo("remote stack trace"));
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(errorResult, exception.ErrorDetails);
+        Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+        Assert.Equal("This is a test error message", exception.ProtocolErrorMessage);
+        Assert.Equal("remote stack trace", exception.RemoteStackTrace);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithInnerException()
     {
         ErrorResult errorResult = ErrorResult.FromErrorInformation("unknown command", "This is a test error message", null);
         InvalidOperationException innerException = new("inner exception message");
         WebDriverBiDiCommandException exception = new("Test exception message", errorResult, innerException);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.ErrorDetails, Is.SameAs(errorResult));
-            Assert.That(exception.ErrorCode, Is.EqualTo(ErrorCode.UnknownCommand));
-            Assert.That(exception.ProtocolErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(exception.RemoteStackTrace, Is.Null);
-            Assert.That(exception.InnerException, Is.SameAs(innerException));
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(errorResult, exception.ErrorDetails);
+        Assert.Equal(ErrorCode.UnknownCommand, exception.ErrorCode);
+        Assert.Equal("This is a test error message", exception.ProtocolErrorMessage);
+        Assert.Null(exception.RemoteStackTrace);
+        Assert.Same(innerException, exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiErrorResponseException()
     {
         ErrorResult errorResult = ErrorResult.FromErrorInformation("no such frame", "Frame not found", null);
         WebDriverBiDiCommandException exception = new("Test exception message", errorResult);
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiErrorResponseException>());
+        Assert.IsType<WebDriverBiDiErrorResponseException>(exception, exactMatch: false);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiException()
     {
         ErrorResult errorResult = ErrorResult.FromErrorInformation("no such frame", "Frame not found", null);
         WebDriverBiDiCommandException exception = new("Test exception message", errorResult);
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiException>());
+        Assert.IsType<WebDriverBiDiException>(exception, exactMatch: false);
     }
 }

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiConnectionExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiConnectionExceptionTests.cs
@@ -3,50 +3,43 @@ namespace WebDriverBiDi;
 using System.Text.Json;
 using WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class WebDriverBiDiConnectionExceptionTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithNoArguments()
     {
         WebDriverBiDiConnectionException exception = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.Not.Null);
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.NotNull(exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreate()
     {
         WebDriverBiDiConnectionException exception = new("Test exception message");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithInnerException()
     {
         ErrorResult errorResult = CreateErrorResult("unknown command", "This is a test error message", null);
         InvalidOperationException innerException = new("inner exception message");
         WebDriverBiDiConnectionException exception = new("Test exception message", innerException);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.SameAs(innerException));
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(innerException, exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiException()
     {
         ErrorResult errorResult = CreateErrorResult("no such frame", "Frame not found", null);
         WebDriverBiDiConnectionException exception = new("Test exception message");
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiException>());
+        Assert.IsType<WebDriverBiDiException>(exception, exactMatch: false);
     }
 
     private static ErrorResult CreateErrorResult(string errorType, string errorMessage, string? stackTrace)
@@ -62,7 +55,8 @@ public class WebDriverBiDiConnectionExceptionTests
                           "message": "{{errorMessage}}"{{stackTraceProperty}}
                         }
                         """;
-        ErrorResponseMessage messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json)!;
+        ErrorResponseMessage? messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
+        Assert.NotNull(messageResult);
         return messageResult.GetErrorResponseData();
     }
 }

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiEventSourceTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiEventSourceTests.cs
@@ -1,403 +1,379 @@
 namespace WebDriverBiDi;
 
 using System.Diagnostics.Tracing;
-using TestUtilities;
 
 /// <summary>
 /// Tests for WebDriverBiDiEventSource to ensure events are emitted correctly
 /// and maintain 100% code coverage.
 /// </summary>
-[TestFixture]
+[Collection("EventSourceTests")]
 public class WebDriverBiDiEventSourceTests
 {
-    [Test]
+    [Fact]
     public void TestEventSourceExists()
     {
-        Assert.That(WebDriverBiDiEventSource.RaiseEvent, Is.Not.Null);
+        Assert.NotNull(WebDriverBiDiEventSource.RaiseEvent);
     }
 
-    [Test]
+    [Fact]
     public void TestEventSourceName()
     {
-        Assert.That(WebDriverBiDiEventSource.RaiseEvent.Name, Is.EqualTo("WebDriverBiDi"));
+        Assert.Equal("WebDriverBiDi", WebDriverBiDiEventSource.RaiseEvent.Name);
     }
 
-    [Test]
+    [Fact]
     public void TestConnectionOpeningEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.ConnectionOpening("conn-123", "ws://localhost:9222");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(1));
-            Assert.That(evt.EventName, Is.EqualTo("ConnectionOpening"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-            Assert.That(evt.Payload, Has.Count.EqualTo(2));
-            Assert.That(evt.Payload![0], Is.EqualTo("conn-123"));
-            Assert.That(evt.Payload![1], Is.EqualTo("ws://localhost:9222"));
-        }
+
+        Assert.Equal(1, evt.EventId);
+        Assert.Equal("ConnectionOpening", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal(2, evt.Payload.Count);
+        Assert.Equal("conn-123", evt.Payload[0]);
+        Assert.Equal("ws://localhost:9222", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestConnectionOpenedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.ConnectionOpened("conn-123", "ws://localhost:9222");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(2));
-            Assert.That(evt.EventName, Is.EqualTo("ConnectionOpened"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-        }
+
+        Assert.Equal(2, evt.EventId);
+        Assert.Equal("ConnectionOpened", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
     }
 
-    [Test]
+    [Fact]
     public void TestConnectionClosingEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.ConnectionClosing("conn-123", "Normal shutdown");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(3));
-            Assert.That(evt.EventName, Is.EqualTo("ConnectionClosing"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-            Assert.That(evt.Payload![1], Is.EqualTo("Normal shutdown"));
-        }
+
+        Assert.Equal(3, evt.EventId);
+        Assert.Equal("ConnectionClosing", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("Normal shutdown", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestConnectionClosedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.ConnectionClosed("conn-123");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(4));
-            Assert.That(evt.EventName, Is.EqualTo("ConnectionClosed"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-        }
+
+        Assert.Equal(4, evt.EventId);
+        Assert.Equal("ConnectionClosed", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
     }
 
-    [Test]
+    [Fact]
     public void TestConnectionErrorEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.ConnectionError("conn-123", "Socket closed unexpectedly");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(5));
-            Assert.That(evt.EventName, Is.EqualTo("ConnectionError"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Error));
-            Assert.That(evt.Payload![1], Is.EqualTo("Socket closed unexpectedly"));
-        }
+
+        Assert.Equal(5, evt.EventId);
+        Assert.Equal("ConnectionError", evt.EventName);
+        Assert.Equal(EventLevel.Error, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("Socket closed unexpectedly", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestCommandSendingEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CommandSending("1", "session.status");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(6));
-            Assert.That(evt.EventName, Is.EqualTo("CommandSending"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Verbose));
-            Assert.That(evt.Payload![0], Is.EqualTo("1"));
-            Assert.That(evt.Payload![1], Is.EqualTo("session.status"));
-        }
+
+        Assert.Equal(6, evt.EventId);
+        Assert.Equal("CommandSending", evt.EventName);
+        Assert.Equal(EventLevel.Verbose, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("1", evt.Payload[0]);
+        Assert.Equal("session.status", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestCommandCompletedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CommandCompleted("1", "session.status", 42);
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(7));
-            Assert.That(evt.EventName, Is.EqualTo("CommandCompleted"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-            Assert.That(evt.Payload![0], Is.EqualTo("1"));
-            Assert.That(evt.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(evt.Payload![2], Is.EqualTo(42L));
-        }
+
+        Assert.Equal(7, evt.EventId);
+        Assert.Equal("CommandCompleted", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("1", evt.Payload[0]);
+        Assert.Equal("session.status", evt.Payload[1]);
+        Assert.Equal(42L, evt.Payload[2]);
     }
 
-    [Test]
+    [Fact]
     public void TestCommandTimeoutEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CommandTimeout("1", "session.status", 5000);
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(8));
-            Assert.That(evt.EventName, Is.EqualTo("CommandTimeout"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Warning));
-            Assert.That(evt.Payload![2], Is.EqualTo(5000L));
-        }
+
+        Assert.Equal(8, evt.EventId);
+        Assert.Equal("CommandTimeout", evt.EventName);
+        Assert.Equal(EventLevel.Warning, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal(5000L, evt.Payload[2]);
     }
 
-    [Test]
+    [Fact]
     public void TestCommandErrorEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CommandError("1", "session.status", ErrorCode.InvalidSessionId, "invalid session id", "Session not found");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(9));
-            Assert.That(evt.EventName, Is.EqualTo("CommandError"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Error));
-            Assert.That(evt.Payload![2], Is.EqualTo(ErrorCode.InvalidSessionId));
-            Assert.That(evt.Payload![3], Is.EqualTo("invalid session id"));
-            Assert.That(evt.Payload![4], Is.EqualTo("Session not found"));
-        }
+
+        Assert.Equal(9, evt.EventId);
+        Assert.Equal("CommandError", evt.EventName);
+        Assert.Equal(EventLevel.Error, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal(ErrorCode.InvalidSessionId, evt.Payload[2]);
+        Assert.Equal("invalid session id", evt.Payload[3]);
+        Assert.Equal("Session not found", evt.Payload[4]);
     }
 
-    [Test]
+    [Fact]
     public void TestEventReceivedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.EventReceived("browsingContext.navigationStarted");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(10));
-            Assert.That(evt.EventName, Is.EqualTo("EventReceived"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Verbose));
-            Assert.That(evt.Payload![0], Is.EqualTo("browsingContext.navigationStarted"));
-        }
+
+        Assert.Equal(10, evt.EventId);
+        Assert.Equal("EventReceived", evt.EventName);
+        Assert.Equal(EventLevel.Verbose, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("browsingContext.navigationStarted", evt.Payload[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestUnknownMessageReceivedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.UnknownMessageReceived("unknown", 256);
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(13));
-            Assert.That(evt.EventName, Is.EqualTo("UnknownMessageReceived"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Warning));
-            Assert.That(evt.Payload![0], Is.EqualTo("unknown"));
-            Assert.That(evt.Payload![1], Is.EqualTo(256));
-        }
+
+        Assert.Equal(13, evt.EventId);
+        Assert.Equal("UnknownMessageReceived", evt.EventName);
+        Assert.Equal(EventLevel.Warning, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("unknown", evt.Payload[0]);
+        Assert.Equal(256, evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestProtocolErrorEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.ProtocolError("Invalid JSON", "{\"invalid");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(14));
-            Assert.That(evt.EventName, Is.EqualTo("ProtocolError"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Error));
-            Assert.That(evt.Payload![0], Is.EqualTo("Invalid JSON"));
-            Assert.That(evt.Payload![1], Is.EqualTo("{\"invalid"));
-        }
+
+        Assert.Equal(14, evt.EventId);
+        Assert.Equal("ProtocolError", evt.EventName);
+        Assert.Equal(EventLevel.Error, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("Invalid JSON", evt.Payload[0]);
+        Assert.Equal("{\"invalid", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestEventHandlerErrorEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.EventHandlerError("log.entryAdded", "NullReferenceException");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(15));
-            Assert.That(evt.EventName, Is.EqualTo("EventHandlerError"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Warning));
-            Assert.That(evt.Payload![0], Is.EqualTo("log.entryAdded"));
-            Assert.That(evt.Payload![1], Is.EqualTo("NullReferenceException"));
-        }
+
+        Assert.Equal(15, evt.EventId);
+        Assert.Equal("EventHandlerError", evt.EventName);
+        Assert.Equal(EventLevel.Warning, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("log.entryAdded", evt.Payload[0]);
+        Assert.Equal("NullReferenceException", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestPendingCommandCountEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.PendingCommandCount(5);
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(16));
-            Assert.That(evt.EventName, Is.EqualTo("PendingCommandCount"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Verbose));
-            Assert.That(evt.Payload![0], Is.EqualTo(5));
-        }
+
+        Assert.Equal(16, evt.EventId);
+        Assert.Equal("PendingCommandCount", evt.EventName);
+        Assert.Equal(EventLevel.Verbose, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal(5, evt.Payload[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestTransportStartedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.TransportStarted();
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(17));
-            Assert.That(evt.EventName, Is.EqualTo("TransportStarted"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-        }
+
+        Assert.Equal(17, evt.EventId);
+        Assert.Equal("TransportStarted", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
     }
 
-    [Test]
+    [Fact]
     public void TestTransportStoppedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.TransportStopped("Normal shutdown");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(18));
-            Assert.That(evt.EventName, Is.EqualTo("TransportStopped"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-            Assert.That(evt.Payload![0], Is.EqualTo("Normal shutdown"));
-        }
+
+        Assert.Equal(18, evt.EventId);
+        Assert.Equal("TransportStopped", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("Normal shutdown", evt.Payload[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestCustomModuleRegisteredEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CustomModuleRegistered("myModule");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(19));
-            Assert.That(evt.EventName, Is.EqualTo("CustomModuleRegistered"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-            Assert.That(evt.Payload![0], Is.EqualTo("myModule"));
-        }
+
+        Assert.Equal(19, evt.EventId);
+        Assert.Equal("CustomModuleRegistered", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("myModule", evt.Payload[0]);
     }
 
-    [Test]
+    [Fact]
     public void TestCustomEventRegisteredEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CustomEventRegistered("myModule.myEvent", "MyEventType");
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(20));
-            Assert.That(evt.EventName, Is.EqualTo("CustomEventRegistered"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Informational));
-            Assert.That(evt.Payload![0], Is.EqualTo("myModule.myEvent"));
-            Assert.That(evt.Payload![1], Is.EqualTo("MyEventType"));
-        }
+
+        Assert.Equal(20, evt.EventId);
+        Assert.Equal("CustomEventRegistered", evt.EventName);
+        Assert.Equal(EventLevel.Informational, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("myModule.myEvent", evt.Payload[0]);
+        Assert.Equal("MyEventType", evt.Payload[1]);
     }
 
-    [Test]
+    [Fact]
     public void TestMessageStatisticsEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.MessageStatistics(100, 95, 80, 5);
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(21));
-            Assert.That(evt.EventName, Is.EqualTo("MessageStatistics"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Verbose));
-            Assert.That(evt.Payload![0], Is.EqualTo(100L));
-            Assert.That(evt.Payload![1], Is.EqualTo(95L));
-            Assert.That(evt.Payload![2], Is.EqualTo(80L));
-            Assert.That(evt.Payload![3], Is.EqualTo(5L));
-        }
+
+        Assert.Equal(21, evt.EventId);
+        Assert.Equal("MessageStatistics", evt.EventName);
+        Assert.Equal(EventLevel.Verbose, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal(100L, evt.Payload[0]);
+        Assert.Equal(95L, evt.Payload[1]);
+        Assert.Equal(80L, evt.Payload[2]);
+        Assert.Equal(5L, evt.Payload[3]);
     }
 
-    [Test]
+    [Fact]
     public void TestCommandSendFailedEventEmitted()
     {
         TestEventListener listener = new();
         WebDriverBiDiEventSource.RaiseEvent.CommandSendFailed("1", "session.status", "System.InvalidOperationException", "Simulated send failure", 12);
         listener.Dispose();
 
-        Assert.That(listener.Events, Has.Count.EqualTo(1));
+        Assert.Single(listener.Events);
         EventWrittenEventArgs evt = listener.Events[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt.EventId, Is.EqualTo(22));
-            Assert.That(evt.EventName, Is.EqualTo("CommandSendFailed"));
-            Assert.That(evt.Level, Is.EqualTo(EventLevel.Warning));
-            Assert.That(evt.Payload![0], Is.EqualTo("1"));
-            Assert.That(evt.Payload![1], Is.EqualTo("session.status"));
-            Assert.That(evt.Payload![2], Is.EqualTo("System.InvalidOperationException"));
-            Assert.That(evt.Payload![3], Is.EqualTo("Simulated send failure"));
-            Assert.That(evt.Payload![4], Is.EqualTo(12L));
-        }
+
+        Assert.Equal(22, evt.EventId);
+        Assert.Equal("CommandSendFailed", evt.EventName);
+        Assert.Equal(EventLevel.Warning, evt.Level);
+        Assert.NotNull(evt.Payload);
+        Assert.Equal("1", evt.Payload[0]);
+        Assert.Equal("session.status", evt.Payload[1]);
+        Assert.Equal("System.InvalidOperationException", evt.Payload[2]);
+        Assert.Equal("Simulated send failure", evt.Payload[3]);
+        Assert.Equal(12L, evt.Payload[4]);
     }
 
-    [Test]
+    [Fact]
     public void TestEventSourceDoesNotEmitWhenDisabled()
     {
         // Don't create a listener - EventSource should be disabled by default
@@ -407,10 +383,9 @@ public class WebDriverBiDiEventSourceTests
         WebDriverBiDiEventSource.RaiseEvent.EventReceived("test.event");
 
         // If we get here without exceptions, the test passes
-        Assert.Pass();
     }
 
-    [Test]
+    [Fact]
     public void TestEventSourceRespectEventLevel()
     {
         TestEventListener listener = new(EventLevel.Warning);
@@ -428,16 +403,14 @@ public class WebDriverBiDiEventSourceTests
         // Should have captured at least the Warning and Error events we just emitted
         // Filter to events with our unique identifiers to avoid test interference
         List<EventWrittenEventArgs> relevantEvents = listener.Events
-            .Where(e => (e.EventName == "CommandTimeout" && e.Payload![1]?.ToString() == "test.respect.level") ||
-                       (e.EventName == "ConnectionError" && e.Payload![1]?.ToString() == "error-respect-level"))
+            .Where(e => (e.EventName == "CommandTimeout" && e.Payload?[1]?.ToString() == "test.respect.level") ||
+                       (e.EventName == "ConnectionError" && e.Payload?[1]?.ToString() == "error-respect-level"))
             .ToList();
 
-        Assert.That(relevantEvents, Has.Count.EqualTo(2));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(relevantEvents[0].EventName, Is.EqualTo("CommandTimeout"));
-            Assert.That(relevantEvents[1].EventName, Is.EqualTo("ConnectionError"));
-        }
+        Assert.Equal(2, relevantEvents.Count);
+
+        Assert.Equal("CommandTimeout", relevantEvents[0].EventName);
+        Assert.Equal("ConnectionError", relevantEvents[1].EventName);
     }
 
     /// <summary>

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiEventSourceTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiEventSourceTests.cs
@@ -418,12 +418,13 @@ public class WebDriverBiDiEventSourceTests
     /// </summary>
     private class TestEventListener : EventListener
     {
+        private readonly object eventLockObject = new();
         private readonly EventLevel minimumLevel;
 
         public TestEventListener(EventLevel minimumLevel = EventLevel.Verbose)
         {
             this.minimumLevel = minimumLevel;
-            this.Events = new List<EventWrittenEventArgs>();
+            this.Events = [];
         }
 
         public List<EventWrittenEventArgs> Events { get; }
@@ -440,7 +441,10 @@ public class WebDriverBiDiEventSourceTests
         {
             if (eventData.EventSource.Name == "WebDriverBiDi")
             {
-                this.Events.Add(eventData);
+                lock (this.eventLockObject)
+                {
+                    this.Events.Add(eventData);
+                }
             }
         }
     }

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiExceptionTests.cs
@@ -1,39 +1,32 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class WebDriverBiDiExceptionTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithNoArguments()
     {
         WebDriverBiDiException exception = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.Not.Null);
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.NotNull(exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreate()
     {
         WebDriverBiDiException exception = new("Test exception message");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithInnerException()
     {
         InvalidOperationException innerException = new("inner exception message");
         WebDriverBiDiException exception = new("Test exception message", innerException);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.SameAs(innerException));
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(innerException, exception.InnerException);
     }
 }

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiProtocolExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiProtocolExceptionTests.cs
@@ -3,71 +3,64 @@ namespace WebDriverBiDi;
 using System.Text.Json;
 using WebDriverBiDi.Protocol;
 
-[TestFixture]
 public class WebDriverBiDiProtocolExceptionTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithNoArguments()
     {
         WebDriverBiDiProtocolException exception = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.Not.Null);
-            Assert.That(exception.ErrorDetails, Is.Not.Null);
-            Assert.That(exception.ErrorCode, Is.EqualTo(ErrorCode.UnsetErrorCode));
-            Assert.That(exception.ProtocolErrorMessage, Is.EqualTo(string.Empty));
-            Assert.That(exception.RemoteStackTrace, Is.Null);
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.NotNull(exception.Message);
+        Assert.NotNull(exception.ErrorDetails);
+        Assert.Equal(ErrorCode.UnsetErrorCode, exception.ErrorCode);
+        Assert.Equal(string.Empty, exception.ProtocolErrorMessage);
+        Assert.Null(exception.RemoteStackTrace);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithErrorResult()
     {
         ErrorResult errorResult = CreateErrorResult("invalid argument", "This is a test error message", "remote stack trace");
         WebDriverBiDiProtocolException exception = new("Test exception message", errorResult);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.ErrorDetails, Is.SameAs(errorResult));
-            Assert.That(exception.ErrorCode, Is.EqualTo(ErrorCode.InvalidArgument));
-            Assert.That(exception.ProtocolErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(exception.RemoteStackTrace, Is.EqualTo("remote stack trace"));
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(errorResult, exception.ErrorDetails);
+        Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+        Assert.Equal("This is a test error message", exception.ProtocolErrorMessage);
+        Assert.Equal("remote stack trace", exception.RemoteStackTrace);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithInnerException()
     {
         ErrorResult errorResult = CreateErrorResult("unknown command", "This is a test error message", null);
         InvalidOperationException innerException = new("inner exception message");
         WebDriverBiDiProtocolException exception = new("Test exception message", errorResult, innerException);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.ErrorDetails, Is.SameAs(errorResult));
-            Assert.That(exception.ErrorCode, Is.EqualTo(ErrorCode.UnknownCommand));
-            Assert.That(exception.ProtocolErrorMessage, Is.EqualTo("This is a test error message"));
-            Assert.That(exception.RemoteStackTrace, Is.Null);
-            Assert.That(exception.InnerException, Is.SameAs(innerException));
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(errorResult, exception.ErrorDetails);
+        Assert.Equal(ErrorCode.UnknownCommand, exception.ErrorCode);
+        Assert.Equal("This is a test error message", exception.ProtocolErrorMessage);
+        Assert.Null(exception.RemoteStackTrace);
+        Assert.Same(innerException, exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiErrorResponseException()
     {
         ErrorResult errorResult = CreateErrorResult("no such frame", "Frame not found", null);
         WebDriverBiDiProtocolException exception = new("Test exception message", errorResult);
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiErrorResponseException>());
+        Assert.IsType<WebDriverBiDiErrorResponseException>(exception, exactMatch: false);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiException()
     {
         ErrorResult errorResult = CreateErrorResult("no such frame", "Frame not found", null);
         WebDriverBiDiProtocolException exception = new("Test exception message", errorResult);
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiException>());
+        Assert.IsType<WebDriverBiDiException>(exception, exactMatch: false);
     }
 
     private static ErrorResult CreateErrorResult(string errorType, string errorMessage, string? stackTrace)
@@ -83,7 +76,8 @@ public class WebDriverBiDiProtocolExceptionTests
                           "message": "{{errorMessage}}"{{stackTraceProperty}}
                         }
                         """;
-        ErrorResponseMessage messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json)!;
+        ErrorResponseMessage? messageResult = JsonSerializer.Deserialize<ErrorResponseMessage>(json);
+        Assert.NotNull(messageResult);
         return messageResult.GetErrorResponseData();
     }
 }

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiSerializationExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiSerializationExceptionTests.cs
@@ -1,46 +1,39 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class WebDriverBiDiSerializationExceptionTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithNoArguments()
     {
         WebDriverBiDiSerializationException exception = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.Not.Null);
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.NotNull(exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreate()
     {
         WebDriverBiDiSerializationException exception = new("Test exception message");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithInnerException()
     {
         InvalidOperationException innerException = new("inner exception message");
         WebDriverBiDiSerializationException exception = new("Test exception message", innerException);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.SameAs(innerException));
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(innerException, exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiException()
     {
         WebDriverBiDiSerializationException exception = new("Test exception message");
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiException>());
+        Assert.IsType<WebDriverBiDiException>(exception, exactMatch: false);
     }
 }

--- a/test/WebDriverBiDi.Tests/WebDriverBiDiTimeoutExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDiTimeoutExceptionTests.cs
@@ -1,46 +1,39 @@
 namespace WebDriverBiDi;
 
-[TestFixture]
 public class WebDriverBiDiTimeoutExceptionTests
 {
-    [Test]
+    [Fact]
     public void TestCanCreateWithNoArguments()
     {
         WebDriverBiDiTimeoutException exception = new();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.Not.Null);
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.NotNull(exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreate()
     {
         WebDriverBiDiTimeoutException exception = new("Test exception message");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.Null);
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Null(exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestCanCreateWithInnerException()
     {
         InvalidOperationException innerException = new("inner exception message");
         WebDriverBiDiTimeoutException exception = new("Test exception message", innerException);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(exception.Message, Is.EqualTo("Test exception message"));
-            Assert.That(exception.InnerException, Is.SameAs(innerException));
-        }
+
+        Assert.Equal("Test exception message", exception.Message);
+        Assert.Same(innerException, exception.InnerException);
     }
 
-    [Test]
+    [Fact]
     public void TestIsWebDriverBiDiException()
     {
         WebDriverBiDiTimeoutException exception = new("Test exception message");
-        Assert.That(exception, Is.InstanceOf<WebDriverBiDiException>());
+        Assert.IsType<WebDriverBiDiException>(exception, exactMatch: false);
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/ExtensionDataTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/ExtensionDataTests.cs
@@ -3,113 +3,137 @@ namespace WebDriverBiDi.WebExtension;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class ExtensionDataTests
 {
-    [Test]
+    [Fact]
     public void TestCanSerializeExtensionPathExtensionData()
     {
         ExtensionPath value = new("myPath");
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("path"));
-            Assert.That(parsed, Contains.Key("path"));
-            Assert.That(parsed["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["path"]!.Value<string>(), Is.EqualTo("myPath"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("path", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("path"));
+        JToken? path = parsed["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myPath", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeExtensionPathExtensionDataWithNoArgs()
     {
         ExtensionPath value = new();
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("path"));
-            Assert.That(parsed, Contains.Key("path"));
-            Assert.That(parsed["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["path"]!.Value<string>(), Is.Empty);
-        }
+
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("path", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("path"));
+        JToken? path = parsed["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal(string.Empty, path.Value<string>());
     }
-    [Test]
+
+    [Fact]
     public void TestCanSerializeExtensionArchivePathExtensionData()
     {
         ExtensionArchivePath value = new("myPath.zip");
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("archivePath"));
-            Assert.That(parsed, Contains.Key("path"));
-            Assert.That(parsed["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["path"]!.Value<string>(), Is.EqualTo("myPath.zip"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("archivePath", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("path"));
+        JToken? path = parsed["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myPath.zip", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeExtensionArchivePathExtensionDataWithNoArgs()
     {
         ExtensionArchivePath value = new();
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("archivePath"));
-            Assert.That(parsed, Contains.Key("path"));
-            Assert.That(parsed["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["path"]!.Value<string>(), Is.Empty);
-        }
+
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("archivePath", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("path"));
+        JToken? path = parsed["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal(string.Empty, path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeExtensionBase64EncodedExtensionData()
     {
         ExtensionBase64Encoded value = new("Base64 Encoded Data");
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.EqualTo("Base64 Encoded Data"));
-        }
+
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("base64", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueToken = parsed["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.String, valueToken.Type);
+        Assert.Equal("Base64 Encoded Data", valueToken.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeExtensionBase64EncodedExtensionDataWithNoArgs()
     {
         ExtensionBase64Encoded value = new();
         string json = JsonSerializer.Serialize(value);
         JObject parsed = JObject.Parse(json);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(parsed, Has.Count.EqualTo(2));
-            Assert.That(parsed, Contains.Key("type"));
-            Assert.That(parsed["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(parsed, Contains.Key("value"));
-            Assert.That(parsed["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(parsed["value"]!.Value<string>(), Is.Empty);
-        }
+
+        Assert.Equal(2, parsed.Count);
+
+        Assert.True(parsed.ContainsKey("type"));
+        JToken? type = parsed["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("base64", type.Value<string>());
+
+        Assert.True(parsed.ContainsKey("value"));
+        JToken? valueToken = parsed["value"];
+        Assert.NotNull(valueToken);
+        Assert.Equal(JTokenType.String, valueToken.Type);
+        Assert.Equal(string.Empty, valueToken.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/InstallCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/InstallCommandParametersTests.cs
@@ -3,79 +3,99 @@ namespace WebDriverBiDi.WebExtension;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class InstallCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         InstallCommandParameters properties = new(new ExtensionPath("myExtension"));
-        Assert.That(properties.MethodName, Is.EqualTo("webExtension.install"));
+        Assert.Equal("webExtension.install", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithExtensionPath()
     {
         InstallCommandParameters properties = new(new ExtensionPath("myExtension"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("extensionData"));
-            Assert.That(serialized["extensionData"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject extensionDataObject = (JObject)serialized["extensionData"]!;
-            Assert.That(extensionDataObject, Has.Count.EqualTo(2));
-            Assert.That(extensionDataObject, Contains.Key("type"));
-            Assert.That(extensionDataObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(extensionDataObject["type"]!.Value<string>(), Is.EqualTo("path"));
-            Assert.That(extensionDataObject, Contains.Key("path"));
-            Assert.That(extensionDataObject["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(extensionDataObject["path"]!.Value<string>(), Is.EqualTo("myExtension"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("extensionData"));
+        JToken? extensionDataToken = serialized["extensionData"];
+        Assert.NotNull(extensionDataToken);
+        Assert.Equal(JTokenType.Object, extensionDataToken.Type);
+        JObject? extensionDataObject = extensionDataToken as JObject;
+        Assert.NotNull(extensionDataObject);
+        Assert.Equal(2, extensionDataObject.Count);
+
+        Assert.True(extensionDataObject.ContainsKey("type"));
+        JToken? type = extensionDataObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("path", type.Value<string>());
+
+        Assert.True(extensionDataObject.ContainsKey("path"));
+        JToken? path = extensionDataObject["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myExtension", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithExtensionArchivePath()
     {
         InstallCommandParameters properties = new(new ExtensionArchivePath("myExtensionArchive"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("extensionData"));
-            Assert.That(serialized["extensionData"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject extensionDataObject = (JObject)serialized["extensionData"]!;
-            Assert.That(extensionDataObject, Has.Count.EqualTo(2));
-            Assert.That(extensionDataObject, Contains.Key("type"));
-            Assert.That(extensionDataObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(extensionDataObject["type"]!.Value<string>(), Is.EqualTo("archivePath"));
-            Assert.That(extensionDataObject, Contains.Key("path"));
-            Assert.That(extensionDataObject["path"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(extensionDataObject["path"]!.Value<string>(), Is.EqualTo("myExtensionArchive"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("extensionData"));
+        JToken? extensionDataToken = serialized["extensionData"];
+        Assert.NotNull(extensionDataToken);
+        Assert.Equal(JTokenType.Object, extensionDataToken.Type);
+        JObject? extensionDataObject = extensionDataToken as JObject;
+        Assert.NotNull(extensionDataObject);
+        Assert.Equal(2, extensionDataObject.Count);
+
+        Assert.True(extensionDataObject.ContainsKey("type"));
+        JToken? type = extensionDataObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("archivePath", type.Value<string>());
+
+        Assert.True(extensionDataObject.ContainsKey("path"));
+        JToken? path = extensionDataObject["path"];
+        Assert.NotNull(path);
+        Assert.Equal(JTokenType.String, path.Type);
+        Assert.Equal("myExtensionArchive", path.Value<string>());
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParametersWithBase64Extension()
     {
         InstallCommandParameters properties = new(new ExtensionBase64Encoded("Some base64 encoded data"));
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("extensionData"));
-            Assert.That(serialized["extensionData"]!.Type, Is.EqualTo(JTokenType.Object));
-            JObject extensionDataObject = (JObject)serialized["extensionData"]!;
-            Assert.That(extensionDataObject, Has.Count.EqualTo(2));
-            Assert.That(extensionDataObject, Contains.Key("type"));
-            Assert.That(extensionDataObject["type"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(extensionDataObject["type"]!.Value<string>(), Is.EqualTo("base64"));
-            Assert.That(extensionDataObject, Contains.Key("value"));
-            Assert.That(extensionDataObject["value"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(extensionDataObject["value"]!.Value<string>(), Is.EqualTo("Some base64 encoded data"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("extensionData"));
+        JToken? extensionDataToken = serialized["extensionData"];
+        Assert.NotNull(extensionDataToken);
+        Assert.Equal(JTokenType.Object, extensionDataToken.Type);
+        JObject? extensionDataObject = extensionDataToken as JObject;
+        Assert.NotNull(extensionDataObject);
+        Assert.Equal(2, extensionDataObject.Count);
+
+        Assert.True(extensionDataObject.ContainsKey("type"));
+        JToken? type = extensionDataObject["type"];
+        Assert.NotNull(type);
+        Assert.Equal(JTokenType.String, type.Type);
+        Assert.Equal("base64", type.Value<string>());
+
+        Assert.True(extensionDataObject.ContainsKey("value"));
+        JToken? value = extensionDataObject["value"];
+        Assert.NotNull(value);
+        Assert.Equal(JTokenType.String, value.Type);
+        Assert.Equal("Some base64 encoded data", value.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/InstallCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/InstallCommandResultTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.WebExtension;
 
 using System.Text.Json;
 
-[TestFixture]
 public class InstallCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         string json = """
@@ -14,11 +13,11 @@ public class InstallCommandResultTests
                       }
                       """;
         InstallCommandResult? result = JsonSerializer.Deserialize<InstallCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ExtensionId, Is.EqualTo("myExtensionId"));
+        Assert.NotNull(result);
+        Assert.Equal("myExtensionId", result.ExtensionId);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         string json = """
@@ -27,19 +26,19 @@ public class InstallCommandResultTests
                       }
                       """;
         InstallCommandResult? result = JsonSerializer.Deserialize<InstallCommandResult>(json);
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         InstallCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithMissingExtensionThrows()
     {
         string json = "{}";
-        Assert.That(() => JsonSerializer.Deserialize<InstallCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<InstallCommandResult>(json));
     }
 
-    [Test]
+    [Fact]
     public void TestDeserializingWithInvalidExtensionTypeThrows()
     {
         string json = """
@@ -47,6 +46,6 @@ public class InstallCommandResultTests
                         "extension": {}
                       }
                       """;
-        Assert.That(() => JsonSerializer.Deserialize<InstallCommandResult>(json), Throws.InstanceOf<JsonException>());
+        Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<InstallCommandResult>(json));
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/UninstallCommandParametersTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/UninstallCommandParametersTests.cs
@@ -3,28 +3,27 @@ namespace WebDriverBiDi.WebExtension;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 
-[TestFixture]
 public class UninstallCommandParametersTests
 {
-    [Test]
+    [Fact]
     public void TestCommandName()
     {
         UninstallCommandParameters properties = new("myExtensionId");
-        Assert.That(properties.MethodName, Is.EqualTo("webExtension.uninstall"));
+        Assert.Equal("webExtension.uninstall", properties.MethodName);
     }
 
-    [Test]
+    [Fact]
     public void TestCanSerializeParameters()
     {
         UninstallCommandParameters properties = new("myExtensionId");
         string json = JsonSerializer.Serialize(properties);
         JObject serialized = JObject.Parse(json);
-        Assert.That(serialized, Has.Count.EqualTo(1));
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(serialized, Contains.Key("extension"));
-            Assert.That(serialized["extension"]!.Type, Is.EqualTo(JTokenType.String));
-            Assert.That(serialized["extension"]!.Value<string>(), Is.EqualTo("myExtensionId"));
-        }
+        Assert.Single(serialized);
+
+        Assert.True(serialized.ContainsKey("extension"));
+        JToken? extension = serialized["extension"];
+        Assert.NotNull(extension);
+        Assert.Equal(JTokenType.String, extension.Type);
+        Assert.Equal("myExtensionId", extension.Value<string>());
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/UninstallCommandResultTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/UninstallCommandResultTests.cs
@@ -2,23 +2,22 @@ namespace WebDriverBiDi.WebExtension;
 
 using System.Text.Json;
 
-[TestFixture]
 public class UninstallCommandResultTests
 {
-    [Test]
+    [Fact]
     public void TestCanDeserialize()
     {
         UninstallCommandResult? result = JsonSerializer.Deserialize<UninstallCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.AdditionalData, Is.Empty);
+        Assert.NotNull(result);
+        Assert.Empty(result.AdditionalData);
     }
 
-    [Test]
+    [Fact]
     public void TestCopySemantics()
     {
         UninstallCommandResult? result = JsonSerializer.Deserialize<UninstallCommandResult>("{}");
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
         UninstallCommandResult copy = result with { };
-        Assert.That(copy, Is.EqualTo(result));
+        Assert.Equal(result, copy);
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
@@ -22,7 +22,7 @@ public class WebExtensionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 
@@ -49,7 +49,7 @@ public class WebExtensionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         };
 
-        BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 

--- a/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
@@ -2,10 +2,9 @@ namespace WebDriverBiDi.WebExtension;
 
 using TestUtilities;
 
-[TestFixture]
 public class WebExtensionModuleTests
 {
-    [Test]
+    [Fact]
     public async Task TestInstallActivateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -24,18 +23,17 @@ public class WebExtensionModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 
-        Task<InstallCommandResult> task = module.InstallAsync(new InstallCommandParameters(new ExtensionPath("myExtensionPath")));
-        task.Wait(TimeSpan.FromSeconds(1));
-        InstallCommandResult result = task.Result;
+        Task<InstallCommandResult> task = module.InstallAsync(new InstallCommandParameters(new ExtensionPath("myExtensionPath")), cancellationToken: TestContext.Current.CancellationToken);
+        InstallCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.ExtensionId, Is.EqualTo("myExtensionId"));
+        Assert.NotNull(result);
+        Assert.Equal("myExtensionId", result.ExtensionId);
     }
 
-    [Test]
+    [Fact]
     public async Task TestUninstallActivateCommand()
     {
         TestWebSocketConnection connection = new();
@@ -52,13 +50,12 @@ public class WebExtensionModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost");
+        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 
-        Task<UninstallCommandResult> task = module.UninstallAsync(new UninstallCommandParameters("myExtensionPath"));
-        task.Wait(TimeSpan.FromSeconds(1));
-        UninstallCommandResult result = task.Result;
+        Task<UninstallCommandResult> task = module.UninstallAsync(new UninstallCommandParameters("myExtensionPath"), cancellationToken: TestContext.Current.CancellationToken);
+        UninstallCommandResult result = await task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.That(result, Is.Not.Null);
+        Assert.NotNull(result);
     }
 }

--- a/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
@@ -23,7 +23,7 @@ public class WebExtensionModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 
         Task<InstallCommandResult> task = module.InstallAsync(new InstallCommandParameters(new ExtensionPath("myExtensionPath")), cancellationToken: TestContext.Current.CancellationToken);
@@ -50,7 +50,7 @@ public class WebExtensionModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
+        await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 
         Task<UninstallCommandResult> task = module.UninstallAsync(new UninstallCommandParameters("myExtensionPath"), cancellationToken: TestContext.Current.CancellationToken);


### PR DESCRIPTION
The more modern unit testing framework in the .NET ecosystem is now xUnit. It is the framework used by the .NET project itself, and we are aligning with that.