### PR TITLE
fix: widen js-uint fields to ulong to cover the full spec range

### DIFF
--- a/src/WebDriverBiDi/BrowsingContext/GetTreeCommandParameters.cs
+++ b/src/WebDriverBiDi/BrowsingContext/GetTreeCommandParameters.cs
@@ -30,7 +30,7 @@ public class GetTreeCommandParameters : CommandParameters<GetTreeCommandResult>
     /// </summary>
     [JsonPropertyName("maxDepth")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? MaxDepth { get; set; }
+    public ulong? MaxDepth { get; set; }
 
     /// <summary>
     /// Gets or sets the ID of the browsing context used as the root of the tree.

--- a/src/WebDriverBiDi/Script/ExceptionDetails.cs
+++ b/src/WebDriverBiDi/Script/ExceptionDetails.cs
@@ -34,7 +34,7 @@ public record ExceptionDetails
     [JsonPropertyName("columnNumber")]
     [JsonRequired]
     [JsonInclude]
-    public int ColumnNumber { get; internal set; } = -1;
+    public ulong ColumnNumber { get; internal set; }
 
     /// <summary>
     /// Gets the line number of the statement that caused the exception.
@@ -42,7 +42,7 @@ public record ExceptionDetails
     [JsonPropertyName("lineNumber")]
     [JsonRequired]
     [JsonInclude]
-    public int LineNumber { get; internal set; } = -1;
+    public ulong LineNumber { get; internal set; }
 
     /// <summary>
     /// Gets the stack trace of the exception.

--- a/src/WebDriverBiDi/Script/NodeProperties.cs
+++ b/src/WebDriverBiDi/Script/NodeProperties.cs
@@ -18,7 +18,7 @@ public record NodeProperties
     [JsonPropertyName("nodeType")]
     [JsonRequired]
     [JsonInclude]
-    public uint NodeType { get; internal set; }
+    public ulong NodeType { get; internal set; }
 
     /// <summary>
     /// Gets the count of the child nodes.
@@ -26,7 +26,7 @@ public record NodeProperties
     [JsonPropertyName("childNodeCount")]
     [JsonRequired]
     [JsonInclude]
-    public uint ChildNodeCount { get; internal set; }
+    public ulong ChildNodeCount { get; internal set; }
 
     /// <summary>
     /// Gets the value of the node.

--- a/src/WebDriverBiDi/Script/StackFrame.cs
+++ b/src/WebDriverBiDi/Script/StackFrame.cs
@@ -34,7 +34,7 @@ public record StackFrame
     [JsonPropertyName("lineNumber")]
     [JsonRequired]
     [JsonInclude]
-    public int LineNumber { get; internal set; } = -1;
+    public ulong LineNumber { get; internal set; }
 
     /// <summary>
     /// Gets the column number for this stack frame.
@@ -42,7 +42,7 @@ public record StackFrame
     [JsonPropertyName("columnNumber")]
     [JsonRequired]
     [JsonInclude]
-    public int ColumnNumber { get; internal set; } = -1;
+    public ulong ColumnNumber { get; internal set; }
 
     /// <summary>
     /// Gets the URL for this stack frame.

--- a/test/WebDriverBiDi.Tests/Script/EvaluateResultExceptionTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/EvaluateResultExceptionTests.cs
@@ -32,8 +32,8 @@ public class EvaluateResultExceptionTests
 
         Assert.Equal("myRealm", exceptionResult.RealmId);
         Assert.Equal("exception thrown", exceptionResult.ExceptionDetails.Text);
-        Assert.Equal(1, exceptionResult.ExceptionDetails.LineNumber);
-        Assert.Equal(5, exceptionResult.ExceptionDetails.ColumnNumber);
+        Assert.Equal(1UL, exceptionResult.ExceptionDetails.LineNumber);
+        Assert.Equal(5UL, exceptionResult.ExceptionDetails.ColumnNumber);
         Assert.Empty(exceptionResult.ExceptionDetails.StackTrace.CallFrames);
         Assert.Equal("exception value", exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
     }

--- a/test/WebDriverBiDi.Tests/Script/ExceptionDetailsTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ExceptionDetailsTests.cs
@@ -25,8 +25,8 @@ public class ExceptionDetailsTests
         Assert.NotNull(exceptionDetails);
 
         Assert.Equal("exception message", exceptionDetails.Text);
-        Assert.Equal(1, exceptionDetails.LineNumber);
-        Assert.Equal(5, exceptionDetails.ColumnNumber);
+        Assert.Equal(1UL, exceptionDetails.LineNumber);
+        Assert.Equal(5UL, exceptionDetails.ColumnNumber);
         Assert.Equal("myException", exceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
         Assert.Empty(exceptionDetails.StackTrace.CallFrames);
     }

--- a/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
@@ -91,8 +91,8 @@ public class ScriptModuleTests
         Assert.Equal("myRealmId", exceptionResult.RealmId);
         Assert.Equal(EvaluateResultType.Exception, exceptionResult.ResultType);
         Assert.Equal("error received from script", exceptionResult.ExceptionDetails.Text);
-        Assert.Equal(2, exceptionResult.ExceptionDetails.LineNumber);
-        Assert.Equal(5, exceptionResult.ExceptionDetails.ColumnNumber);
+        Assert.Equal(2UL, exceptionResult.ExceptionDetails.LineNumber);
+        Assert.Equal(5UL, exceptionResult.ExceptionDetails.ColumnNumber);
         Assert.NotNull(exceptionResult.ExceptionDetails.StackTrace);
         Assert.Empty(exceptionResult.ExceptionDetails.StackTrace.CallFrames);
         Assert.Equal("myStringValue", exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);
@@ -184,8 +184,8 @@ public class ScriptModuleTests
         Assert.Equal("myRealmId", exceptionResult.RealmId);
         Assert.Equal(EvaluateResultType.Exception, exceptionResult.ResultType);
         Assert.Equal("error received from script", exceptionResult.ExceptionDetails.Text);
-        Assert.Equal(2, exceptionResult.ExceptionDetails.LineNumber);
-        Assert.Equal(5, exceptionResult.ExceptionDetails.ColumnNumber);
+        Assert.Equal(2UL, exceptionResult.ExceptionDetails.LineNumber);
+        Assert.Equal(5UL, exceptionResult.ExceptionDetails.ColumnNumber);
         Assert.NotNull(exceptionResult.ExceptionDetails.StackTrace);
         Assert.Empty(exceptionResult.ExceptionDetails.StackTrace.CallFrames);
         Assert.Equal("myStringValue", exceptionResult.ExceptionDetails.Exception.ConvertTo<StringRemoteValue>().Value);

--- a/test/WebDriverBiDi.Tests/Script/StackFrameTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/StackFrameTests.cs
@@ -19,8 +19,8 @@ public class StackFrameTests
         Assert.NotNull(stackFrame);
 
         Assert.Equal("myFunction", stackFrame.FunctionName);
-        Assert.Equal(1, stackFrame.LineNumber);
-        Assert.Equal(5, stackFrame.ColumnNumber);
+        Assert.Equal(1UL, stackFrame.LineNumber);
+        Assert.Equal(5UL, stackFrame.ColumnNumber);
         Assert.Equal("http://some.url/file.js", stackFrame.Url);
     }
 


### PR DESCRIPTION
Widens seven `js-uint` fields from 32-bit `int`/`uint` to 64-bit `ulong` to match the spec's declared range.

The spec types these fields `js-uint` (0 to 2^53 − 1), which a 32-bit type can't hold; the codebase already maps the same concepts to `ulong` elsewhere, so these are the outliers.

Practical overflow risk is ~nil (all are small counts/indices) and it is not backwards compatible, so feel free to close this in favor of maintaining backwards compatibility.
