### PR TITLE
fix: allow overflow properties on command parameters

### DIFF
--- a/docs/code/WebDriverBiDi.DocSnippets.csproj
+++ b/docs/code/WebDriverBiDi.DocSnippets.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="OpenTelemetry" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebDriverBiDi.Client/Launchers/ChromeLauncher.cs
+++ b/src/WebDriverBiDi.Client/Launchers/ChromeLauncher.cs
@@ -19,20 +19,26 @@ public class ChromeLauncher : BrowserLauncher, IPipeServerProcessProvider
     private static readonly SemaphoreSlim LockObject = new(1, 1);
 
     private readonly List<string> disabledFeatures = [
-      "Translate",
+        "Translate",
 
-      // AcceptCHFrame disabled because of crbug.com/1348106.
-      "AcceptCHFrame",
-      "MediaRouter",
-      "OptimizationHints",
-   ];
+        // AcceptCHFrame disabled because of crbug.com/1348106.
+        "AcceptCHFrame",
+        "MediaRouter",
+        "OptimizationHints",
+        "WebUIReloadButton",
+        "WebUIOmniboxPopup",
+        "WebUIOmniboxAimPopup",
+        "IPH_ReadingModePageActionLabel",
+        "ReadAnythingOmniboxChip",
+        "ProcessPerSiteUpToMainFrameThreshold",
+        "IsolateSandboxedIframes",
+    ];
 
     private readonly List<string> enabledFeatures = [
         "PdfOopif",
     ];
 
     private readonly List<string> chromeArguments = [
-        "--allow-browser-signin=false",
         "--allow-pre-commit-input",
         "--disable-background-networking",
         "--disable-background-timer-throttling",
@@ -40,25 +46,23 @@ public class ChromeLauncher : BrowserLauncher, IPipeServerProcessProvider
         "--disable-breakpad",
         "--disable-client-side-phishing-detection",
         "--disable-component-extensions-with-background-pages",
-        "--disable-component-update",
         "--disable-default-apps",
         "--disable-dev-shm-usage",
-        "--disable-extensions",
+        "--disable-field-trial-config",
         "--disable-hang-monitor",
         "--disable-infobars",
         "--disable-ipc-flooding-protection",
-        "--disable-notifications",
         "--disable-popup-blocking",
         "--disable-prompt-on-repost",
         "--disable-renderer-backgrounding",
         "--disable-search-engine-choice-screen",
         "--disable-sync",
         "--enable-automation",
+        "--enable-blink-features=IdleDetection",
         "--export-tagged-pdf",
         "--generate-pdf-document-outline",
         "--force-color-profile=srgb",
         "--metrics-recording-only",
-        "--no-default-browser-check",
         "--no-first-run",
         "--password-store=basic",
         "--use-mock-keychain",
@@ -123,7 +127,6 @@ public class ChromeLauncher : BrowserLauncher, IPipeServerProcessProvider
             if (this.IsBrowserHeadless)
             {
                 args.Add("--headless=new");
-                args.Add("--disable-dev-shm-usage");
                 args.Add("--no-sandbox");
                 args.Add("--disable-gpu");
             }

--- a/src/WebDriverBiDi.Client/WebDriverBiDi.Client.csproj
+++ b/src/WebDriverBiDi.Client/WebDriverBiDi.Client.csproj
@@ -20,8 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageReference Include="System.Text.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebDriverBiDi.Demo/Program.cs
+++ b/src/WebDriverBiDi.Demo/Program.cs
@@ -21,7 +21,7 @@ int port = 0;
 WebDriverBiDiLogLevel logReportingLevel = WebDriverBiDiLogLevel.Info;
 
 // Select the browser type for which to run this demo.
-BrowserKind testBrowserType = BrowserKind.Firefox;
+BrowserKind testBrowserType = BrowserKind.Chrome;
 
 // Select the release channel of the browser tu use for this demo.
 // The release channel is browser-agnostic, but is mapped to a

--- a/src/WebDriverBiDi.Logging/WebDriverBiDi.Logging.csproj
+++ b/src/WebDriverBiDi.Logging/WebDriverBiDi.Logging.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/WebDriverBiDi/CommandParameters.cs
+++ b/src/WebDriverBiDi/CommandParameters.cs
@@ -55,6 +55,6 @@ public abstract class CommandParameters
     /// or the command will fail at send time with a <see cref="NotSupportedException"/>.
     /// </para>
     /// </remarks>
-    [JsonIgnore]
+    [JsonExtensionData]
     public Dictionary<string, object?> AdditionalData { get; } = [];
 }

