### PR TITLE
feat: add initial support for Safari in WebDriverBiDi.Client

### DIFF
--- a/src/WebDriverBiDi.Client/Launchers/BrowserLauncherBuilder.cs
+++ b/src/WebDriverBiDi.Client/Launchers/BrowserLauncherBuilder.cs
@@ -257,12 +257,10 @@ public class BrowserLauncherBuilder
         {
             BrowserKind.Chrome => this.CreateChromeLauncher(),
             BrowserKind.Firefox => this.CreateFirefoxLauncher(),
+            BrowserKind.Safari => this.CreateSafariLauncher(),
             BrowserKind.Edge => throw new NotImplementedException(
                 "Microsoft Edge browser support is not yet implemented. Currently supported browsers: Chrome, Firefox. " +
                 "Edge support is planned for a future release."),
-            BrowserKind.Safari => throw new NotImplementedException(
-                "Apple Safari browser support is not yet implemented. Currently supported browsers: Chrome, Firefox. " +
-                "Safari support is planned for a future release pending maturity of Safari's BiDi implementation."),
             _ => throw new WebDriverBiDiException($"Unknown browser type: {this.browser}"),
         };
 
@@ -335,6 +333,19 @@ public class BrowserLauncherBuilder
             }
         }
 
+        if (this.browser == BrowserKind.Safari)
+        {
+            if (this.launchStrategy == LaunchStrategy.Direct)
+            {
+                throw new BrowserLauncherConfigurationException("Safari must be launched using a driver; you must use the .LaunchUsingDriver() method with the builder.");
+            }
+
+            if (this.locationBehavior != FileLocationBehavior.UseSystemInstallLocation)
+            {
+                throw new BrowserLauncherConfigurationException("Safari cannot be launched from a custom lcoation; you must use the .AtDefaultInstallLocation() method.");
+            }
+        }
+
         // Validate capabilities are only used with remote grid
         if (this.capabilities is not null && this.capabilities.Count > 0 && this.launchStrategy != LaunchStrategy.UsingRemoteGrid)
         {
@@ -402,6 +413,25 @@ public class BrowserLauncherBuilder
                 "Cannot specify release channel with LaunchUsingRemoteGrid. " +
                 "Use capabilities to configure browser options on the remote grid.");
         }
+    }
+
+    private BrowserLauncher CreateSafariLauncher()
+    {
+        if (this.launchStrategy == LaunchStrategy.UsingRemoteGrid)
+        {
+            return this.CreateRemoteLauncher("chrome");
+        }
+
+        SafariChannel safariChannel = this.channel switch
+        {
+            BrowserReleaseChannel.Stable => SafariChannel.Stable,
+            BrowserReleaseChannel.DeveloperPreview => SafariChannel.TechnologyPreview,
+            _ => throw new WebDriverBiDiException($"Invalid browser release channel for Safari: {this.channel}"),
+        };
+
+        SafariBrowserLocatorSettings settings = new(safariChannel);
+        SafariLauncher safariLauncher = new(settings);
+        return safariLauncher;
     }
 
     private BrowserLauncher CreateChromeLauncher()

