### PR TITLE
fix: improve test parallelism robustness

### DIFF
--- a/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Bluetooth/BluetoothModuleTests.cs
@@ -20,7 +20,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -46,7 +46,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -72,7 +72,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -98,7 +98,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -123,7 +123,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -149,7 +149,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -175,7 +175,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -201,7 +201,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -227,7 +227,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -253,7 +253,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -279,7 +279,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -305,7 +305,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -331,7 +331,7 @@ public class BluetoothModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -345,7 +345,7 @@ public class BluetoothModuleTests
     public async Task TestCanReceiveCharacteristicEventGeneratedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -383,7 +383,7 @@ public class BluetoothModuleTests
     public async Task TestCanReceiveDescriptorEventGeneratedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -423,7 +423,7 @@ public class BluetoothModuleTests
     public async Task TestGattConnectionAttemptedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 
@@ -454,7 +454,7 @@ public class BluetoothModuleTests
     public async Task TestCanReceiveRequestDevicePromptUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BluetoothModule module = driver.Bluetooth;
 

--- a/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
@@ -20,7 +20,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -46,7 +46,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -74,7 +74,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -103,7 +103,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -151,7 +151,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -214,7 +214,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -265,7 +265,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -304,7 +304,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -334,7 +334,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -368,7 +368,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 
@@ -409,7 +409,7 @@ public class BrowserModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowserModule module = driver.Browser;
 

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
@@ -20,7 +20,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -48,7 +48,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -75,7 +75,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -103,7 +103,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -141,7 +141,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -174,7 +174,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -201,7 +201,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -239,7 +239,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -268,7 +268,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -299,7 +299,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -329,7 +329,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -358,7 +358,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -384,7 +384,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -413,7 +413,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -444,7 +444,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -472,7 +472,7 @@ public class BrowsingContextModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -486,7 +486,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveContextCreatedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -525,7 +525,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveContextDestroyedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -562,7 +562,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveDomContentLoadedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -599,7 +599,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveDownloadWillBeginEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -640,7 +640,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveDownloadEndEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -683,7 +683,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveFragmentNavigatedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -720,7 +720,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveLoadEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -757,7 +757,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationAbortedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -794,7 +794,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationCommittedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -831,7 +831,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationFailedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -868,7 +868,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveNavigationStartedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -905,7 +905,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveHistoryUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -937,7 +937,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveUserPromptClosedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 
@@ -970,7 +970,7 @@ public class BrowsingContextModuleTests
     public async Task TestCanReceiveUserPromptOpenedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         BrowsingContextModule module = driver.BrowsingContext;
 

--- a/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/DigitalCredentials/DigitalCredentialsModuleTests.cs
@@ -20,7 +20,7 @@ public class DigitalCredentialsModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         DigitalCredentialsModule module = driver.DigitalCredentials;
 

--- a/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Emulation/EmulationModuleTests.cs
@@ -20,7 +20,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -46,7 +46,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -72,7 +72,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -98,7 +98,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -124,7 +124,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -150,7 +150,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -176,7 +176,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -202,7 +202,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -228,7 +228,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -254,7 +254,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 
@@ -283,7 +283,7 @@ public class EmulationModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         EmulationModule module = driver.Emulation;
 

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -596,9 +596,11 @@ public class EventObserverTests
         // ShouldReportAsyncFault = false. The drain logic must attach a new continuation
         // that observes the fault so UnobservedTaskException is never raised.
         bool unobservedExceptionRaised = false;
+        AggregateException? unobservedException = null;
         void UnobservedHandler(object? sender, UnobservedTaskExceptionEventArgs e)
         {
             unobservedExceptionRaised = true;
+            unobservedException = e.Exception;
             e.SetObserved();
         }
         TaskScheduler.UnobservedTaskException += UnobservedHandler;
@@ -658,6 +660,11 @@ public class EventObserverTests
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
+
+            if (unobservedException is not null)
+            {
+                throw unobservedException.InnerExceptions[0];
+            }
 
             Assert.False(unobservedExceptionRaised);
         }

--- a/test/WebDriverBiDi.Tests/EventObserverTests.cs
+++ b/test/WebDriverBiDi.Tests/EventObserverTests.cs
@@ -596,12 +596,12 @@ public class EventObserverTests
         // ShouldReportAsyncFault = false. The drain logic must attach a new continuation
         // that observes the fault so UnobservedTaskException is never raised.
         bool unobservedExceptionRaised = false;