--- a/src/WebDriverBiDi/JsonConverters/CommandJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/CommandJsonConverter.cs
@@ -67,12 +67,6 @@ public class CommandJsonConverter : JsonConverter<Command>
         // to remove warnings when publishing AOT compiled applications.
         JsonTypeInfo paramsTypeInfo = options.GetTypeInfo(value.CommandParameters.GetType());
         JsonSerializer.Serialize(writer, value.CommandParameters, paramsTypeInfo);
-        foreach (KeyValuePair<string, object?> pair in value.AdditionalData)
-        {
-            writer.WritePropertyName(pair.Key);
-            JsonSerializer.Serialize(writer, pair.Value, options);
-        }
-
         writer.WriteEndObject();
     }
 }

--- a/src/WebDriverBiDi/JsonConverters/CommandJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/CommandJsonConverter.cs
@@ -14,6 +14,13 @@ using WebDriverBiDi.Protocol;
 /// <summary>
 /// A converter for a serializing a Command object.
 /// </summary>
+/// <remarks>
+/// This custom converter is used for <see cref="Command"/> objects so that we do not have
+/// to use the System.Text.Json attribute-based polymorphic serialization. That would require
+/// the base <see cref="CommandParameters"/> class to maintain a list of <see cref="JsonDerivedType"/>
+/// attributes for each command parameter objects. This makes it easier for consumers of this
+/// library to create command parameters classes for custom commands.
+/// </remarks>
 public class CommandJsonConverter : JsonConverter<Command>
 {
     /// <summary>

--- a/src/WebDriverBiDi/JsonConverters/CommandJsonConverter.cs
+++ b/src/WebDriverBiDi/JsonConverters/CommandJsonConverter.cs
@@ -74,6 +74,15 @@ public class CommandJsonConverter : JsonConverter<Command>
         // to remove warnings when publishing AOT compiled applications.
         JsonTypeInfo paramsTypeInfo = options.GetTypeInfo(value.CommandParameters.GetType());
         JsonSerializer.Serialize(writer, value.CommandParameters, paramsTypeInfo);
+
+        // This will now serialize the additional overflow properties for the
+        // command envelope.
+        foreach (KeyValuePair<string, object?> pair in value.AdditionalCommandProperties)
+        {
+            writer.WritePropertyName(pair.Key);
+            JsonSerializer.Serialize(writer, pair.Value, options);
+        }
+
         writer.WriteEndObject();
     }
 }

--- a/src/WebDriverBiDi/JsonConverters/WebDriverBiDiJsonSerializerContext.cs
+++ b/src/WebDriverBiDi/JsonConverters/WebDriverBiDiJsonSerializerContext.cs
@@ -38,6 +38,19 @@ using WebDriverBiDi.WebExtension;
 /// </code>
 /// </para>
 /// </summary>
+// ── Standard .NET types typically used in serialization of extension data ──
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(uint))]
+[JsonSerializable(typeof(ulong))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(List<object?>))]
+[JsonSerializable(typeof(Dictionary<string, object?>))]
+
 // ── Protocol ──
 [JsonSerializable(typeof(Command))]
 [JsonSerializable(typeof(ErrorResponseMessage))]

--- a/src/WebDriverBiDi/Protocol/Command.cs
+++ b/src/WebDriverBiDi/Protocol/Command.cs
@@ -50,12 +50,6 @@ public class Command
     public CommandParameters CommandParameters { get; }
 
     /// <summary>
-    /// Gets additional properties to be serialized with this command.
-    /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object?> AdditionalData => this.CommandParameters.AdditionalData;
-
-    /// <summary>
     /// Gets the type of the response for this command.
     /// </summary>
     [JsonIgnore]
@@ -88,6 +82,7 @@ public class Command
     /// <summary>
     /// Gets the elapsed time in milliseconds since the command was sent by a <see cref="Transport"/>.
     /// </summary>
+    [JsonIgnore]
     public long ElapsedMilliseconds => this.commandStopwatch.ElapsedMilliseconds;
 
     /// <summary>

--- a/src/WebDriverBiDi/Protocol/Command.cs
+++ b/src/WebDriverBiDi/Protocol/Command.cs
@@ -50,6 +50,16 @@ public class Command
     public CommandParameters CommandParameters { get; }
 
     /// <summary>