--- a/src/WebDriverBiDi.Client/Launchers/SafariBrowserLocatorSettings.cs
+++ b/src/WebDriverBiDi.Client/Launchers/SafariBrowserLocatorSettings.cs
@@ -1,0 +1,141 @@
+// <copyright file="SafariBrowserLocatorSettings.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Client.Launchers;
+
+/// <summary>
+/// Defines the locator settings for the Safari browser, including properties such as the browser name,
+/// channel, version, environment variable name, expected executable path, and installer file name.
+/// This class does not provide includes methods to allow browser download information based on the
+/// specified channel or version, as Safari is only supported when used with the executables installed
+/// by the system package manager. The locator settings are used by the BrowserLocator to
+/// locate the binaries of Safari specified for testing with WebDriver BiDi.
+/// </summary>
+internal class SafariBrowserLocatorSettings : BrowserLocatorSettings
+{
+    private readonly SafariChannel channelValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SafariBrowserLocatorSettings"/> class.
+    /// </summary>
+    public SafariBrowserLocatorSettings()
+        : this(SafariChannel.Stable)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SafariBrowserLocatorSettings"/> class.
+    /// </summary>
+    /// <param name="channel">The distribution channel of the Safari browser.</param>
+    internal SafariBrowserLocatorSettings(SafariChannel channel)
+    {
+        this.channelValue = channel;
+        this.BrowserName = "safari";
+        this.Channel = channel.ToString().ToLowerInvariant();
+        this.BrowserDisplayName = $"Safari{(channel == SafariChannel.TechnologyPreview ? "Technology Preview" : string.Empty)}";
+        this.EnvironmentVariableName = "SAFARI_EXECUTABLE";
+        this.LocationBehavior = FileLocationBehavior.UseSystemInstallLocation;
+        this.InstallerFileName = string.Empty;
+        this.ExpectedExecutablePath = this.GetDefaultSystemInstalledLocation();
+        this.IncludeDriver = true;
+        this.DriverLocationBehavior = FileLocationBehavior.UseSystemInstallLocation;
+        this.DriverExecutableLocation = this.GetDriverLocation();
+        this.Version = SystemVersionString;
+        this.InitializeExtractors();
+    }
+
+    /// <summary>
+    /// Gets the name of the browser (e.g., "safari").
+    /// </summary>
+    public override string BrowserName { get; } = "safari";
+
+    /// <summary>
+    /// Gets the name of the driver executable (e.g., "safaridriver").
+    /// </summary>
+    public override string DriverExecutableName => "safaridriver";
+
+    /// <summary>
+    /// Gets the name of the environment variable that can be used to override the driver executable path.
+    /// </summary>
+    public override string DriverEnvironmentVariableName => "SAFARIDRIVER_EXECUTABLE";
+
+    /// <summary>
+    /// Gets a value indicating whether the Safari browser is the technology preview edition.
+    /// </summary>
+    public bool IsTechnologyPreview => this.channelValue == SafariChannel.TechnologyPreview;
+
+    /// <summary>
+    /// Gets the browser download information for the Safari browser version or channel specified.
+    /// For Safari, the browser cannot be downloaded independently, so this hard-codes no download
+    /// information.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with the browser download information as the result.</returns>
+    public override async Task<BrowserDownloadInfo> GetBrowserDownloadInfo()
+    {
+        BrowserDownloadInfo downloadInfo = new()
+        {
+            BrowserName = this.BrowserName,
+            Channel = this.Channel,
+            Version = this.Version,
+        };
+
+        return downloadInfo;
+    }
+
+    /// <summary>
+    /// Gets the driver download information for the safaridriver that is compatible with the Safari browser.
+    /// For Safari, this is hard-coded, as the user can only use the system-installed version of Safari and
+    /// its accompanying driver.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with the driver download information as the result.</returns>
+    public override async Task<DriverDownloadInfo> GetMatchingDriverDownloadInfo()
+    {
+        DriverDownloadInfo driverDownloadInfo = new()
+        {
+            DriverName = "safaridriver",
+            Version = string.Empty,
+            BrowserVersion = this.Version,
+            DownloadUrl = string.Empty,
+            InstallerFileName = string.Empty,
+        };
+
+        return driverDownloadInfo;
+    }
+
+    private void InitializeExtractors()
+    {
+        this.BrowserExtractor = new DiskImageFileExtractor();
+        this.DriverExtractor = new DiskImageFileExtractor();
+    }
+
+    private string GetDriverLocation()
+    {
+        return this.channelValue == SafariChannel.Stable ? Path.Combine("usr", "bin") : this.GetInstallLocation();
+    }
+
+    private string GetDefaultSystemInstalledLocation()
+    {
+            return Path.Combine(this.GetInstallLocation(), this.GetAppBundleName());
+    }
+
+    private string GetAppBundleName()
+    {
+        return this.channelValue switch
+        {
+            SafariChannel.Stable => "Safari",
+            SafariChannel.TechnologyPreview => "Safari Technology Preview",
+            _ => "Safari",
+        };
+    }
+
+    private string GetInstallLocation()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            $"{this.GetAppBundleName()}.app",
+            "Contents",
+            "MacOS");
+    }
+}