-        EventHandler<UnobservedTaskExceptionEventArgs> unobservedHandler = (sender, e) =>
+        void UnobservedHandler(object? sender, UnobservedTaskExceptionEventArgs e)
         {
             unobservedExceptionRaised = true;
             e.SetObserved();
-        };
-        TaskScheduler.UnobservedTaskException += unobservedHandler;
+        }
+        TaskScheduler.UnobservedTaskException += UnobservedHandler;
 
         try
         {
@@ -643,9 +643,15 @@ public class EventObserverTests
             Task[] tasks = await observer.WaitForCapturedTasksAsync(1, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             _ = Assert.Single(tasks);
 
-            // Let the raced handler fault and wait for it to complete before triggering GC.
+            // Let the raced handler fault and wait for the finally block to run.
             allowFaultTaskCompletionSource.TrySetResult();
             await handlerFaultedTaskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            // handlerFaultedTaskCompletionSource fires from the finally block, which runs
+            // before the async state machine calls SetException to transition the task to
+            // Faulted. Give the faulting thread a scheduler quantum to finish SetException
+            // and run the drain's ExecuteSynchronously fault continuation before GC runs.
+            await Task.Delay(50, TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.
@@ -657,7 +663,7 @@ public class EventObserverTests
         }
         finally
         {
-            TaskScheduler.UnobservedTaskException -= unobservedHandler;
+            TaskScheduler.UnobservedTaskException -= UnobservedHandler;
         }
     }
 
@@ -916,8 +922,11 @@ public class EventObserverTests
 
             await testEventSource.RaiseTestEventAsync("myValue");
 
-            // Wait for the handler to fault before triggering GC.
+            // Wait for the handler to signal just before throwing, then give the faulting
+            // thread time to finish SetException and run the ExecuteSynchronously fault
+            // continuation that observes the exception, before GC pressure is applied.
             await taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            await Task.Delay(50, TestContext.Current.CancellationToken);
 
             // Force garbage collection to trigger UnobservedTaskException
             // for any task whose exception was not observed.

--- a/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
@@ -21,7 +21,7 @@ public class InputModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -47,7 +47,7 @@ public class InputModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -73,7 +73,7 @@ public class InputModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -88,7 +88,7 @@ public class InputModuleTests
     public async Task TestCanReceiveFileDialogOpenedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 
@@ -120,7 +120,7 @@ public class InputModuleTests
     public async Task TestCanReceiveFileDialogOpenedEventWithElementReference()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         InputModule module = driver.Input;
 

--- a/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Log/LogModuleTests.cs
@@ -8,7 +8,7 @@ public class LogModuleTests
     public async Task TestCanReceiveEntryAddedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 
@@ -53,7 +53,7 @@ public class LogModuleTests
     public async Task TestCanReceiveEntryAddedEventForConsoleLogType()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         LogModule module = driver.Log;
 

--- a/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
@@ -99,7 +99,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -133,7 +133,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -162,7 +162,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -189,7 +189,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -216,7 +216,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -247,7 +247,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -275,7 +275,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -307,7 +307,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -337,7 +337,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -364,7 +364,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -392,7 +392,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -419,7 +419,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -446,7 +446,7 @@ public class NetworkModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -467,7 +467,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -545,7 +545,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -613,7 +613,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -678,7 +678,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 
@@ -756,7 +756,7 @@ public class NetworkModuleTests
         ulong milliseconds = Convert.ToUInt64(eventTime.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
 
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         NetworkModule module = driver.Network;
 

--- a/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
@@ -20,7 +20,7 @@ public class PermissionsModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         PermissionsModule module = driver.Permissions;
 

--- a/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/PipeConnectionTests.cs
@@ -212,7 +212,7 @@ public class PipeConnectionTests
 
         testPipeServer.Start(connection.ReadPipeHandle, connection.WritePipeHandle);
         await connection.StartAsync("pipe://local", TestContext.Current.CancellationToken);
-        _ = Task.Run(() => connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        Task firstSendTask = Task.Run(() => connection.SendDataAsync(Encoding.UTF8.GetBytes("Hello"), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
 
         // Wait until the first send has acquired the semaphore and is blocked on the barrier,
         // then attempt a second send which must time out before the barrier releases.
@@ -220,6 +220,17 @@ public class PipeConnectionTests
         await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync(Encoding.UTF8.GetBytes("World"), TestContext.Current.CancellationToken));
         sendBarrier.SetResult();
         testPipeServer.Stop();
+
+        // The first send may fault with a WebDriverBiDiConnectionException if Stop closed
+        // the pipe before the send completed. Observe the exception to prevent
+        // UnobservedTaskException from being raised when the task is garbage-collected.
+        try
+        {
+            await firstSendTask;
+        }
+        catch (WebDriverBiDiConnectionException)
+        {
+        }
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
@@ -787,9 +787,13 @@ public class WebSocketConnectionTests : IAsyncDisposable
         // The first send may fault with a WebDriverBiDiConnectionException if StopAsync aborted
         // the WebSocket before the send completed. Observe the exception to prevent
         // UnobservedTaskException from being raised when the task is garbage-collected.
-        await firstSendTask.ContinueWith(
-            t => _ = t.Exception,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        try
+        {
+            await firstSendTask;
+        }
+        catch (WebDriverBiDiConnectionException)
+        {
+        }
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/WebSocketConnectionTests.cs
@@ -775,7 +775,7 @@ public class WebSocketConnectionTests : IAsyncDisposable
         connection.OnDataSendStarting.AddObserver(e => taskCompletionSource.TrySetResult());
 
         string registeredConnectionId = this.WaitForServerToRegisterConnection(TimeSpan.FromSeconds(1));
-        _ = Task.Run(() => connection.SendDataAsync("first data"u8.ToArray(), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
+        Task firstSendTask = Task.Run(() => connection.SendDataAsync("first data"u8.ToArray(), TestContext.Current.CancellationToken), TestContext.Current.CancellationToken);
 
         // Wait until the first send has acquired the semaphore and is blocked on the barrier,
         // then attempt a second send which must time out before the barrier releases.
@@ -783,6 +783,13 @@ public class WebSocketConnectionTests : IAsyncDisposable
         Assert.Equal("Timed out waiting to access WebSocket for sending; only one send operation is permitted at a time.", (await Assert.ThrowsAnyAsync<WebDriverBiDiTimeoutException>(async () => await connection.SendDataAsync("second data"u8.ToArray(), TestContext.Current.CancellationToken))).Message);
         sendBarrier.SetResult();
         await connection.StopAsync(TestContext.Current.CancellationToken);
+
+        // The first send may fault with a WebDriverBiDiConnectionException if StopAsync aborted
+        // the WebSocket before the send completed. Observe the exception to prevent
+        // UnobservedTaskException from being raised when the task is garbage-collected.
+        await firstSendTask.ContinueWith(
+            t => _ = t.Exception,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
@@ -28,7 +28,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -78,7 +78,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -123,7 +123,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -173,7 +173,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -220,7 +220,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -259,7 +259,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -286,7 +286,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -301,7 +301,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveRealmCreatedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -337,7 +337,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveRealmCreatedEventForNonWindowRealm()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -371,7 +371,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveRealmDestroyedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -400,7 +400,7 @@ public class ScriptModuleTests
     public async Task TestCanReceiveMessageEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -456,7 +456,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 
@@ -484,7 +484,7 @@ public class ScriptModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         ScriptModule module = driver.Script;
         await driver.StartAsync("ws:localhost", cancellationToken: TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
@@ -23,7 +23,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -55,7 +55,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -86,7 +86,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -114,7 +114,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -142,7 +142,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -184,7 +184,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -226,7 +226,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -252,7 +252,7 @@ public class SessionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         SessionModule module = driver.Session;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Speculation/SpeculationModuleTests.cs
@@ -8,7 +8,7 @@ public class SpeculationModuleTests
     public async Task TestCanReceivePrefetchStatusUpdatedEvent()
     {
         TestWebSocketConnection connection = new();
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         SpeculationModule module = driver.Speculation;
 

--- a/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
@@ -46,7 +46,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -89,7 +89,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -118,7 +118,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -149,7 +149,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 
@@ -183,7 +183,7 @@ public class StorageModuleTests()
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new Transport(connection));
         StorageModule module = driver.Storage;
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
 

--- a/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/UserAgentClientHints/UserAgentClientHintsModuleTests.cs
@@ -20,7 +20,7 @@ public class UserAgentClientHintsModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         UserAgentClientHintsModule module = driver.UserAgentClientHints;
 

--- a/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/WebExtension/WebExtensionModuleTests.cs
@@ -22,7 +22,7 @@ public class WebExtensionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 
@@ -49,7 +49,7 @@ public class WebExtensionModuleTests
             await connection.RaiseDataReceivedEventAsync(responseJson);
         });
 
-        await using BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await using BiDiDriver driver = new(TimeSpan.FromSeconds(5), new(connection));
         await driver.StartAsync("ws:localhost", TestContext.Current.CancellationToken);
         WebExtensionModule module = driver.WebExtension;
 


### PR DESCRIPTION
The increase in parallelism due to the migration to xUnit has introduced some instability in some of the unit tests. These changes help isolate the tests so that state does not leak, and the increased load on the system due to parallelization is accounted for.