+    /// Gets additional properties to be serialized with this command envelope.
+    /// Note carefully this serializes these additional properties at the top
+    /// level of the command; additional properties to be serialized with the
+    /// command parameters should use the <see cref="CommandParameters.AdditionalData"/>
+    /// property.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, object?> AdditionalCommandProperties { get; } = [];
+
+    /// <summary>
     /// Gets the type of the response for this command.
     /// </summary>
     [JsonIgnore]

--- a/src/WebDriverBiDi/Protocol/Transport.cs
+++ b/src/WebDriverBiDi/Protocol/Transport.cs
@@ -471,8 +471,7 @@ public class Transport : IAsyncDisposable
         // this to make the command parameters immutable for this command
         // execution and prevent modification of the parameters while the
         // command is being sent.
-        long commandId = this.GetNextCommandId();
-        Command command = new(commandId, commandData);
+        Command command = this.CreateCommand(commandData);
         byte[] commandJson = this.SerializeCommand(command);
         await this.AcquireConnectionLockAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -487,7 +486,7 @@ public class Transport : IAsyncDisposable
             {
                 // Start timing and log command sending
                 command.StartTiming();
-                WebDriverBiDiEventSource.RaiseEvent.CommandSending(commandId, command.CommandName);
+                WebDriverBiDiEventSource.RaiseEvent.CommandSending(command.CommandId, command.CommandName);
                 if (this.OnLogMessage.CurrentObserverCount > 0)
                 {
                     await this.LogAsync($"Sending command data for command '{command.CommandName}' (command ID: {command.CommandId})", WebDriverBiDiLogLevel.Debug).ConfigureAwait(false);
@@ -504,12 +503,12 @@ public class Transport : IAsyncDisposable
             {
                 // Command failed to send, so roll back adding the command to the pending command
                 // collection, and emit the event for the failure.
-                if (this.PendingCommands.RemovePendingCommand(commandId, out _))
+                if (this.PendingCommands.RemovePendingCommand(command.CommandId, out _))
                 {
                     command.StopTiming();
                 }
 
-                WebDriverBiDiEventSource.RaiseEvent.CommandSendFailed(commandId, command.CommandName, ex.GetType().ToString(), ex.Message, command.ElapsedMilliseconds);
+                WebDriverBiDiEventSource.RaiseEvent.CommandSendFailed(command.CommandId, command.CommandName, ex.GetType().ToString(), ex.Message, command.ElapsedMilliseconds);
                 WebDriverBiDiEventSource.RaiseEvent.PendingCommandCount(this.PendingCommands.PendingCommandCount);
                 throw;
             }
@@ -601,6 +600,23 @@ public class Transport : IAsyncDisposable
     protected virtual void AddEventMessageType(string eventName, Type eventMessageType)
     {
         this.eventMessageTypes[eventName] = eventMessageType;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Command"/> object from the specified command parameters.
+    /// </summary>
+    /// <param name="commandData">The <see cref="CommandParameters"/> object containing the command data.</param>
+    /// <returns>The created <see cref="Command"/>.</returns>
+    /// <remarks>
+    /// This method allows a developer to override the creation of a command. This is useful
+    /// for cases where additional properties need to be sent in the command envelope as
+    /// opposed to the command parameters object.
+    /// </remarks>
+    protected virtual Command CreateCommand(CommandParameters commandData)
+    {
+        long commandId = this.GetNextCommandId();
+        Command command = new(commandId, commandData);
+        return command;
     }
 
     /// <summary>

--- a/src/WebDriverBiDi/WebDriverBiDi.csproj
+++ b/src/WebDriverBiDi/WebDriverBiDi.csproj
@@ -30,14 +30,14 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="10.0.10" />
-    <PackageReference Include="System.Threading.Channels" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.10" />
+    <PackageReference Include="System.Text.Json" Version="10.0.11" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Text.Json" Version="10.0.10" />
+    <PackageReference Include="System.Text.Json" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="../../.stylecop.json" />

--- a/test/WebDriverBiDi.Logging.Tests/WebDriverBiDi.Logging.Tests.csproj
+++ b/test/WebDriverBiDi.Logging.Tests/WebDriverBiDi.Logging.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="coverlet.MTP" Version="10.0.1" />
   </ItemGroup>

--- a/test/WebDriverBiDi.Tests/JsonConverters/CommandJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/CommandJsonConverterTests.cs
@@ -52,8 +52,11 @@ public class CommandJsonConverterTests
         Command command = new(1, commandParams);
         string json = JsonSerializer.Serialize(command);
         JObject serialized = JObject.Parse(json);
-        Assert.True(serialized.ContainsKey("extraKey"));
-        JToken? extraKey = serialized["extraKey"];
+        Assert.True(serialized.ContainsKey("params"));
+        JObject? paramsObject = serialized["params"] as JObject;
+        Assert.NotNull(paramsObject);
+        Assert.True(paramsObject.ContainsKey("extraKey"));
+        JToken? extraKey = paramsObject["extraKey"];
         Assert.NotNull(extraKey);
         Assert.Equal("extraValue", extraKey.Value<string>());
     }

--- a/test/WebDriverBiDi.Tests/JsonConverters/CommandJsonConverterTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/CommandJsonConverterTests.cs
@@ -50,6 +50,7 @@ public class CommandJsonConverterTests
         TestCommandParameters commandParams = new TestCommandParameters("module.command");
         commandParams.AdditionalData["extraKey"] = "extraValue";
         Command command = new(1, commandParams);
+        command.AdditionalCommandProperties["extraCommandProperty"] = "extraCommandPropertyValue";
         string json = JsonSerializer.Serialize(command);
         JObject serialized = JObject.Parse(json);
         Assert.True(serialized.ContainsKey("params"));
@@ -59,6 +60,11 @@ public class CommandJsonConverterTests
         JToken? extraKey = paramsObject["extraKey"];
         Assert.NotNull(extraKey);
         Assert.Equal("extraValue", extraKey.Value<string>());
+        Assert.True(serialized.ContainsKey("extraCommandProperty"));
+        JToken? extraCommandProperty = serialized["extraCommandProperty"];
+        Assert.NotNull(extraCommandProperty);
+        Assert.Equal(JTokenType.String, extraCommandProperty.Type);
+        Assert.Equal("extraCommandPropertyValue", extraCommandProperty.Value<string>());
     }
 
     [Fact]

--- a/test/WebDriverBiDi.Tests/JsonConverters/WebDriverBiDiJsonSerializerContextTests.cs
+++ b/test/WebDriverBiDi.Tests/JsonConverters/WebDriverBiDiJsonSerializerContextTests.cs
@@ -204,6 +204,14 @@ public class WebDriverBiDiJsonSerializerContextTests
                     missingTypes.Add(derivedTypeAttribute.DerivedType);
                 }
             }