--- a/src/WebDriverBiDi.Client/Launchers/SafariChannel.cs
+++ b/src/WebDriverBiDi.Client/Launchers/SafariChannel.cs
@@ -1,0 +1,27 @@
+// <copyright file="SafariChannel.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Client.Launchers;
+
+/// <summary>
+/// Defines the distribution channels for the Safari browser, which include Stable and Technology Preview.
+/// </summary>
+public enum SafariChannel
+{
+    /// <summary>
+    /// The Stable channel, which is the default channel for released versions of
+    /// Safari that have been thoroughly tested and are considered stable for
+    /// general use.
+    /// </summary>
+    Stable,
+
+    /// <summary>
+    /// The Technology Preview channel, which includes versions of Safari that are in the
+    /// final stages of testing before release. These versions may contain new features and
+    /// bug fixes that are not yet available in the Stable channel, but they may also have
+    /// some instability or issues that are still being addressed.
+    /// </summary>
+    TechnologyPreview,
+}

--- a/src/WebDriverBiDi.Client/Launchers/SafariLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/SafariLauncher.cs
@@ -1,0 +1,76 @@
+// <copyright file="SafariLauncher.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Client.Launchers;
+
+/// <summary>
+/// Object for launching a Safari browser to connect to using a WebDriverBiDi session
+/// using a local instance of the safaridriver browser driver executable.
+/// </summary>
+public class SafariLauncher : ClassicDriverExecutableBrowserLauncher
+{
+    private readonly bool isTechnologyPreview;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SafariLauncher" /> class using Safari browser locator settings.
+    /// The settings must have <see cref="BrowserLocatorSettings.IncludeDriver"/> set to true.
+    /// </summary>
+    /// <param name="settings">The Safari browser locator settings to use for locating the browser and driver executables.</param>
+    /// <exception cref="ArgumentNullException">Thrown when settings is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when settings.IncludeDriver is false.</exception>
+    internal SafariLauncher(SafariBrowserLocatorSettings settings)
+        : base(settings, 0)
+    {
+        this.isTechnologyPreview = settings.IsTechnologyPreview;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the browser can be closed using WebDriver BiDi's browser.close command.
+    /// </summary>
+    public override bool IsBrowserCloseAllowed => false;
+
+    /// <summary>
+    /// Gets a value indicating the time to wait for the service to terminate before forcing it to terminate.
+    /// </summary>
+    protected override TimeSpan TerminationTimeout => TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets a value indicating whether the service has a shutdown API that can be called to terminate
+    /// it gracefully before forcing a termination.
+    /// </summary>
+    protected override bool HasShutdownApi => false;
+
+    /// <summary>
+    /// Creates the WebDriver Classic capabilities used to launch the browser.
+    /// </summary>
+    /// <returns>A dictionary containing the capabilities.</returns>
+    protected override Dictionary<string, object> CreateBrowserLaunchCapabilities()
+    {
+        // CONSIDER: This is a very naive and simple set of capabilities.
+        // A future implementation could create a more fully-featured
+        // generation of capabilities.
+        // Note carefully the addition of the "safari:experimentalWebSocketUrl"
+        // capability. This is mandatory to enable WebDriverBiDi for now, but
+        // should not be necessary in the future.
+        Dictionary<string, object> capabilities = new()
+        {
+            ["browserName"] = "safari",
+            ["webSocketUrl"] = true,
+            ["safari:experimentalWebSocketUrl"] = true,
+        };
+
+        if (this.isTechnologyPreview)
+        {
+            Dictionary<string, object> options = new()
+            {
+                ["technologyPreview"] = true,
+            };
+
+            capabilities["safari:options"] = options;
+        }
+
+        return capabilities;
+    }
+}


### PR DESCRIPTION
Note carefully that at the time of this commit, Safari's support for WebDriver BiDi is extremely limited. With this commit, one can launch Safari, initiate a WebDriver BiDi session, and get its status using the `session.status` command. More functionality will be available as the browser vendor makes it available in the browser.