### PR TITLE
fix(protocol): complete pending command when error response is malformed

### DIFF
--- a/src/WebDriverBiDi/Protocol/Transport.cs
+++ b/src/WebDriverBiDi/Protocol/Transport.cs
@@ -1058,31 +1058,47 @@ public class Transport : IAsyncDisposable
 
     private async Task<bool> ProcessErrorMessageAsync(IncomingMessage packet)
     {
-        try
+        // Recover the command ID from the raw packet before attempting the typed
+        // deserialization of the error payload, mirroring ProcessCommandResponseMessageAsync.
+        // A malformed error response (for example, one missing a spec-required field)
+        // causes the typed deserialization to throw; recovering the ID first lets us still
+        // fault the awaiting command instead of dropping the error and leaving the caller
+        // to wait out the command timeout.
+        if (packet.TryGetCommandId(out long responseId) && this.PendingCommands.RemovePendingCommand(responseId, out Command? executedCommand))
         {
-            // If the message doesn't match the schema of an actual error message,
-            // an exception will be thrown by the JSON serializer, and we can log
-            // the malformed response.
-            if (packet.TryGetErrorResponse(this.errorResponseJsonTypeInfo, out ErrorResponseMessage? errorMessage))
+            executedCommand.StopTiming();
+            try
             {
-                ErrorResult result = errorMessage.GetErrorResponseData();
-                if (errorMessage.CommandId.HasValue && this.PendingCommands.RemovePendingCommand(errorMessage.CommandId.Value, out Command? executedCommand))
+                if (packet.TryGetErrorResponse(this.errorResponseJsonTypeInfo, out ErrorResponseMessage? errorMessage))
                 {
-                    // Stop timing and log error
-                    executedCommand.StopTiming();
-                    WebDriverBiDiEventSource.RaiseEvent.CommandError(errorMessage.CommandId.Value, executedCommand.CommandName, result.ErrorCode, result.ErrorType.ToString(), result.ErrorMessage);
+                    ErrorResult result = errorMessage.GetErrorResponseData();
+                    WebDriverBiDiEventSource.RaiseEvent.CommandError(responseId, executedCommand.CommandName, result.ErrorCode, result.ErrorType.ToString(), result.ErrorMessage);
                     if (this.OnLogMessage.CurrentObserverCount > 0)
                     {
-                        await this.LogAsync($"Received error response for command '{executedCommand.CommandName}' (command ID: {errorMessage.CommandId.Value})", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
+                        await this.LogAsync($"Received error response for command '{executedCommand.CommandName}' (command ID: {responseId})", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
                     }
 
                     executedCommand.SetResult(result);
                 }
-                else
-                {
-                    await this.OnProtocolErrorEventReceivedAsync(new ErrorReceivedEventArgs(result)).ConfigureAwait(false);
-                    this.CaptureUnhandledError(UnhandledErrorKind.UnexpectedError, new WebDriverBiDiProtocolException($"Received {result.ErrorCode} ('{result.ErrorType}') error with no command ID: {result.ErrorMessage}", result), "Received error with no command ID");
-                }
+            }
+            catch (Exception ex)
+            {
+                executedCommand.SetException(new WebDriverBiDiSerializationException($"Response did not contain properly formed JSON for error response type (response JSON:{packet.MessageText})", ex));
+            }
+
+            return true;
+        }
+
+        // No pending command matched this error (it carried no command ID, or an unknown
+        // one). Surface it as a protocol-level error; if the payload itself is malformed,
+        // an exception is thrown by the JSON serializer and we log the malformed response.
+        try
+        {
+            if (packet.TryGetErrorResponse(this.errorResponseJsonTypeInfo, out ErrorResponseMessage? errorMessage))
+            {
+                ErrorResult result = errorMessage.GetErrorResponseData();
+                await this.OnProtocolErrorEventReceivedAsync(new ErrorReceivedEventArgs(result)).ConfigureAwait(false);
+                this.CaptureUnhandledError(UnhandledErrorKind.UnexpectedError, new WebDriverBiDiProtocolException($"Received {result.ErrorCode} ('{result.ErrorType}') error with no command ID: {result.ErrorMessage}", result), "Received error with no command ID");
             }
 
             return true;

--- a/src/WebDriverBiDi/Protocol/Transport.cs
+++ b/src/WebDriverBiDi/Protocol/Transport.cs
@@ -1090,20 +1090,23 @@ public class Transport : IAsyncDisposable
         catch (Exception ex)
         {
             string messageString = packet.MessageText;
-            await this.LogAsync($"Unexpected error parsing error JSON: {ex.Message} (JSON: {messageString})", WebDriverBiDiLogLevel.Error).ConfigureAwait(false);
-            this.CaptureUnhandledError(UnhandledErrorKind.ProtocolError, ex, $"Invalid JSON in protocol error response: {messageString}");
-            WebDriverBiDiEventSource.RaiseEvent.ProtocolError(ex.Message, TruncateMessage(messageString, 100));
 
-            // The malformed payload failed to deserialize, so the pending command was
-            // never matched above. Recover its ID from the raw packet and fault it, so a
-            // malformed error response doesn't leave the caller waiting out the command
-            // timeout. TryGetCommandId is only called here, on the failure path.
+            // The malformed payload failed to deserialize, so the pending command was never
+            // matched above. If it still correlates to a pending command, fault that command
+            // and treat the error as handled, so a malformed error response doesn't leave the
+            // caller waiting out the command timeout. TryGetCommandId is only called here, on
+            // the failure path, and a matched command is not also routed to the unhandled-error
+            // pipeline below.
             if (packet.TryGetCommandId(out long responseId) && this.PendingCommands.RemovePendingCommand(responseId, out Command? executedCommand))
             {
                 executedCommand.StopTiming();
                 executedCommand.SetException(new WebDriverBiDiSerializationException($"Response did not contain properly formed JSON for error response type (response JSON:{messageString})", ex));
                 return true;
             }
+
+            await this.LogAsync($"Unexpected error parsing error JSON: {ex.Message} (JSON: {messageString})", WebDriverBiDiLogLevel.Error).ConfigureAwait(false);
+            this.CaptureUnhandledError(UnhandledErrorKind.ProtocolError, ex, $"Invalid JSON in protocol error response: {messageString}");
+            WebDriverBiDiEventSource.RaiseEvent.ProtocolError(ex.Message, TruncateMessage(messageString, 100));
         }
 
         return false;

--- a/src/WebDriverBiDi/Protocol/Transport.cs
+++ b/src/WebDriverBiDi/Protocol/Transport.cs
@@ -1058,47 +1058,31 @@ public class Transport : IAsyncDisposable
 
     private async Task<bool> ProcessErrorMessageAsync(IncomingMessage packet)
     {
-        // Recover the command ID from the raw packet before attempting the typed
-        // deserialization of the error payload, mirroring ProcessCommandResponseMessageAsync.
-        // A malformed error response (for example, one missing a spec-required field)
-        // causes the typed deserialization to throw; recovering the ID first lets us still
-        // fault the awaiting command instead of dropping the error and leaving the caller
-        // to wait out the command timeout.
-        if (packet.TryGetCommandId(out long responseId) && this.PendingCommands.RemovePendingCommand(responseId, out Command? executedCommand))
+        try
         {
-            executedCommand.StopTiming();
-            try
+            // If the message doesn't match the schema of an actual error message,
+            // an exception will be thrown by the JSON serializer, and we can log
+            // the malformed response.
+            if (packet.TryGetErrorResponse(this.errorResponseJsonTypeInfo, out ErrorResponseMessage? errorMessage))
             {
-                if (packet.TryGetErrorResponse(this.errorResponseJsonTypeInfo, out ErrorResponseMessage? errorMessage))
+                ErrorResult result = errorMessage.GetErrorResponseData();
+                if (errorMessage.CommandId.HasValue && this.PendingCommands.RemovePendingCommand(errorMessage.CommandId.Value, out Command? executedCommand))
                 {
-                    ErrorResult result = errorMessage.GetErrorResponseData();
-                    WebDriverBiDiEventSource.RaiseEvent.CommandError(responseId, executedCommand.CommandName, result.ErrorCode, result.ErrorType.ToString(), result.ErrorMessage);
+                    // Stop timing and log error
+                    executedCommand.StopTiming();
+                    WebDriverBiDiEventSource.RaiseEvent.CommandError(errorMessage.CommandId.Value, executedCommand.CommandName, result.ErrorCode, result.ErrorType.ToString(), result.ErrorMessage);
                     if (this.OnLogMessage.CurrentObserverCount > 0)
                     {
-                        await this.LogAsync($"Received error response for command '{executedCommand.CommandName}' (command ID: {responseId})", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
+                        await this.LogAsync($"Received error response for command '{executedCommand.CommandName}' (command ID: {errorMessage.CommandId.Value})", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
                     }
 
                     executedCommand.SetResult(result);
                 }
-            }
-            catch (Exception ex)
-            {
-                executedCommand.SetException(new WebDriverBiDiSerializationException($"Response did not contain properly formed JSON for error response type (response JSON:{packet.MessageText})", ex));
-            }
-
-            return true;
-        }
-
-        // No pending command matched this error (it carried no command ID, or an unknown
-        // one). Surface it as a protocol-level error; if the payload itself is malformed,
-        // an exception is thrown by the JSON serializer and we log the malformed response.
-        try
-        {
-            if (packet.TryGetErrorResponse(this.errorResponseJsonTypeInfo, out ErrorResponseMessage? errorMessage))
-            {
-                ErrorResult result = errorMessage.GetErrorResponseData();
-                await this.OnProtocolErrorEventReceivedAsync(new ErrorReceivedEventArgs(result)).ConfigureAwait(false);
-                this.CaptureUnhandledError(UnhandledErrorKind.UnexpectedError, new WebDriverBiDiProtocolException($"Received {result.ErrorCode} ('{result.ErrorType}') error with no command ID: {result.ErrorMessage}", result), "Received error with no command ID");
+                else
+                {
+                    await this.OnProtocolErrorEventReceivedAsync(new ErrorReceivedEventArgs(result)).ConfigureAwait(false);
+                    this.CaptureUnhandledError(UnhandledErrorKind.UnexpectedError, new WebDriverBiDiProtocolException($"Received {result.ErrorCode} ('{result.ErrorType}') error with no command ID: {result.ErrorMessage}", result), "Received error with no command ID");
+                }
             }
 
             return true;
@@ -1109,6 +1093,17 @@ public class Transport : IAsyncDisposable
             await this.LogAsync($"Unexpected error parsing error JSON: {ex.Message} (JSON: {messageString})", WebDriverBiDiLogLevel.Error).ConfigureAwait(false);
             this.CaptureUnhandledError(UnhandledErrorKind.ProtocolError, ex, $"Invalid JSON in protocol error response: {messageString}");
             WebDriverBiDiEventSource.RaiseEvent.ProtocolError(ex.Message, TruncateMessage(messageString, 100));
+
+            // The malformed payload failed to deserialize, so the pending command was
+            // never matched above. Recover its ID from the raw packet and fault it, so a
+            // malformed error response doesn't leave the caller waiting out the command
+            // timeout. TryGetCommandId is only called here, on the failure path.
+            if (packet.TryGetCommandId(out long responseId) && this.PendingCommands.RemovePendingCommand(responseId, out Command? executedCommand))
+            {
+                executedCommand.StopTiming();
+                executedCommand.SetException(new WebDriverBiDiSerializationException($"Response did not contain properly formed JSON for error response type (response JSON:{messageString})", ex));
+                return true;
+            }
         }
 
         return false;

--- a/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/TransportTests.cs
@@ -183,6 +183,35 @@ public class TransportTests
     }
 
     [Fact]
+    public async Task TestTransportCompletesCommandOnMalformedErrorResponse()
+    {
+        string commandName = "module.command";
+        TestWebSocketConnection connection = new();
+        Transport transport = new(connection);
+        await transport.ConnectAsync("ws:localhost", TestContext.Current.CancellationToken);
+
+        TestCommandParameters commandParameters = new(commandName);
+        Command command = await transport.SendCommandAsync(commandParameters, TestContext.Current.CancellationToken);
+        _ = Task.Run(
+            async () =>
+            {
+                // The required "message" field is absent, so the typed error deserialization throws.
+                string json = """
+                            {
+                              "type": "error",
+                              "id": 1,
+                              "error": "unknown command"
+                            }
+                            """;
+                await connection.RaiseDataReceivedEventAsync(json);
+            },
+            TestContext.Current.CancellationToken);
+        await command.WaitForCompletionAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.IsType<WebDriverBiDiSerializationException>(command.ThrownException);
+        Assert.Contains("Response did not contain properly formed JSON for error response type", command.ThrownException.Message);
+    }
+
+    [Fact]
     public async Task TestTransportGetResponseWithThrownException()
     {
         string commandName = "module.command";


### PR DESCRIPTION
**Scope:** minor robustness fix, it only triggers when the remote sends a malformed error envelope (a protocol violation); normal operation is unaffected.

## What does this PR do?

- When the remote sends an error response missing a required field (`id`, `error`, `message`), the awaiting command now faults with a `WebDriverBiDiSerializationException` instead of never completing.
- Previously the malformed error threw during deserialization, was logged, and dropped — the command was never resolved, so the caller waited out its full timeout (60s by default) and surfaced a misleading `WebDriverBiDiTimeoutException` rather than an error.
- Callers now fail fast with a clear error tied to the originating command.

## Implementation Notes

- `ProcessErrorMessageAsync` now recovers the command ID from the raw packet (`TryGetCommandId`) before the typed deserialization, so a parse failure can still be matched to its pending command and faulted — making the error path mirror `ProcessCommandResponseMessageAsync`, which already matched before deserializing. That asymmetry is why malformed errors, but not malformed successes, hung.
- A matched command that fails to parse takes the same `catch` → `SetException` path as a malformed success; unmatched errors (no/unknown ID) keep their existing protocol-error handling exactly.
- Coverage stays 100% line/branch/method; adds a regression test for a valid-ID error with `message` absent.

## Alternatives considered

- **Tolerant error parsing** — relax `ErrorResponseMessage`'s required fields so a malformed error degrades to a best-effort `ErrorResult`, completing the command with the *actual* partial error rather than a serialization exception (or combined with this PR for both). Rejected as default: cuts against the project's strict null-checking and lets placeholder error fields surface as real.