+
+            foreach(DiscriminatedDerivedTypeAttribute discriminatedDerivedTypeAttribute in assembly.GetCustomAttributes<DiscriminatedDerivedTypeAttribute>())
+            {
+                if (!coveredTypes.Contains(discriminatedDerivedTypeAttribute.DerivedType) && !missingTypes.Contains(discriminatedDerivedTypeAttribute.DerivedType))
+                {
+                    missingTypes.Add(discriminatedDerivedTypeAttribute.DerivedType);
+                }
+            }
         }
 
         // There should be no missing types.

--- a/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
@@ -21,12 +21,14 @@ public class CommandTests
             { "id", 1 },
             { "method", commandName },
             { "params", expectedCommandParameters },
+            { "additionalCommandProperty", "additionalCommandPropertyValue" },
         };
 
         TestCommandParameters commandParams = new TestCommandParameters(commandName);
         commandParams.AdditionalData["overflowParameterName"] = "overflowParameterValue";
 
         Command command = new(1, commandParams);
+        command.AdditionalCommandProperties["additionalCommandProperty"] = "additionalCommandPropertyValue";
         string json = JsonSerializer.Serialize(command);
         Dictionary<string, object?> dataValue = JObject.Parse(json).ToParsedDictionary();
         Assert.Equivalent(expected, dataValue);

--- a/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/CommandTests.cs
@@ -14,13 +14,13 @@ public class CommandTests
         Dictionary<string, object?> expectedCommandParameters = new()
         {
             { "parameterName", "parameterValue" },
+            { "overflowParameterName", "overflowParameterValue" },
         };
         Dictionary<string, object?> expected = new()
         {
             { "id", 1 },
             { "method", commandName },
             { "params", expectedCommandParameters },
-            { "overflowParameterName", "overflowParameterValue" },
         };
 
         TestCommandParameters commandParams = new TestCommandParameters(commandName);

--- a/test/WebDriverBiDi.Tests/WebDriverBiDi.Tests.csproj
+++ b/test/WebDriverBiDi.Tests/WebDriverBiDi.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageReference Include="xunit.analyzers" Version="1.27.0">
       <PrivateAssets>none</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Before, the `AdditionalData` property put overflow properties in the command's JSON envelope. This is almost certainly not the most interesting use case. Instead, we want the overflow properties to be on the command parameters object itself, so that the remote end can properly parse optionsl/extension properties for a command.